### PR TITLE
Stash Maven in bins to fix #88

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/maven_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/maven_config.rb
@@ -1,3 +1,15 @@
-# Override maven attributes
+require 'pathname'
 
 node.override['maven']['install_java'] = false
+
+internet_download_url = node['maven']['3']['url']
+maven_file = Pathname.new(node['maven']['3']['url']).basename
+
+node.override['maven']['3']['url'] = "#{get_binary_server_url}/#{maven_file}"
+
+# download Maven only if not already stashed in the bins directory
+remote_file "/home/vagrant/chef-bcpc/bins/#{maven_file}" do
+  source internet_download_url
+  action :create_if_missing
+  mode '0555'
+end


### PR DESCRIPTION
This fixes issues #88 by stashing Maven in `/home/vagrant/chef-bcpc/bins` for later use.