### PR TITLE
Changes to allow users to skip hadoop service restart coordination

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -41,8 +41,13 @@ default["bcpc"]["hadoop"]["restart_lock_acquire"]["max_tries"] = 5
 default["bcpc"]["hadoop"]["restart_lock"]["root"] = "/"
 # Sleep time in seconds between tries to acquire the lock for restart
 default["bcpc"]["hadoop"]["restart_lock_acquire"]["sleep_time"] = 2
-# Flag to set whether the restart process was successful or not
-default["bcpc"]["hadoop"]["datanode"]["restart_failed"] = false
+# Flag to set whether the HDFS datanode restart process was successful or not
+default["bcpc"]["hadoop"]["hadoop_hdfs_datanode"]["restart_failed"] = false
+# Attribute to save the time when HDFS datanode restart process failed
+default["bcpc"]["hadoop"]["hadoop_hdfs_datanode"]["restart_failed_time"] = ""
+# Flag to control whether automatic restarts due to config changes need to be skipped 
+# for e.g. if ZK quorum is down or if the recipes need to be run in a non ZK env
+default["bcpc"]["hadoop"]["skip_restart_coordination"] = false
 
 default[:bcpc][:hadoop][:nn_hosts] = []
 default[:bcpc][:hadoop][:jn_hosts] = []

--- a/cookbooks/bcpc-hadoop/definitions/hadoop_service.rb
+++ b/cookbooks/bcpc-hadoop/definitions/hadoop_service.rb
@@ -1,0 +1,118 @@
+define :hadoop_service, :service_name => nil, :dependencies => nil, :process_identifier => nil do
+
+  params[:service_name] ||= params[:name]
+
+  service "#{params[:service_name]}" do
+    supports :status => true, :restart => true, :reload => false
+    action [:enable, :start]
+  end
+
+  if node["bcpc"]["hadoop"]["skip_restart_coordination"]
+    Chef::Log.info "Coordination of #{params[:service_name]} restart will be skipped as per user request."
+    begin
+      res = resources(service: "#{params[:service_name]}")
+      if params[:dependencies]
+        params[:dependencies].each do |dep|
+          res.subscribes(:restart, "#{dep}", :delayed)
+        end
+      end
+    rescue Chef::Exceptions::ResourceNotFound
+      Chef::Log.info("Resource service #{params[:service_name]} not found")
+    end
+  else
+    if !params[:process_identifier]
+      Chef::Application.fatal!("hadoop_service for #{params[:service_name]} need to specify a valid value for the parameter :process_identifier")
+    end
+    #
+    # When there is a need to restart a hadoop service, a lock need to be taken so that the restart is sequenced preventing all nodes being down at the sametime
+    # If there is a failure in acquiring a lock with in a certian period, the restart is scheduled for the next run on chef-client on the node.
+    # To determine whether the prev restart failed is the node attribute node[:bcpc][:hadoop][:service_name][:restart_failed] is set to true
+    # This ruby block is to check whether this node attribute is set to true and if it is set then gets the hadoop service restart process in motion.
+    #
+    ruby_block "handle_prev_#{params[:service_name].gsub('-','_')}_restart_failure" do
+      block do
+        Chef::Log.info "Need to restart #{params[:service_name]} since it failed during the previous run. Another node's restart process failure is a possible reason"
+      end
+      action :create
+      only_if { node[:bcpc][:hadoop][params[:service_name].gsub('-','_').to_sym][:restart_failed] and 
+              !process_restarted_after_failure?(node[:bcpc][:hadoop][params[:service_name].gsub('-','_').to_sym][:restart_failed_time],"#{params[:process_identifier]}")}
+    end
+    #
+    # Since string with all the zookeeper nodes is used multiple times this variable is populated once and reused reducing calls to Chef server
+    #
+    zk_hosts = (get_node_attributes(MGMT_IP_ATTR_SRCH_KEYS,"zookeeper_server","bcpc-hadoop").map{|zkhost| "#{zkhost['mgmt_ip']}:#{node[:bcpc][:hadoop][:zookeeper][:port]}"}).join(",")
+    #
+    # znode is used as the locking mechnism to control restart of services. The following code is to build the path
+    # to create the znode before initiating the restart of hadoop service 
+    #
+    lock_znode_path = format_restart_lock_path(node[:bcpc][:hadoop][:restart_lock][:root],"#{params[:service_name]}")
+    #
+    # All hadoop service restart situations like changes in config files or restart due to previous failures invokes this ruby_block
+    # This ruby block tries to acquire a lock and if not able to acquire the lock, sets the restart_failed node attribute to true
+    #
+    ruby_block "acquire_lock_to_restart_#{params[:service_name].gsub('-','_')}" do
+      require 'time'
+      block do
+        tries = 0
+        Chef::Log.info("#{node[:hostname]}: Acquring lock at #{lock_znode_path}")
+        while true 
+          lock = acquire_restart_lock(lock_znode_path, zk_hosts, node[:fqdn])
+          if lock
+            break
+          else
+            tries += 1
+            if tries >= node[:bcpc][:hadoop][:restart_lock_acquire][:max_tries]
+              failure_time = Time.now().to_s
+              Chef::Log.info("Couldn't acquire lock to restart #{params[:service_name]} with in the #{node[:bcpc][:hadoop][:restart_lock_acquire][:max_tries] * node[:bcpc][:hadoop][:restart_lock_acquire][:sleep_time]} secs. Failure time is #{failure_time}")
+              Chef::Log.info("Node #{get_restart_lock_holder(lock_znode_path, zk_hosts)} may have died during #{params[:service_name]} restart.")
+              node.set[:bcpc][:hadoop][params[:service_name].gsub('-','_').to_sym][:restart_failed] = true
+              node.set[:bcpc][:hadoop][params[:service_name].gsub('-','_').to_sym][:restart_failed_time] = failure_time
+              node.save
+              break
+            end
+            sleep(node[:bcpc][:hadoop][:restart_lock_acquire][:sleep_time])
+          end
+        end
+      end
+      action :nothing
+      if params[:dependencies]
+        params[:dependencies].each do |dep|
+          subscribes :create, "#{dep}", :immediate
+        end
+      end
+      subscribes :create, "ruby_block[handle_prev_#{params[:service_name].gsub('-','_')}_restart_failure]", :immediate
+    end
+    #
+    # If lock to restart hadoop service is acquired by the node, this ruby_block executes which is primarily used to notify the hadoop service to restart
+    #
+    ruby_block "coordinate_#{params[:service_name].gsub('-','_')}_restart" do
+      block do
+        Chef::Log.info("Data node will be restarted in node #{node[:fqdn]}")
+      end
+      action :create
+      only_if { my_restart_lock?(lock_znode_path, zk_hosts, node[:fqdn]) }
+    end
+
+    begin
+      res = resources(service: "#{params[:service_name]}")
+      res.subscribes(:restart, "ruby_block[coordinate_#{params[:service_name].gsub('-','_')}_restart]", :immediate)
+    rescue Chef::Exceptions::ResourceNotFound
+      Chef::Log.info("Resource service #{params[:service_name]} not found")
+    end
+    #
+    # Once the hadoop service restart is complete, the following block releases the lock if the node executing is the one which holds the lock 
+    #
+    ruby_block "release_#{params[:service_name].gsub('-','_')}_restart_lock" do
+      block do
+        Chef::Log.info("#{node[:hostname]}: Releasing lock at #{lock_znode_path}")
+        lock_rel = rel_restart_lock(lock_znode_path, zk_hosts, node[:fqdn])
+        if lock_rel
+          node.set[:bcpc][:hadoop][params[:service_name].gsub('-','_').to_sym][:restart_failed] = false
+          node.save
+        end
+      end
+      action :create
+      only_if { my_restart_lock?(lock_znode_path, zk_hosts, node[:fqdn]) }
+    end
+  end
+end

--- a/cookbooks/bcpc-hadoop/libraries/utils.rb
+++ b/cookbooks/bcpc-hadoop/libraries/utils.rb
@@ -260,6 +260,7 @@ end
 # of the service to be restarted for e.g "hadoop-hdfs-datanode" and is located by default at "/".
 # The imput parameters are service name along with the ZK path (znode name), string of zookeeper 
 # servers ("zk_host1:port,sk_host2:port"), and the fqdn of the node acquiring the lock
+# Return value : true or false
 #
 def acquire_restart_lock(znode_path, zk_hosts="localhost:2181",node_name)
   require 'zookeeper'
@@ -268,7 +269,7 @@ def acquire_restart_lock(znode_path, zk_hosts="localhost:2181",node_name)
   begin
     zk = Zookeeper.new(zk_hosts)
     if !zk.connected?
-      raise "acquire_restart_lock : unable to connect to ZooKeeper"
+      raise "acquire_restart_lock : unable to connect to ZooKeeper quorum #{zk_hosts}"
     end
     ret = zk.create(:path => znode_path, :data => node_name)
     if ret[:rc] == 0
@@ -288,6 +289,7 @@ end
 # This function is to check whether the lock to restart a particular service is held by a node.
 # The input parameters are the path to the znode used to restart a hadoop service, a string containing the 
 # host port values of the ZooKeeper nodes "host1:port, host2:port" and the fqdn of the host
+# Return value : true or false
 #
 def my_restart_lock?(znode_path,zk_hosts="localhost:2181",node_name)
   require 'zookeeper'
@@ -296,7 +298,7 @@ def my_restart_lock?(znode_path,zk_hosts="localhost:2181",node_name)
   begin
     zk = Zookeeper.new(zk_hosts)
     if !zk.connected?
-      raise "my_restart_lock?: unable to connect to ZooKeeper"
+      raise "my_restart_lock?: unable to connect to ZooKeeper quorum #{zk_hosts}"
     end
     ret = zk.get(:path => znode_path)
     val = ret[:data]
@@ -318,6 +320,7 @@ end
 # The input parameters are the name of the path to znode which was used to lock for restarting service,
 # string containing the zookeeper host and port ("host1:port,host2:port") and the fqdn
 # of the node trying to release the lock.
+# Return value : true or false based on whether the lock release was successful or not
 #
 def rel_restart_lock(znode_path, zk_hosts="localhost:2181",node_name)
   require 'zookeeper'
@@ -326,7 +329,7 @@ def rel_restart_lock(znode_path, zk_hosts="localhost:2181",node_name)
   begin
     zk = Zookeeper.new(zk_hosts)
     if !zk.connected?
-      raise "rel_restart_lock : unable to connect to ZooKeeper"
+      raise "rel_restart_lock : unable to connect to ZooKeeper quorum #{zk_hosts}"
     end
     if my_restart_lock?(znode_path, zk_hosts, node_name)
       ret = zk.delete(:path => znode_path)
@@ -349,13 +352,14 @@ end
 #
 # Function to get the node name which is holding a particular service restart lock
 # Input parameters: The path to the znode (lock) and the string of zookeeper hosts:port 
+# Return value    : The fqdn of the node which created the znode to restart or nil
 #
 def get_restart_lock_holder(znode_path, zk_hosts="localhost:2181")
   require 'zookeeper'
   begin
     zk = Zookeeper.new(zk_hosts)
     if !zk.connected?
-      raise "get_restart_lock_holder : unable to connect to ZooKeeper"
+      raise "get_restart_lock_holder : unable to connect to ZooKeeper quorum #{zk_hosts}"
     end
     ret = zk.get(:path => znode_path)
     if ret[:rc] == 0
@@ -369,4 +373,64 @@ def get_restart_lock_holder(znode_path, zk_hosts="localhost:2181")
     end
   end
   return val
+end
+#
+# Function to generate the full path of znode which will be used to create a restart lock znode
+# Input paramaters: The path in ZK where znodes are created for the retart locks and the lock name
+# Return value    : Fully formed path which can be used to create the znode 
+#
+def format_restart_lock_path(root, lock_name)
+  begin
+    if root.nil?
+      return "/#{lock_name}"
+    elsif root == "/"
+      return "/#{lock_name}"
+    else
+      return "#{root}/#{lock_name}"
+    end
+  end
+end
+#
+# Function to identify start time of a process
+# Input paramater: string to identify the process through pgrep command
+# Returned value : The starttime for the process. If multiple instances are returned from pgrep
+# command, time returned will be the earliest time of all the instances
+#
+def process_start_time(process_identifier)
+  require 'time'
+  begin
+    target_process_pid = `pgrep -f #{process_identifier}`
+    if target_process_pid == ""
+      return nil
+    else
+      target_process_pid_arr = Array.new()
+      target_process_pid_arr = target_process_pid.split("\n").map{|pid| (`ps --no-header -o start_time #{pid}`).strip}
+      start_time_arr = Array.new()
+      target_process_pid_arr.each do |t|
+        if t != ""
+          start_time_arr.push(Time.parse(t))
+        end
+      end
+      return start_time_arr.sort.first.to_s
+    end
+  end
+end
+#
+# Function to check whether a process was started manually after restart of the process failed during prev chef client run
+# Input paramaters : Last restart failure time, string to identify the process
+# Returned value   : true or false
+#
+def process_restarted_after_failure?(restart_failure_time, process_identifier)
+  require 'time'
+  begin
+    start_time = process_start_time(process_identifier)
+    if start_time.nil?
+      return false
+    elsif Time.parse(restart_failure_time).to_i < Time.parse(start_time).to_i
+      Chef::Log.info ("#{process_identifier} seem to be started at #{start_time} after last restart failure at #{restart_failure_time}") 
+      return true
+    else
+      return false
+    end
+  end
 end

--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -96,96 +96,12 @@ node[:bcpc][:hadoop][:mounts].each do |i|
   end
 end
 
-#
-# When there is a need to restart datanode, a lock need to be taken so that the restart is sequenced preventing all DNs being down at the sametime
-# If there is a failure in acquiring a lock with in a certian period, the restart is scheduled for the next run on chef-client on the node.
-# To determine whether the prev restart failed is the node attribute node[:bcpc][:hadoop][:datanode][:restart_failed] is set to true
-# This ruby block is to check whether this node attribute is set to true and if it is set then gets the DN restart process in motion.
-#
-ruby_block "handle_prev_datanode_restart_failure" do
-  block do
-    Chef::Log.info "Need to restart DN since it failed during the previous run. Another node's DN restart process failure is a possible reason"
-  end
-  action :create
-  only_if { node[:bcpc][:hadoop][:datanode][:restart_failed] }
-end
+dep = ["template[/etc/hadoop/conf/hdfs-site.xml]",
+       "template[/etc/hadoop/conf/hadoop-env.sh]"]
 
-#
-# Since string with all the zookeeper nodes is used multiple times this variable is populated once and reused reducing calls to Chef server
-#
-zk_hosts = (get_node_attributes(MGMT_IP_ATTR_SRCH_KEYS,"zookeeper_server","bcpc-hadoop").map{|zkhost| "#{zkhost['mgmt_ip']}:#{node[:bcpc][:hadoop][:zookeeper][:port]}"}).join(",")
-#
-# znode is used as the locking mechnism to control restart of services. The following code is to build the path
-# to create the znode before initiating the restart of HDFS datanode service 
-#
-if (! node[:bcpc][:hadoop][:restart_lock].attribute?(:root) or  node[:bcpc][:hadoop][:restart_lock][:root].nil?)
-  lock_znode_path = "/hadoop-hdfs-datanode"
-elsif (node[:bcpc][:hadoop][:restart_lock][:root] == "/")
-  lock_znode_path = "/hadoop-hdfs-datanode"
-else
-  lock_znode_path = "#{node[:bcpc][:hadoop][:restart_lock][:root]}/hadoop-hdfs-datanode"
-end
-#
-# All datanode restart situations like changes in config files or restart due to previous failures invokes this ruby_block
-# This ruby block tries to acquire a lock and if not able to acquire the lock, sets the restart_failed node attribute to true
-#
-ruby_block "acquire_lock_to_restart_datanode" do
-  block do
-    tries = 0
-    Chef::Log.info("#{node[:hostname]}: Acquring lock at #{lock_znode_path}")
-    while true 
-      lock = acquire_restart_lock(lock_znode_path, zk_hosts, node[:fqdn])
-      if lock
-        break
-      else
-        tries += 1
-        if tries >= node[:bcpc][:hadoop][:restart_lock_acquire][:max_tries]
-          Chef::Log.info("Couldn't acquire lock to restart datanode with in the #{node[:bcpc][:hadoop][:restart_lock_acquire][:max_tries] * node[:bcpc][:hadoop][:restart_lock_acquire][:sleep_time]} secs.")
-          Chef::Log.info("Node #{get_restart_lock_holder(lock_znode_path, zk_hosts)} may have died during datanode restart.")
-          node.set[:bcpc][:hadoop][:datanode][:restart_failed] = true
-          node.save
-          break
-        end
-        sleep(node[:bcpc][:hadoop][:restart_lock_acquire][:sleep_time])
-      end
-    end
-  end
-  action :nothing
-  subscribes :create, "template[/etc/hadoop/conf/hdfs-site.xml]", :immediate
-  subscribes :create, "template[/etc/hadoop/conf/hadoop-env.sh]", :immediate
-  subscribes :create, "ruby_block[handle_prev_datanode_restart_failure]", :immediate
-end
-#
-# If lock to restart datanode is acquired by the node, this ruby_block executes which is primarily used to notify the datanode service to restart
-#
-ruby_block "coordinate_datanode_restart" do
-  block do
-    Chef::Log.info("Data node will be restarted in node #{node[:fqdn]}")
-  end
-  action :create
-  only_if { my_restart_lock?(lock_znode_path, zk_hosts, node[:fqdn]) }
-end
-
-service "hadoop-hdfs-datanode" do
-  supports :status => true, :restart => true, :reload => false
-  action [:enable, :start]
-  subscribes :restart, "ruby_block[coordinate_datanode_restart]", :immediate
-end
-
-#
-# Once the datanode service restart is complete, the following block releases the lock if the node executing is the one which holds the lock 
-#
-ruby_block "release_datanode_restart_lock" do
-  block do
-    Chef::Log.info("#{node[:hostname]}: Releasing lock at #{lock_znode_path}")
-    lock_rel = rel_restart_lock(lock_znode_path, zk_hosts, node[:fqdn])
-    if lock_rel
-      node.set[:bcpc][:hadoop][:datanode][:restart_failed] = false
-      node.save
-    end
-  end
-  action :create
-  only_if { my_restart_lock?(lock_znode_path, zk_hosts, node[:fqdn]) }
+hadoop_service "hadoop-hdfs-datanode" do
+  dependencies dep
+  process_identifier "org.apache.hadoop.hdfs.server.datanode.DataNode"
 end
 
 service "hadoop-yarn-nodemanager" do


### PR DESCRIPTION
Changes in this pull request
- will allow users to skip the HDFS datanode restart coordination process so that the cluster can be bounced quickly and also will allow users to use the recipe in environments where ZooKeeper is not required.
- will skip the restart of datanode process if the process was started (manually or otherwise) after the previous restart failure through chef client run.
- Also a new definition "hadoop_service" is added to the bcpc-hadoop cookbook so that the restart logic for hadoop services can be reused across all the components.

Refer to req [#349](https://github.com/bloomberg/chef-bcpc/issues/349) in chef-bcpc repo for the initial discussion.
