### PR TITLE
Change timezone to show the correct time on Graphite graphs

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -149,6 +149,7 @@ default['bcpc']['keepalived']['config_template'] = "keepalived.conf_openstack"
 default['bcpc']['graphite']['relay_port'] = 2013
 default['bcpc']['graphite']['web_port'] = 8888
 default['bcpc']['graphite']['log']['retention'] = 15
+default['bcpc']['graphite']['timezone'] = "'America/New_York'"
 
 default[:bcpc][:ports][:apache][:radosgw] = 8080
 default[:bcpc][:ports][:apache][:radosgw_https] = 8443

--- a/cookbooks/bcpc/templates/default/graphite.local_settings.py.erb
+++ b/cookbooks/bcpc/templates/default/graphite.local_settings.py.erb
@@ -15,7 +15,7 @@
 # Set your local timezone (Django's default is America/Chicago)
 # If your graphs appear to be offset by a couple hours then this probably
 # needs to be explicitly set to your local timezone.
-#TIME_ZONE = 'America/Los_Angeles'
+TIME_ZONE = <%= node['bcpc']['graphite']['timezone'] %>
 
 # Override this to provide documentation specific to your Graphite deployment
 #DOCUMENTATION_URL = "http://graphite.readthedocs.org/"


### PR DESCRIPTION
This is to fix issue #108.