### PR TITLE
Fix embedded ruby block to set oozie java_home

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-env.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-env.sh.erb
@@ -20,6 +20,6 @@ export OOZIE_HTTPS_KEYSTORE_PASS=<%=get_config("oozie-keystore-password") %>
 export CATALINA_OPTS="$CATALINA_OPTS -Doozie.https.port=${OOZIE_HTTPS_PORT}"
 export CATALINA_OPTS="$CATALINA_OPTS -Doozie.https.keystore.pass=${OOZIE_HTTPS_KEYSTORE_PASS}"
 
-export JAVA_HOME=<% node["bcpc"]["hadoop"]["java"] %>
+export JAVA_HOME=<%= node["bcpc"]["hadoop"]["java"] %>
 export JAVA_LIBRARY_PATH=/usr/lib/hadoop/lib/native/Linux-amd64-64
 


### PR DESCRIPTION
Fixes the embedded ruby code which set Java home in oozie environment script.