### PR TITLE
Modify automated_install to chef all vms in parallel

### DIFF
--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -76,10 +76,8 @@ printf "Snapshotting post-Cobbler\n"
 printf "#### Chef all the nodes\n"
 vagrant ssh -c "sudo apt-get install -y sshpass"
 
-for i in 1 2 3; do
-  printf "#### Chef machine bcpc-vm${i}\n"
-  vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT Hadoop bcpc-vm$i"
-done
+printf "#### Chef machine bcpc-vms\n"
+vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT Hadoop"
 
 printf "Snapshotting post-Cobbler\n"
 VBoxManage snapshot bcpc-vm1 take Full-Shoes


### PR DESCRIPTION
This PR enables chef'ing all the VM nodes in parallel instead of serially in a for loop. Refer issue #92 

EDIT: This is supposed to set /etc/hosts correctly on all the nodes without having to chef them in a particular order.