### PR TITLE
MySQL changes to support Percona 5.6.21

### DIFF
--- a/cookbooks/bcpc/recipes/mysql.rb
+++ b/cookbooks/bcpc/recipes/mysql.rb
@@ -77,17 +77,8 @@ end
 template "/etc/mysql/conf.d/wsrep.cnf" do
   source "wsrep.cnf.erb"
   mode 00644
-  results = get_node_attributes(HOSTNAME_MGMT_IP_ATTR_SRCH_KEYS,"mysql","bcpc")
-  # If we are the first one, special case
-  seed = ""
-  if ((results.length == 1) && (results[0]['hostname'] == node[:hostname])) then
-    seed = "gcomm://"
-    # Commented out to prevent mysql from always restarting when 1 head-node
-    notifies :run, "bash[remove-bare-gcomm]", :delayed
-  end
-  variables( :seed => seed,
-             :max_connections => [results.length*50+get_all_nodes.length*5, 200].max,
-             :servers => results )
+  variables( :max_connections => [get_nodes_for('mysql','bcpc').length*50+get_all_nodes.length*5, 200].max,
+             :servers => get_nodes_for('mysql','bcpc') )
   notifies :restart, "service[mysql]", :immediate
 end
 

--- a/cookbooks/bcpc/templates/default/wsrep.cnf.erb
+++ b/cookbooks/bcpc/templates/default/wsrep.cnf.erb
@@ -14,7 +14,6 @@
 # The rest of defaults should work out of the box.
 
 [mysqld_safe]
-wsrep_urls="<%= "#{@servers.map{|x| 'gcomm://'+x['mgmt_ip']+':4567'}.join(',')},#{@seed}" %>"
 
 ##
 ## mysqld options _MANDATORY_ for correct opration of the cluster
@@ -47,6 +46,9 @@ max_connections=<%="#{@max_connections}"%>
 ##
 ## WSREP options
 ##
+
+<% @servers.delete(node) -%>
+wsrep_cluster_address=gcomm://<%="#{@servers.collect{|x| x['bcpc']['management']['ip']}.join(',')}"%>
 
 # Full path to wsrep provider library or 'none'
 wsrep_provider=/usr/lib/libgalera_smm.so
@@ -116,7 +118,7 @@ wsrep_notify_cmd=
 ##
 
 # State Snapshot Transfer method
-wsrep_sst_method=xtrabackup
+wsrep_sst_method=xtrabackup-v2
 
 # Address on THIS node to receive SST at. DON'T SET IT TO DONOR ADDRESS!!!
 # (SST method dependent. Defaults to the first IP of the first interface)


### PR DESCRIPTION
This PR supports for new parameter that are required to setup a MySQL cluster using `percona 5.6.21`. Following issue(s) are fixed in this PR:
Issue #41 Cluster Installation Fails while starting MySQL Service

I have tested the replication on all MySQL instances and it works fine.
