### PR TITLE
Configure heap size for Hive processes

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hive.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hive.rb
@@ -1,2 +1,3 @@
 default[:bach][:hive][:metastore][:port] = 9083
 default[:bach][:hive][:hiveserver2][:port] = 10000
+default[:bcpc][:hive][:heap][:size]=1024

--- a/cookbooks/bcpc-hadoop/templates/default/hv_hive-env.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hv_hive-env.sh.erb
@@ -6,3 +6,4 @@ export HIVE_CONF_DIR=/etc/hive/conf.<%= node.chef_environment %>
 # export HIVE_AUX_JARS_PATH=
 export HIVE_AUX_JARS_PATH=/usr/lib/hcatalog/share/hcatalog/hcatalog-core.jar
 
+export HADOOP_HEAPSIZE=<%=node[:bcpc][:hive][:heap][:size] %>


### PR DESCRIPTION
This PR will allow configuring a custom heap size for Hive processes `hive-metastore` and `hiveserver2`.