### PR TITLE
Changes to coordinate the restart of ZooKeeper services

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -52,6 +52,10 @@ default["bcpc"]["hadoop"]["skip_restart_coordination"] = false
 default["bcpc"]["hadoop"]["hbase_regionserver"]["restart_failed"] = false
 # Attribute to save the time when HBase region server restart process failed
 default["bcpc"]["hadoop"]["hbase_regionserver"]["restart_failed_time"] = ""
+# Flag to set whether the ZooKeeper server restart process was successful or not
+default["bcpc"]["hadoop"]["zookeeper_server"]["restart_failed"] = false
+# Attribute to save the time when ZooKeeper server restart process failed
+default["bcpc"]["hadoop"]["zookeeper_server"]["restart_failed_time"] = ""
 
 default[:bcpc][:hadoop][:nn_hosts] = []
 default[:bcpc][:hadoop][:jn_hosts] = []

--- a/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
+++ b/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
@@ -62,11 +62,12 @@ file "#{node[:bcpc][:hadoop][:zookeeper][:data_dir]}/myid" do
   mode 0644
 end
 
-service "zookeeper-server" do
-  supports :status => true, :restart => true, :reload => false
-  action [:enable, :start]
-  subscribes :restart, "template[/etc/zookeeper/conf/zoo.cfg]", :delayed
-  subscribes :restart, "template[/usr/lib/zookeeper/bin/zkServer.sh]", :delayed
-  subscribes :restart, "template[/etc/default/zookeeper-server]", :delayed
-  subscribes :restart, "file[#{node[:bcpc][:hadoop][:zookeeper][:data_dir]}/myid]", :delayed
+zk_service_dep = ["template[/etc/zookeeper/conf/zoo.cfg]",
+                  "template[/usr/lib/zookeeper/bin/zkServer.sh]",
+                  "template[/etc/default/zookeeper-server]",
+                  "file[#{node[:bcpc][:hadoop][:zookeeper][:data_dir]}/myid]"]
+
+hadoop_service "zookeeper-server" do
+  dependencies zk_service_dep
+  process_identifier "org.apache.zookeeper.server.quorum.QuorumPeerMain"
 end


### PR DESCRIPTION
Changes in this PR will coordinate the restart of ZK servers one at a time in scenarios like configuration changes so that all the ZK servers are not down at the same time.
