### PR TITLE
Changes to coordinate the restart of HBase RS services

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -48,6 +48,10 @@ default["bcpc"]["hadoop"]["hadoop_hdfs_datanode"]["restart_failed_time"] = ""
 # Flag to control whether automatic restarts due to config changes need to be skipped 
 # for e.g. if ZK quorum is down or if the recipes need to be run in a non ZK env
 default["bcpc"]["hadoop"]["skip_restart_coordination"] = false
+# Flag to set whether the HBase region server restart process was successful or not
+default["bcpc"]["hadoop"]["hbase_regionserver"]["restart_failed"] = false
+# Attribute to save the time when HBase region server restart process failed
+default["bcpc"]["hadoop"]["hbase_regionserver"]["restart_failed_time"] = ""
 
 default[:bcpc][:hadoop][:nn_hosts] = []
 default[:bcpc][:hadoop][:jn_hosts] = []

--- a/cookbooks/bcpc-hadoop/recipes/region_server.rb
+++ b/cookbooks/bcpc-hadoop/recipes/region_server.rb
@@ -15,10 +15,11 @@ link "/usr/lib/hbase/lib/native/Linux-amd64-64/libsnappy.so.1" do
   to "/usr/lib/libsnappy.so.1"
 end
 
-service "hbase-regionserver" do
-  supports :status => true, :restart => true, :reload => false
-  action [:enable, :start]
-  subscribes :restart, "template[/etc/hbase/conf/hbase-site.xml]", :delayed
-  subscribes :restart, "template[/etc/hbase/conf/hbase-policy.xml]", :delayed
-  subscribes :restart, "template[/etc/hbase/conf/hbase-env.sh]", :delayed
+rs_service_dep = ["template[/etc/hbase/conf/hbase-site.xml]",
+                  "template[/etc/hbase/conf/hbase-env.sh]",
+                  "template[/etc/hbase/conf/hbase-policy.xml]"] 
+
+hadoop_service "hbase-regionserver" do
+  dependencies rs_service_dep
+  process_identifier "org.apache.hadoop.hbase.regionserver.HRegionServer"
 end


### PR DESCRIPTION
The changes in this PR will coordinate the restart of HBase region server service in a Hadoop cluster during scenarios like configuration changes so that only one RS is restarted at a time.The changes in this PR will coordinate the restart of HBase region server service in a Hadoop cluster during scenarios like configuration changes so that only one RS is restarted at a time.
