### PR TITLE
Changes to install correct hive config files on all worker nodes

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -1,4 +1,5 @@
 include_recipe 'bcpc-hadoop::hadoop_config'
+include_recipe 'bcpc-hadoop::hive_config'
 
 %w{hadoop-yarn-nodemanager
    hadoop-hdfs-datanode


### PR DESCRIPTION
Currently default config files are getting installed on worker nodes resulting in hive actions ending up using local Derby DB instead of the common mysql metastore. This is a fix for the chef-bcpc issue [#338](https://github.com/bloomberg/chef-bcpc/issues/338).