### PR TITLE
Change graphite queries to comply with the changes made to Graphite data store

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/graphite.query_graphite.config.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/graphite.query_graphite.config.erb
@@ -3,11 +3,11 @@
 <% node[:bcpc][:hadoop][:graphite][:queries].each_with_index do |(host, value),hidx| -%>
   <% value.each_with_index do |q,aidx| -%>
     <% if hidx == node[:bcpc][:hadoop][:graphite][:queries].length-1 and aidx == value.length()-1 -%>
-      {"graphite_url": "https://<%=node[:bcpc][:management][:vip]%>:<%=node[:bcpc][:graphite][:web_port]%>/render/?from=-2min&target=<%=q['type']%>.*_<%=node[:bcpc][:hadoop][host][:jmx][:port]%>.<%=q['query']%>&format=json",
+      {"graphite_url": "https://<%=node[:bcpc][:management][:vip]%>:<%=node[:bcpc][:graphite][:web_port]%>/render/?from=-2min&target=<%=q['type']%>.<%= host %>.*.<%=q['query']%>&format=json",
        "zabbix_host" : "<%= host %>", 
        "zabbix_key"  : "<%=q['key']%>"}
     <% else -%>
-      {"graphite_url": "https://<%=node[:bcpc][:management][:vip]%>:<%=node[:bcpc][:graphite][:web_port]%>/render/?from=-2min&target=<%=q['type']%>.*_<%=node[:bcpc][:hadoop][host][:jmx][:port]%>.<%=q['query']%>&format=json",
+      {"graphite_url": "https://<%=node[:bcpc][:management][:vip]%>:<%=node[:bcpc][:graphite][:web_port]%>/render/?from=-2min&target=<%=q['type']%>.<%= host %>.*.<%=q['query']%>&format=json",
        "zabbix_host" : "<%= host %>", 
        "zabbix_key"  : "<%=q['key']%>"},
     <% end %>


### PR DESCRIPTION
As part of PR #28, changes were made to the format in which data is stored in Graphite database so that the data is presented in a user friendly format on the UI. The changes in this PR is to make queries run against Graphite (to send data to Zabbix) to comply with the changes in PR#28.
