### PR TITLE
Zabbix alarming extension

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -85,6 +85,8 @@ default["bcpc"]["revelytix"]["port"] = 8080
 default["bcpc"]["hadoop"]["zabbix"]["history_days"] = 1
 default["bcpc"]["hadoop"]["zabbix"]["trend_days"] = 15
 default["bcpc"]["hadoop"]["zabbix"]["cron_check_time"] = 240
+default["bcpc"]["hadoop"]["zabbix"]["mail_source"] = "zabbix.zbx_mail.sh.erb"
+default["bcpc"]["hadoop"]["zabbix"]["cookbook"] = nil 
 default["bcpc"]["hadoop"]["graphite"]["queries"] = {
    'namenode' => [
     {
@@ -94,7 +96,9 @@ default["bcpc"]["hadoop"]["graphite"]["queries"] = {
       'trigger_val' => "max(61,0)",
       'trigger_cond' => "=0",
       'trigger_name' => "NameNodeAvailability",
-      'trigger_enable' => true
+      'trigger_enable' => true,
+      'trigger_desc' => "Namenode service seems to be down",
+      'severity' => 2
     },
     {
       'type'  => "jmx",
@@ -110,7 +114,9 @@ default["bcpc"]["hadoop"]["graphite"]["queries"] = {
       'trigger_val' => "max(61,0)",
       'trigger_cond' => "=0",
       'trigger_name' => "HBaseMasterAvailability",
-      'trigger_dep' => ["NameNodeAvailability"]
+      'trigger_dep' => ["NameNodeAvailability"],
+      'trigger_desc' => "HBase master seems to be down",
+      'severity' => 1
     },
     {
       'type'  => "jmx",
@@ -127,7 +133,9 @@ default["bcpc"]["hadoop"]["graphite"]["queries"] = {
       'trigger_cond' => "=0",
       'trigger_name' => "HBaseRSAvailability",
       'trigger_enable' => true,
-      'trigger_dep' => ["HBaseMasterAvailability"]
+      'trigger_dep' => ["HBaseMasterAvailability"],
+      'trigger_desc' => "HBase region server seems to be down",
+      'severity' => 2
     }
   ]
 }

--- a/cookbooks/bcpc-hadoop/templates/default/zabbix.zbx_mail.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/zabbix.zbx_mail.sh.erb
@@ -1,4 +1,8 @@
 #!/bin/bash
 trigger_name=$1
 cluster_name=$2
-echo "Please attend to issue with $trigger_name in $cluster_name" | logger -t "Zabbix-Trigger-Action"
+severity=$3
+description=$4
+host=$5
+
+logger -t "Zabbix-Trigger-Action" <<< "Please attend to severity $severity issue with $trigger_name on $cluster_name:$host; problem description=$description"

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -141,7 +141,9 @@ default['bcpc']['zabbix']['user'] = "zabbix"
 default['bcpc']['zabbix']['group'] = "adm"
 default['bcpc']['zabbix']['server_port'] = 10051
 default['bcpc']['zabbix']['web_port'] = 7777
-default['bcpc']['zabbix']['scripts_dir'] = "/usr/local/bin"
+default['bcpc']['zabbix']['scripts']['sender'] = "/usr/local/bin/run_zabbix_sender.sh"
+default['bcpc']['zabbix']['scripts']['mail'] = "/usr/local/bin/zbx_mail.sh"
+default['bcpc']['zabbix']['scripts']['query_graphite'] = "/usr/local/bin/query_graphite.py"
 
 default['bcpc']['keepalived']['config_template'] = "keepalived.conf_openstack"
 default['bcpc']['graphite']['relay_port'] = 2013


### PR DESCRIPTION
This PR provides alarming extensions to zabbix users.

Extending zabbix to provide trigger severity and description to alarm notifications.
To allow wrapper cookbooks to override the zabbix mail script.
