### PR TITLE
Changes to upgrade Kafka cookbook to version v0.6.0

### DIFF
--- a/cookbooks/kafka-bcpc/attributes/default.rb
+++ b/cookbooks/kafka-bcpc/attributes/default.rb
@@ -8,8 +8,8 @@ default[:use_hadoop_zookeeper_quorum] = false
 #
 # Overwriting community kafka cookbook attributes 
 #
-default[:kafka][:port] = 6667
-default[:kafka][:advertised_port] = 6667
+default[:kafka][:broker][:port] = 6667
+default[:kafka][:broker][:advertised_port] = 6667
 default[:kafka][:automatic_start] = true
 default[:kafka][:automatic_restart] = true
 

--- a/cookbooks/kafka-bcpc/recipes/kafka.rb
+++ b/cookbooks/kafka-bcpc/recipes/kafka.rb
@@ -10,8 +10,8 @@ end
 ruby_block "kafkaup" do
   i = 0
   block do
-    brokerpath="/brokers/ids/#{node[:kafka][:broker_id]}"
-    zk_host = node[:kafka][:zookeeper][:connect].map{|zkh| "#{zkh}:2181"}.join(",")
+    brokerpath="/brokers/ids/#{node[:kafka][:broker][:broker_id]}"
+    zk_host = node[:kafka][:broker][:zookeeper][:connect].map{|zkh| "#{zkh}:2181"}.join(",")
     Chef::Log.info("Zookeeper hosts are #{zk_host}")
     sleep_time = 0.5
     kafka_in_zk = znode_exists?(brokerpath, zk_host)

--- a/cookbooks/kafka-bcpc/recipes/setattr.rb
+++ b/cookbooks/kafka-bcpc/recipes/setattr.rb
@@ -16,8 +16,8 @@ else
   node.override[:bcpc][:hadoop][:zookeeper][:servers] = zk_hosts
 end
 # Override Kafka related node attributes
-node.override[:kafka][:zookeeper][:connect] = zk_hosts.map{|x| float_host(x['hostname'])}
+node.override[:kafka][:broker][:zookeeper][:connect] = zk_hosts.map{|x| float_host(x['hostname'])}
 node.override[:kafka][:base_url] = get_binary_server_url + "kafka"
-node.override[:kafka][:host_name] = float_host(node[:fqdn])
-node.override[:kafka][:advertised_host_name] = float_host(node[:fqdn])
-node.override[:kafka][:jmx_port] = node[:bcpc][:hadoop][:kafka][:jmx][:port]
+node.override[:kafka][:broker][:host_name] = float_host(node[:fqdn])
+node.override[:kafka][:broker][:advertised_host_name] = float_host(node[:fqdn])
+node.override[:kafka][:broker][:jmx_port] = node[:bcpc][:hadoop][:kafka][:jmx][:port]

--- a/setup_chef_cookbooks.sh
+++ b/setup_chef_cookbooks.sh
@@ -68,7 +68,7 @@ done
 [[ -d dpkg_autostart ]] || git clone https://github.com/hw-cookbooks/dpkg_autostart.git
 if [[ ! -d kafka ]]; then
   git clone https://github.com/mthssdrbrg/kafka-cookbook.git kafka
-  cd kafka && git checkout v0.4.1 && cd ..
+  cd kafka && git checkout v0.6.0 && cd ..
 fi
 [[ -d java ]] || git clone https://github.com/socrata-cookbooks/java.git java
 [[ -d jmxtrans ]] || git clone https://github.com/bijugs/chef-jmxtrans.git jmxtrans


### PR DESCRIPTION
Changes to upgrade to v0.6.0 of Kafka cookbook which supports option to gracefully restart Kafka service which.
