### PR TITLE
Fix redundant bcpc::bootstrap recipe entry

### DIFF
--- a/roles/BCPC-Bootstrap.json
+++ b/roles/BCPC-Bootstrap.json
@@ -9,8 +9,7 @@
       "recipe[bcpc::apache-mirror]",
       "recipe[bcpc::ufw]",
       "recipe[bcpc::cobbler]",
-      "recipe[bcpc::cobbler-centos]",
-      "recipe[bcpc::bootstrap]"
+      "recipe[bcpc::cobbler-centos]"
     ],
     "description": "A bootstrap node in a BCPC cluster",
     "chef_type": "role",


### PR DESCRIPTION
Updated BCPC-Bootstrap role.
Unit tested by running: sudo knife role from file roles/*.json -u admin -k /etc/chef-server/admin.pem; The role is compiled and updated.
Will add a comment when I complete testing with cluster standup from scratch.
