### PR TITLE
Changes to copy Oozie sharelibs to HDFS

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/oozie.rb
+++ b/cookbooks/bcpc-hadoop/recipes/oozie.rb
@@ -65,14 +65,15 @@ EOH
   not_if "hdfs dfs -test #{HDFS_URL}/user/oozie/share/", :user => "hdfs"
 end
 
+#
+# not_if logic will prevent upgrades to the sharelibs being updated
+# But this should be fine for HDP 2.0 version
+#
 bash "oozie_update_shared_libs" do
   share_dir_url="#{HDFS_URL}/user/oozie/share/"
-  code "#{OOZIE_LIB_PATH}/bin/oozie-setup.sh sharelib update -fs #{HDFS_URL}"
+  code "#{OOZIE_LIB_PATH}/bin/oozie-setup.sh sharelib create -fs #{HDFS_URL}"
   user "oozie"
-  not_if { require 'time'
-           hdfs_mtime=`hdfs dfs -stat #{share_dir_url}`.strip
-           Time.parse("#{hdfs_mtime} UTC") >
-           File.mtime("#{OOZIE_LIB_PATH}/oozie-sharelib.tar.gz") }
+  not_if "hdfs dfs -test -d #{HDFS_URL}/user/oozie/share/lib", :user => "hdfs"
 end
 
 file "#{OOZIE_LIB_PATH}/oozie.sql" do


### PR DESCRIPTION
In the current code Oozie sharelibs are not being copied into HDFS. This PR is to fix the issue.