### PR TITLE
macOS_sed_fix

### DIFF
--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -36,7 +36,7 @@ $SEDINPLACE 's/vb.gui = true/vb.gui = false/' Vagrantfile
 
 # setup environment file
 $SEDINPLACE "s/\"dns_servers\" : \[ \"8.8.8.8\", \"8.8.4.4\" \]/\"dns_servers\" : \[ $DNS_SERVERS \]/" environments/${ENVIRONMENT}.json
-[[ -n "$PROXY" ]] && $SEDINPLACE "s#\(\"bootstrap\": {\)#\1\n\"proxy\" : \"http://$PROXY\",\n#" environments/${ENVIRONMENT}.json
+[[ -n "$PROXY" ]] && $SEDINPLACE -e "s#\(\"bootstrap\": \)#\1\\\n\"proxy\" : \"http://$PROXY\",#" -e $'s/\\\\n/\\\n/' environments/${ENVIRONMENT}.json
 
 printf "#### Setup VB's and Bootstrap\n"
 source ./vbox_create.sh

--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -36,7 +36,7 @@ $SEDINPLACE 's/vb.gui = true/vb.gui = false/' Vagrantfile
 
 # setup environment file
 $SEDINPLACE "s/\"dns_servers\" : \[ \"8.8.8.8\", \"8.8.4.4\" \]/\"dns_servers\" : \[ $DNS_SERVERS \]/" environments/${ENVIRONMENT}.json
-[[ -n "$PROXY" ]] && $SEDINPLACE -e "s#\(\"bootstrap\": \)#\1\\\n\"proxy\" : \"http://$PROXY\",#" -e $'s/\\\\n/\\\n/' environments/${ENVIRONMENT}.json
+[[ -n "$PROXY" ]] && $SEDINPLACE -e "s#\(\"bootstrap\": {\)#\1\\\n\"proxy\" : \"http://$PROXY\",#" -e $'s/\\\\n/\\\n/' environments/${ENVIRONMENT}.json
 
 printf "#### Setup VB's and Bootstrap\n"
 source ./vbox_create.sh


### PR DESCRIPTION
Description: tests/automated_install has a encode issue with MAC OS. Because MAC OS uses BSD version SED, while ubuntu uses Unix version SED. The character '\n' encodes different in these two versions.

My solution: use two patterns in SED. The first will put an '\n' in needing newline place, second pattern will replace this \n with real newline character.

