### PR TITLE
Remove hardcoded cookbook versions

### DIFF
--- a/environments/Test-Laptop.json
+++ b/environments/Test-Laptop.json
@@ -67,7 +67,10 @@
       "cache_path": "/var/chef/cache",
       "backup_path": "/var/chef/backup",
       "validation_client_name": "chef-validator",
-      "run_path": "/var/chef"
+      "run_path": "/var/chef",
+      "config": {
+        "verify_api_cert": false
+      }
     }
   },
   "json_class": "Chef::Environment",

--- a/setup_chef_cookbooks.sh
+++ b/setup_chef_cookbooks.sh
@@ -57,7 +57,30 @@ EOF
 cd cookbooks
 
 # allow versions on cookbooks via "cookbook version"
-for cookbook in "apt 2.4.0" python build-essential ubuntu cron "chef-client 3.0.6" ntp yum logrotate yum-epel sysctl chef_handler 7-zip windows ark sudo ulimit pam ohai poise graphite_handler java maven; do
+for cookbook in \
+  apt \
+  python \
+  build-essential \
+  ubuntu \
+  cron \
+  chef-client \
+  ntp \
+  yum \
+  logrotate \
+  yum-epel \
+  sysctl \
+  chef_handler \
+  7-zip \
+  windows \
+  ark \
+  sudo \
+  ulimit \
+  pam \
+  ohai \
+  poise \
+  graphite_handler \
+  java \
+  maven; do
   if [[ ! -d ${cookbook% *} ]]; then
      # unless the proxy was defined this knife config will be the same as the one generated above
     knife cookbook site download $cookbook --config ../.chef/knife.rb


### PR DESCRIPTION
- This reverts the change from chef-bcpc [issue 266](https://github.com/bloomberg/chef-bcpc/issues/266) which seems to be resolved in the current apt cookbook.
- This reverts the change from our initial Chef 11 [commit](https://github.com/bloomberg/chef-bach/commit/d6e431e0c18e7d2897028bb59cd3c736397ca580#diff-95d29768b114a017d5a3307f0e57eb09) which hard coded chef-client to version 3.0.6
- This also updates the list of cookbooks in `setup_chef_cookbooks.sh` to have each cookbook on its own line to aide in `git blame` being useful for seeing when things changed per cookbook
