### PR TITLE
Fix for #79: get_req_node_attributes fails a chef run with unhelpful "undefined method `[]' for nil:NilClass"

### DIFF
--- a/cookbooks/bcpc-hadoop/libraries/utils.rb
+++ b/cookbooks/bcpc-hadoop/libraries/utils.rb
@@ -236,7 +236,12 @@ def get_req_node_attributes(node_objects,srch_keys)
   node_objects.each do |obj|
     temp = Hash.new
     srch_keys.each do |name, key|
-      val = key.split('.').reduce(obj) {|memo, key| memo[key]}
+      begin
+        val = key.split('.').reduce(obj) {|memo, key| memo[key]}
+      rescue NoMethodError
+        Chef::Log.fatal "Node #{obj} does not have key #{key}!"
+        raise
+      end
       temp[name] = val
     end
     result.push(temp)

--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -155,7 +155,12 @@ def get_req_node_attributes(node_objects,srch_keys)
   node_objects.each do |obj|
     temp = Hash.new
     srch_keys.each do |name, key|
-      val = key.split('.').reduce(obj) {|memo, key| memo[key]}
+      begin
+        val = key.split('.').reduce(obj) {|memo, key| memo[key]}
+      rescue NoMethodError
+        Chef::Log.fatal "Node #{obj} does not have key #{key}!"
+        raise
+      end
       temp[name] = val
     end
     result.push(temp)


### PR DESCRIPTION
This will print out a log message showing the node object and which key is missing for easier debugging. The Chef run will stop and error at that point as well.