### PR TITLE
Changes to copy logs from nodes into HDFS

### DIFF
--- a/cluster.txt
+++ b/cluster.txt
@@ -1,3 +1,3 @@
-bcpc-vm1 08:00:27:56:A2:28 10.0.100.11 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Head-Namenode-NoHA],role[BCPC-Hadoop-Head-HBase]
-bcpc-vm2 08:00:27:E5:3A:00 10.0.100.12 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Head-Namenode-Standby],role[BCPC-Hadoop-Head-MapReduce],role[BCPC-Hadoop-Head-Hive]
-bcpc-vm3 08:00:27:AD:1D:EA 10.0.100.13 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Worker]
+bcpc-vm1 08:00:27:56:A2:28 10.0.100.11 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Head-Namenode-NoHA],role[BCPC-Hadoop-Head-HBase],role[Copylog]
+bcpc-vm2 08:00:27:E5:3A:00 10.0.100.12 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Head-Namenode-Standby],role[BCPC-Hadoop-Head-MapReduce],role[BCPC-Hadoop-Head-Hive],role[Copylog]
+bcpc-vm3 08:00:27:AD:1D:EA 10.0.100.13 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Worker],role[Copylog]

--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -145,3 +145,20 @@ default["bcpc"]["hadoop"]["graphite"]["queries"] = {
     }
   ]
 }
+#
+# Attributes to store details about (log) files from nodes to be copied
+# into a centralized location (currently HDFS).
+# E.g. value {'hbase_rs' =>  { 'logfile' => "/path/file_name_of_log_file",
+#                              'docopy' => true (or false)
+#                             },...
+#            }
+#
+default['bcpc']['hadoop']['copylog'] = {}
+#
+# Attribute to enable/disable the copylog feature
+#
+default['bcpc']['hadoop']['copylog_enable'] = true
+#
+# File rollup interval in secs for log data copied into HDFS through Flume
+#
+default['bcpc']['hadoop']['copylog_rollup_interval'] = 86400

--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -24,6 +24,7 @@ default["bcpc"]["hadoop"]["hdfs"]["HA"] = false
 default["bcpc"]["hadoop"]["hdfs"]["failed_volumes_tolerated"] = 1
 default["bcpc"]["hadoop"]["hdfs"]["dfs_replication_factor"] = 3
 default["bcpc"]["hadoop"]["hdfs"]["dfs_blocksize"] = "128m"
+default['bcpc']['hadoop']['hdfs_url']="hdfs://#{node.chef_environment}/"
 default["bcpc"]["hadoop"]["jmx_enabled"] = true
 default["bcpc"]["hadoop"]["namenode"]["jmx"]["port"] = 10111
 default["bcpc"]["hadoop"]["namenode"]["rpc"]["port"] = 8020

--- a/cookbooks/bcpc-hadoop/recipes/copylog.rb
+++ b/cookbooks/bcpc-hadoop/recipes/copylog.rb
@@ -1,0 +1,97 @@
+#
+# Recipe to copy log data from nodes into HDFS
+# Flume is used to copy data and runs as an agent on the nodes
+# 
+#**** Attention ***** Attention ****
+# This should be the last recipe in the runlist for any role since 
+# individual recipes can make requests to copy log files to HDFS
+# This can be achieved by adding the Copylog role as the last role to the node
+# Since flume writes into HDFS nodes running this recipe should have HDFS
+# client components installed on them.
+
+
+dpkg_autostart "flume-agent" do
+  allow false
+end
+
+%w{flume flume-agent}.each do |p|
+  package p do
+    action :upgrade
+  end
+end
+
+service "flume-agent" do
+  action [:stop, :disable]
+end
+
+bash "make_shared_logs_dir" do
+  code <<EOH
+  hdfs dfs -mkdir -p #{node['bcpc']['hadoop']['hdfs_url']}/user/flume/logs/ && \
+  hdfs dfs -chown -R flume #{node['bcpc']['hadoop']['hdfs_url']}/user/flume/
+EOH
+  user "hdfs"
+  not_if "hdfs dfs -test #{node['bcpc']['hadoop']['hdfs_url']}/user/flume/logs/", :user => "hdfs"
+end
+
+#
+# Dummy template resource for future use
+# Currently we use the default flume-env values
+#
+template "/etc/flume/conf/flume-env.sh" do
+  action :nothing
+end
+
+template "/etc/init.d/flume-agent-multi" do
+  source "flume_flume-agent.erb"
+  owner "root"
+  group "root"
+  mode "0755"
+  action :create
+end
+
+if node['bcpc']['hadoop']['copylog_enable']
+  service "flume-agent-multi" do
+    supports :status => true, :restart => true, :reload => false
+    action [:enable, :start]
+    subscribes :restart, "template[/etc/flume/conf/flume-env.sh]", :delayed
+  end
+  node['bcpc']['hadoop']['copylog'].each do |id,f|
+    if f['docopy'] 
+      template "/etc/flume/conf/flume-#{id}.conf" do
+        source "flume_flume-conf.erb"
+        owner "root"
+        group "root"
+        mode "0444"
+        action :create
+        variables(:agent_name => "#{id}",
+                  :log_location => "#{f['logfile']}" )
+        notifies :restart,"service[flume-agent-multi-#{id}]",:delayed
+      end
+      
+      service "flume-agent-multi-#{id}" do
+        supports :status => true, :restart => true, :reload => false
+        service_name "flume-agent-multi"
+        action :start
+        start_command "service flume-agent-multi start #{id}"
+        restart_command "service flume-agent-multi restart #{id}"
+        status_command "service flume-agent-multi status #{id}"
+      end
+    else
+      service "flume-agent-multi-#{id}" do
+        supports :status => true, :restart => true, :reload => false
+        action :stop
+        stop_command "service flume-agent-multi stop #{id}"
+        status_command "service flume-agent-multi status #{id}"
+      end
+
+      file "/etc/flume/conf/flume-#{id}.conf" do
+        action :delete
+      end
+    end
+  end
+else
+  service "flume-agent-multi" do
+    supports :status => true, :restart => true, :reload => false
+    action [:stop, :disable]
+  end
+end

--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -1,5 +1,10 @@
 include_recipe 'bcpc-hadoop::hadoop_config'
 
+node.default['bcpc']['hadoop']['copylog']['datanode'] = {
+    'logfile' => "/var/log/hadoop-hdfs/hadoop-hdfs-datanode-#{node.hostname}.log",
+    'docopy' => true
+}
+
 %w{hadoop-yarn-nodemanager
    hadoop-hdfs-datanode
    hadoop-mapreduce

--- a/cookbooks/bcpc-hadoop/recipes/default.rb
+++ b/cookbooks/bcpc-hadoop/recipes/default.rb
@@ -17,6 +17,20 @@
 # limitations under the License.
 #
 
+#
+# Updating node attributes to copy syslog and auth.log from all bcpc-hadoop nodes
+# to a centralized location (currently HDFS). Enable after deciding userid to use. 
+#
+node.default['bcpc']['hadoop']['copylog']['syslog'] = {
+    'logfile' => "/var/log/syslog",
+    'docopy' => false
+}
+
+node.default['bcpc']['hadoop']['copylog']['authlog'] = {
+    'logfile' => "/var/log/auth.log",
+    'docopy' => false
+}
+
 # ensure the Zookeeper Gem is available for use in later recipes
 # it seems chef_gem fails to use the embedded gem(1) binary so use gem_package
 # and a hack to use rubygems to find the current Ruby binary;

--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -1,5 +1,18 @@
 include_recipe 'bcpc-hadoop::hbase_config'
 
+#
+# Updating node attributes to copy HBase master log file to centralized location (HDFS)
+#
+node.default['bcpc']['hadoop']['copylog']['hbase_master'] = {
+    'logfile' => "/var/log/hbase/hbase-hbase-master-#{node.hostname}.log",
+    'docopy' => true
+}
+
+node.default['bcpc']['hadoop']['copylog']['hbase_master_out'] = {
+    'logfile' => "/var/log/hbase/hbase-hbase-master-#{node.hostname}.out",
+    'docopy' => true
+}
+
 %w{
 hbase
 hbase-master

--- a/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
@@ -2,6 +2,19 @@ include_recipe 'dpkg_autostart'
 require "base64"
 include_recipe 'bcpc-hadoop::hadoop_config'
 
+#
+# Updating node attribuetes to copy namenode log files to centralized location (HDFS)
+#
+node.default['bcpc']['hadoop']['copylog']['namenode_master'] = {
+    'logfile' => "/var/log/hadoop-hdfs/hadoop-hdfs-namenode-#{node.hostname}.log",
+    'docopy' => true
+}
+
+node.default['bcpc']['hadoop']['copylog']['namenode_master_out'] = {
+    'logfile' => "/var/log/hadoop-hdfs/hadoop-hdfs-namenode-#{node.hostname}.out",
+    'docopy' => true
+}
+
 %w{hadoop-hdfs-namenode hadoop-hdfs-zkfc hadoop-mapreduce}.each do |pkg|
   dpkg_autostart pkg do
     allow false

--- a/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
@@ -3,6 +3,19 @@ require "base64"
 
 include_recipe 'bcpc-hadoop::hadoop_config'
 
+#
+# Updating node attribuetes to copy namenode log files to centralized location (HDFS)
+#
+node.default['bcpc']['hadoop']['copylog']['namenode'] = {
+    'logfile' => "/var/log/hadoop-hdfs/hadoop-hdfs-namenode-#{node.hostname}.log", 
+    'docopy' => true
+}
+
+node.default['bcpc']['hadoop']['copylog']['namenode_out'] = {
+    'logfile' => "/var/log/hadoop-hdfs/hadoop-hdfs-namenode-#{node.hostname}.out", 
+    'docopy' => true
+}
+
 %w{hadoop-hdfs-namenode hadoop-mapreduce}.each do |pkg|
   dpkg_autostart pkg do
     allow false

--- a/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
@@ -2,6 +2,19 @@ include_recipe 'dpkg_autostart'
 include_recipe 'bcpc-hadoop::hadoop_config'
 require "base64"
 
+#
+# Updating node attributes to copy namenode log files to centralized location (HDFS)
+#
+node.default['bcpc']['hadoop']['copylog']['namenode_standby'] = {
+    'logfile' => "/var/log/hadoop-hdfs/hadoop-hdfs-namenode-#{node.hostname}.log",
+    'docopy' => true
+}
+
+node.default['bcpc']['hadoop']['copylog']['namenode_standby_out'] = {
+    'logfile' => "/var/log/hadoop-hdfs/hadoop-hdfs-namenode-#{node.hostname}.out",
+    'docopy' => true
+}
+
 %w{hadoop-hdfs-namenode hadoop-hdfs-zkfc hadoop-mapreduce}.each do |pkg|
   dpkg_autostart pkg do
     allow false

--- a/cookbooks/bcpc-hadoop/recipes/oozie.rb
+++ b/cookbooks/bcpc-hadoop/recipes/oozie.rb
@@ -13,7 +13,7 @@ end
 
 OOZIE_LIB_PATH='/usr/lib/oozie'
 OOZIE_SERVER_PATH='/var/lib/oozie/oozie-server'
-HDFS_URL="hdfs://#{node.chef_environment}/"
+HDFS_URL="#{node['bcpc']['hadoop']['hdfs_url']}/"
 
 directory "#{OOZIE_LIB_PATH}/libext" do
   owner "oozie"

--- a/cookbooks/bcpc-hadoop/recipes/region_server.rb
+++ b/cookbooks/bcpc-hadoop/recipes/region_server.rb
@@ -1,5 +1,15 @@
 include_recipe 'bcpc-hadoop::hbase_config'
 
+node.default['bcpc']['hadoop']['copylog']['region_server'] = {
+    'logfile' => "/var/log/hbase/hbase-hbase-regionserver-#{node.hostname}.log", 
+    'docopy' => true
+}
+
+node.default['bcpc']['hadoop']['copylog']['region_server_out'] = {
+    'logfile' => "/var/log/hbase/hbase-hbase-regionserver-#{node.hostname}.out", 
+    'docopy' => true
+}
+
 %w{hbase-regionserver libsnappy1}.each do |pkg|
   package pkg do
     action :install

--- a/cookbooks/bcpc-hadoop/templates/default/flume_flume-agent.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/flume_flume-agent.erb
@@ -1,0 +1,267 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Starts a Flume NG agent
+#
+# chkconfig: 345 90 10
+# description: Flume NG agent
+#
+### BEGIN INIT INFO
+# Provides:          flume-agent
+# Required-Start:    $remote_fs
+# Should-Start:
+# Required-Stop:     $remote_fs
+# Should-Stop:
+# Default-Start:     3 4 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Flume NG agent
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+if [ -f /etc/default/flume-agent ] ; then
+  . /etc/default/flume-agent
+fi
+
+# Autodetect JAVA_HOME if not defined
+if [ -e /usr/libexec/bigtop-detect-javahome ]; then
+  . /usr/libexec/bigtop-detect-javahome
+elif [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then
+  . /usr/lib/bigtop-utils/bigtop-detect-javahome
+fi
+
+STATUS_RUNNING=0
+STATUS_DEAD=1
+STATUS_DEAD_AND_LOCK=2
+STATUS_NOT_RUNNING=3
+
+ERROR_PROGRAM_NOT_INSTALLED=5
+
+FLUME_LOG_DIR=/var/log/flume
+FLUME_CONF_DIR=/etc/flume/conf
+FLUME_RUN_DIR=/var/run/flume
+FLUME_HOME=/usr/lib/flume
+FLUME_USER=flume
+
+FLUME_LOCK_DIR="/var/lock/subsys/"
+LOCKFILE="${FLUME_LOCK_DIR}/flume-agent"
+desc="Flume NG agent daemon"
+
+FLUME_CONF_FILE=${FLUME_CONF_FILE:-${FLUME_CONF_DIR}/flume.conf}
+EXEC_PATH=/usr/bin/flume-ng
+FLUME_PID_FILE=${FLUME_RUN_DIR}/flume-agent.pid
+
+# These directories may be tmpfs and may or may not exist
+# depending on the OS (ex: /var/lock/subsys does not exist on debian/ubuntu)
+for dir in "$FLUME_RUN_DIR" "$FLUME_LOCK_DIR"; do
+  [ -d "${dir}" ] || install -d -m 0755 -o $FLUME_USER -g $FLUME_USER ${dir}
+done
+
+DEFAULT_FLUME_AGENT_NAME="agent"
+FLUME_AGENT_NAME=${FLUME_AGENT_NAME:-${DEFAULT_FLUME_AGENT_NAME}}
+FLUME_SHUTDOWN_TIMEOUT=${FLUME_SHUTDOWN_TIMEOUT:-60}
+
+# Update variables if service request is followed by a service name
+# e.g. service flume-agent start|stop|status|restart service-name
+# Starts a flume agent with the name flume-service-name
+# Expects flume-service-name.conf file in FLUME_CONF_DIR
+setvariables() {
+  AGENT_NAME=$1
+  LOCKFILE="${FLUME_LOCK_DIR}/flume-${AGENT_NAME}"
+  FLUME_CONF_FILE=${FLUME_CONF_DIR}/flume-${AGENT_NAME}.conf
+  FLUME_PID_FILE=${FLUME_RUN_DIR}/flume-${AGENT_NAME}.pid
+  DEFAULT_FLUME_AGENT_NAME=${AGENT_NAME}
+  FLUME_AGENT_NAME=${DEFAULT_FLUME_AGENT_NAME}
+}
+
+start() {
+  [ -x $exec ] || exit $ERROR_PROGRAM_NOT_INSTALLED
+
+  checkstatus
+  status=$?
+  if [ "$status" -eq "$STATUS_RUNNING" ]; then
+    return 0
+  fi
+
+  log_success_msg "Starting $desc $FLUME_AGENT_NAME: "
+  /bin/su -s /bin/bash -c "/bin/bash -c 'echo \$\$ >${FLUME_PID_FILE} && exec ${EXEC_PATH} agent --conf $FLUME_CONF_DIR --conf-file $FLUME_CONF_FILE --name $FLUME_AGENT_NAME >>${FLUME_LOG_DIR}/flume-${FLUME_AGENT_NAME}.out 2>&1' &" $FLUME_USER
+  RETVAL=$?
+  [ $RETVAL -eq 0 ] && touch $LOCKFILE
+  return $RETVAL
+}
+
+stop() {
+  if [ ! -e $FLUME_PID_FILE ]; then
+    log_failure_msg "Flume agent $FLUME_AGENT_NAME is not running"
+    return 0
+  fi
+
+  log_success_msg "Stopping $desc $FLUME_AGENT_NAME: "
+
+  FLUME_PID=`cat $FLUME_PID_FILE`
+  if [ -n $FLUME_PID ]; then
+    kill -TERM ${FLUME_PID} &>/dev/null
+    for i in `seq 1 ${FLUME_SHUTDOWN_TIMEOUT}` ; do
+      kill -0 ${FLUME_PID} &>/dev/null || break
+      sleep 1
+    done
+    kill -KILL ${FLUME_PID} &>/dev/null
+  fi
+  rm -f $LOCKFILE $FLUME_PID_FILE
+  return 0
+}
+
+restart() {
+  stop
+  start
+}
+
+checkstatus(){
+  pidofproc -p $FLUME_PID_FILE java > /dev/null
+  status=$?
+
+  case "$status" in
+    $STATUS_RUNNING)
+      log_success_msg "Flume NG agent $FLUME_AGENT_NAME is running"
+      ;;
+    $STATUS_DEAD)
+      log_failure_msg "Flume NG agent $FLUME_AGENT_NAME is dead and pid file exists"
+      ;;
+    $STATUS_DEAD_AND_LOCK)
+      log_failure_msg "Flume NG agent $FLUME_AGENT_NAME is dead and lock file exists"
+      ;;
+    $STATUS_NOT_RUNNING)
+      log_failure_msg "Flume NG agent $FLUME_AGENT_NAME is not running"
+      ;;
+    *)
+      log_failure_msg "Flume NG agent $FLUME_AGENT_NAME status is unknown"
+      ;;
+  esac
+  return $status
+}
+
+condrestart(){
+  [ -e ${LOCKFILE} ] && restart || :
+}
+
+#
+# If user doesn't provide a flume agent name to start,
+# will attempt to start all agents based on conf files in ${FLUME_CONF_DIR} 
+#
+startall() {
+  run_functions_on_conf start
+}
+
+#
+# If user doesn't provide a flume agent name to stop,
+# will attempt to stop all agents based on conf files in ${FLUME_CONF_DIR} 
+#
+stopall() {
+  run_functions_on_conf stop
+}
+
+#
+# If user doesn't provide a flume agent name to restart,
+# will attempt to restart all agents based on conf files in ${FLUME_CONF_DIR} 
+#
+restartall() {
+  run_functions_on_conf restart
+}
+
+#
+# If user doesn't provide a flume agent name to perform cond restart,
+# will attempt to do condrestart all agents based on conf files in ${FLUME_CONF_DIR} 
+#
+condrestartall() {
+  run_functions_on_conf condrestart
+}
+
+#
+# If user doesn't provide a flume agent name to check the status,
+# status of all agents based on conf files in ${FLUME_CONF_DIR} is checked
+#
+checkallstatus() {
+  run_functions_on_conf checkstatus
+}
+
+#
+# Common function to perform user action on all flume conf files
+#
+run_functions_on_conf() {
+  for f in ${FLUME_CONF_DIR}/*
+  do
+    file_ext=${f##*.}
+    if [ "$file_ext" = "conf" ]; then
+      conf_file=${f%.*}
+      file_name=${conf_file##*/}
+      agent_name=${file_name#*-}
+      echo $agent_name
+      setvariables $agent_name
+      $1
+    fi
+  done
+}
+
+#
+# Logic to update variables if service start|stop|... is made with a flume agent name
+#
+if [ "$#" -eq 2 ]; then
+  setvariables $2
+fi
+
+case "$1" in
+  start)
+    if [ "$#" -eq 2 ];then
+      start
+    else
+      startall
+    fi
+    ;;
+  stop)
+    if [ "$#" -eq 2 ]; then
+      stop
+    else
+      stopall
+    fi
+    ;;
+  status)
+    if [ "$#" -eq 2 ]; then
+      checkstatus
+    else
+      checkallstatus
+    fi
+    ;;
+  restart)
+    if [ "$#" -eq 2 ]; then
+      restart
+    else
+      restartall
+    fi
+    ;;
+  condrestart|try-restart)
+    if [ "$#" -eq 2 ]; then
+      condrestart
+    else
+      condrestartall
+    fi
+    ;;
+  *)
+    echo $"Usage: $0 {start|stop|status|restart|try-restart|condrestart}"
+    RETVAL=1
+esac
+
+exit $RETVAL

--- a/cookbooks/bcpc-hadoop/templates/default/flume_flume-conf.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/flume_flume-conf.erb
@@ -1,0 +1,17 @@
+<%= @agent_name %>.channels = memoryChannel
+<%= @agent_name %>.channels.memoryChannel.type = memory
+<%= @agent_name %>.sources = pstream
+<%= @agent_name %>.sources.pstream.channels = memoryChannel
+<%= @agent_name %>.sources.pstream.type = exec
+<%= @agent_name %>.sources.pstream.command = tail -f <%= @log_location %>
+<%= @agent_name %>.sinks = hdfsSink
+<%= @agent_name %>.sinks.hdfsSink.type = hdfs
+<%= @agent_name %>.sinks.hdfsSink.channel = memoryChannel
+<%= @agent_name %>.sinks.hdfsSink.hdfs.useLocalTimeStamp = true
+<%= @agent_name %>.sinks.hdfsSink.hdfs.path = <%= node['bcpc']['hadoop']['hdfs_url'] %>/user/flume/logs/%y-%m-%d
+<%= @agent_name %>.sinks.hdfsSink.hdfs.filePrefix = <%= @agent_name %>-<%= node.hostname %>
+<%= @agent_name %>.sinks.hdfsSink.hdfs.fileType = DataStream
+<%= @agent_name %>.sinks.hdfsSink.hdfs.writeFormat = Text
+<%= @agent_name %>.sinks.hdfsSink.hdfs.rollInterval = <%= node['bcpc']['hadoop']['copylog_rollup_interval'] %>
+<%= @agent_name %>.sinks.hdfsSink.hdfs.rollSize = 0
+<%= @agent_name %>.sinks.hdfsSink.hdfs.rollCount = 0

--- a/cookbooks/bcpc-hadoop/templates/default/hb_hbase-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hb_hbase-site.xml.erb
@@ -10,7 +10,7 @@
 <configuration>
   <property>
     <name>hbase.rootdir</name>
-    <value>hdfs://<%= node.chef_environment %>/hbase</value>
+    <value><%= node['bcpc']['hadoop']['hdfs_url'] %>/hbase</value>
   </property>
   <property>
     <name>hbase.zookeeper.quorum</name>

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_core-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_core-site.xml.erb
@@ -11,7 +11,7 @@
 <configuration>
   <property>
     <name>fs.defaultFS</name>
-    <value>hdfs://<%= node.chef_environment %></value>
+    <value><%= node['bcpc']['hadoop']['hdfs_url']%></value>
   </property>
 
   <property>

--- a/cookbooks/bcpc-hadoop/templates/default/hv_hive-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hv_hive-site.xml.erb
@@ -99,7 +99,7 @@
 
 <property>
   <name>hive.metastore.warehouse.dir</name>
-  <value><%= "hdfs://#{node.chef_environment}/user/hive/warehouse" %></value>
+  <value><%= "#{node['bcpc']['hadoop']['hdfs_url']}/user/hive/warehouse" %></value>
 </property>
 
 <property>

--- a/cookbooks/bcpc-hadoop/templates/default/revelytix-loom-properties.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/revelytix-loom-properties.erb
@@ -15,7 +15,7 @@ activeScan.hdfs.enabled=<%= node.bcpc.revelytix.activescan_hdfs_enabled %>
 # path that will be resolved against the Loom working directory. The scan is
 # recursive, so all sub-directories of each configured directory will be scanned.
 # Defaults to the Loom working directory if not set.
-activeScan.hdfs.baseDir=hdfs://<%= node.chef_environment %>/user,hdfs://<%= node.chef_environment %>/projects
+activeScan.hdfs.baseDir=<%= node['bcpc']['hadoop']['hdfs_url'] %>/user,hdfs://<%= node.chef_environment %>/projects
 
 # The username to run the potential-source scanner service as. A Loom account is
 # created with this username when the Loom server is launched, and that account

--- a/roles/Copylog.json
+++ b/roles/Copylog.json
@@ -1,0 +1,13 @@
+{
+    "name": "Copylog",
+    "default_attributes": {
+    },
+    "json_class": "Chef::Role",
+    "run_list": [
+      "recipe[bcpc-hadoop::copylog]"
+    ],
+    "description": "Copies log to centralized location",
+    "chef_type": "role",
+    "override_attributes": {
+    }
+}


### PR DESCRIPTION
Changes in the PR will enable copying of log files from nodes in the cluster to a centralized location currently HDFS. There is an additional commit to use node attribute to store HDFS URL.

**Note** Any user trying to copy logs from nodes to HDFS or change the current log locations, need to update the recipe for the corresponding component to set the correct key values for the [copylog node attribute](https://github.com/bijugs/chef-bach/blob/copy_logs/cookbooks/bcpc-hadoop/attributes/default.rb#L143-L151)

**Future work:**
1) Need to identify the access control to  read and copy syslog, auth.log and chef log to HDFS.
2) Identify the correct components to copy the logs from the bootstrap node into HDFS.
3) When changes are made to dynamically create `` site.xml `` and `` env.sh `` the file locations for copylog need to be updated as well.

