### PR TITLE
Changes to enable rolling restart of Hadoop components

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -62,6 +62,10 @@ default["bcpc"]["hadoop"]["hbase_regionserver"]["restart_failed_time"] = ""
 default["bcpc"]["hadoop"]["zookeeper_server"]["restart_failed"] = false
 # Attribute to save the time when ZooKeeper server restart process failed
 default["bcpc"]["hadoop"]["zookeeper_server"]["restart_failed_time"] = ""
+# Flag to set whether Yarn nodemanager server restart process was successful or not
+default["bcpc"]["hadoop"]["hadoop_yarn_nodemanager"]["restart_failed"] = false
+# Attribute to save the time when Yarn nodemanager server restart process failed
+default["bcpc"]["hadoop"]["hadoop_yarn_nodemanager"]["restart_failed_time"] = ""
 
 default[:bcpc][:hadoop][:nn_hosts] = []
 default[:bcpc][:hadoop][:jn_hosts] = []

--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -47,8 +47,13 @@ default["bcpc"]["hadoop"]["restart_lock_acquire"]["max_tries"] = 5
 default["bcpc"]["hadoop"]["restart_lock"]["root"] = "/"
 # Sleep time in seconds between tries to acquire the lock for restart
 default["bcpc"]["hadoop"]["restart_lock_acquire"]["sleep_time"] = 2
-# Flag to set whether the restart process was successful or not
-default["bcpc"]["hadoop"]["datanode"]["restart_failed"] = false
+# Flag to set whether the HDFS datanode restart process was successful or not
+default["bcpc"]["hadoop"]["hadoop_hdfs_datanode"]["restart_failed"] = false
+# Attribute to save the time when HDFS datanode restart process failed
+default["bcpc"]["hadoop"]["hadoop_hdfs_datanode"]["restart_failed_time"] = ""
+# Flag to control whether automatic restarts due to config changes need to be skipped 
+# for e.g. if ZK quorum is down or if the recipes need to be run in a non ZK env
+default["bcpc"]["hadoop"]["skip_restart_coordination"] = false
 
 default[:bcpc][:hadoop][:nn_hosts] = []
 default[:bcpc][:hadoop][:jn_hosts] = []

--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -58,6 +58,10 @@ default["bcpc"]["hadoop"]["skip_restart_coordination"] = false
 default["bcpc"]["hadoop"]["hbase_regionserver"]["restart_failed"] = false
 # Attribute to save the time when HBase region server restart process failed
 default["bcpc"]["hadoop"]["hbase_regionserver"]["restart_failed_time"] = ""
+# Flag to set whether the ZooKeeper server restart process was successful or not
+default["bcpc"]["hadoop"]["zookeeper_server"]["restart_failed"] = false
+# Attribute to save the time when ZooKeeper server restart process failed
+default["bcpc"]["hadoop"]["zookeeper_server"]["restart_failed_time"] = ""
 
 default[:bcpc][:hadoop][:nn_hosts] = []
 default[:bcpc][:hadoop][:jn_hosts] = []

--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -54,6 +54,10 @@ default["bcpc"]["hadoop"]["hadoop_hdfs_datanode"]["restart_failed_time"] = ""
 # Flag to control whether automatic restarts due to config changes need to be skipped 
 # for e.g. if ZK quorum is down or if the recipes need to be run in a non ZK env
 default["bcpc"]["hadoop"]["skip_restart_coordination"] = false
+# Flag to set whether the HBase region server restart process was successful or not
+default["bcpc"]["hadoop"]["hbase_regionserver"]["restart_failed"] = false
+# Attribute to save the time when HBase region server restart process failed
+default["bcpc"]["hadoop"]["hbase_regionserver"]["restart_failed_time"] = ""
 
 default[:bcpc][:hadoop][:nn_hosts] = []
 default[:bcpc][:hadoop][:jn_hosts] = []

--- a/cookbooks/bcpc-hadoop/definitions/hadoop_service.rb
+++ b/cookbooks/bcpc-hadoop/definitions/hadoop_service.rb
@@ -1,0 +1,118 @@
+define :hadoop_service, :service_name => nil, :dependencies => nil, :process_identifier => nil do
+
+  params[:service_name] ||= params[:name]
+
+  service "#{params[:service_name]}" do
+    supports :status => true, :restart => true, :reload => false
+    action [:enable, :start]
+  end
+
+  if node["bcpc"]["hadoop"]["skip_restart_coordination"]
+    Chef::Log.info "Coordination of #{params[:service_name]} restart will be skipped as per user request."
+    begin
+      res = resources(service: "#{params[:service_name]}")
+      if params[:dependencies]
+        params[:dependencies].each do |dep|
+          res.subscribes(:restart, "#{dep}", :delayed)
+        end
+      end
+    rescue Chef::Exceptions::ResourceNotFound
+      Chef::Log.info("Resource service #{params[:service_name]} not found")
+    end
+  else
+    if !params[:process_identifier]
+      Chef::Application.fatal!("hadoop_service for #{params[:service_name]} need to specify a valid value for the parameter :process_identifier")
+    end
+    #
+    # When there is a need to restart a hadoop service, a lock need to be taken so that the restart is sequenced preventing all nodes being down at the sametime
+    # If there is a failure in acquiring a lock with in a certian period, the restart is scheduled for the next run on chef-client on the node.
+    # To determine whether the prev restart failed is the node attribute node[:bcpc][:hadoop][:service_name][:restart_failed] is set to true
+    # This ruby block is to check whether this node attribute is set to true and if it is set then gets the hadoop service restart process in motion.
+    #
+    ruby_block "handle_prev_#{params[:service_name].gsub('-','_')}_restart_failure" do
+      block do
+        Chef::Log.info "Need to restart #{params[:service_name]} since it failed during the previous run. Another node's restart process failure is a possible reason"
+      end
+      action :create
+      only_if { node[:bcpc][:hadoop][params[:service_name].gsub('-','_').to_sym][:restart_failed] and 
+              !process_restarted_after_failure?(node[:bcpc][:hadoop][params[:service_name].gsub('-','_').to_sym][:restart_failed_time],"#{params[:process_identifier]}")}
+    end
+    #
+    # Since string with all the zookeeper nodes is used multiple times this variable is populated once and reused reducing calls to Chef server
+    #
+    zk_hosts = (get_node_attributes(MGMT_IP_ATTR_SRCH_KEYS,"zookeeper_server","bcpc-hadoop").map{|zkhost| "#{zkhost['mgmt_ip']}:#{node[:bcpc][:hadoop][:zookeeper][:port]}"}).join(",")
+    #
+    # znode is used as the locking mechnism to control restart of services. The following code is to build the path
+    # to create the znode before initiating the restart of hadoop service 
+    #
+    lock_znode_path = format_restart_lock_path(node[:bcpc][:hadoop][:restart_lock][:root],"#{params[:service_name]}")
+    #
+    # All hadoop service restart situations like changes in config files or restart due to previous failures invokes this ruby_block
+    # This ruby block tries to acquire a lock and if not able to acquire the lock, sets the restart_failed node attribute to true
+    #
+    ruby_block "acquire_lock_to_restart_#{params[:service_name].gsub('-','_')}" do
+      require 'time'
+      block do
+        tries = 0
+        Chef::Log.info("#{node[:hostname]}: Acquring lock at #{lock_znode_path}")
+        while true 
+          lock = acquire_restart_lock(lock_znode_path, zk_hosts, node[:fqdn])
+          if lock
+            break
+          else
+            tries += 1
+            if tries >= node[:bcpc][:hadoop][:restart_lock_acquire][:max_tries]
+              failure_time = Time.now().to_s
+              Chef::Log.info("Couldn't acquire lock to restart #{params[:service_name]} with in the #{node[:bcpc][:hadoop][:restart_lock_acquire][:max_tries] * node[:bcpc][:hadoop][:restart_lock_acquire][:sleep_time]} secs. Failure time is #{failure_time}")
+              Chef::Log.info("Node #{get_restart_lock_holder(lock_znode_path, zk_hosts)} may have died during #{params[:service_name]} restart.")
+              node.set[:bcpc][:hadoop][params[:service_name].gsub('-','_').to_sym][:restart_failed] = true
+              node.set[:bcpc][:hadoop][params[:service_name].gsub('-','_').to_sym][:restart_failed_time] = failure_time
+              node.save
+              break
+            end
+            sleep(node[:bcpc][:hadoop][:restart_lock_acquire][:sleep_time])
+          end
+        end
+      end
+      action :nothing
+      if params[:dependencies]
+        params[:dependencies].each do |dep|
+          subscribes :create, "#{dep}", :immediate
+        end
+      end
+      subscribes :create, "ruby_block[handle_prev_#{params[:service_name].gsub('-','_')}_restart_failure]", :immediate
+    end
+    #
+    # If lock to restart hadoop service is acquired by the node, this ruby_block executes which is primarily used to notify the hadoop service to restart
+    #
+    ruby_block "coordinate_#{params[:service_name].gsub('-','_')}_restart" do
+      block do
+        Chef::Log.info("Data node will be restarted in node #{node[:fqdn]}")
+      end
+      action :create
+      only_if { my_restart_lock?(lock_znode_path, zk_hosts, node[:fqdn]) }
+    end
+
+    begin
+      res = resources(service: "#{params[:service_name]}")
+      res.subscribes(:restart, "ruby_block[coordinate_#{params[:service_name].gsub('-','_')}_restart]", :immediate)
+    rescue Chef::Exceptions::ResourceNotFound
+      Chef::Log.info("Resource service #{params[:service_name]} not found")
+    end
+    #
+    # Once the hadoop service restart is complete, the following block releases the lock if the node executing is the one which holds the lock 
+    #
+    ruby_block "release_#{params[:service_name].gsub('-','_')}_restart_lock" do
+      block do
+        Chef::Log.info("#{node[:hostname]}: Releasing lock at #{lock_znode_path}")
+        lock_rel = rel_restart_lock(lock_znode_path, zk_hosts, node[:fqdn])
+        if lock_rel
+          node.set[:bcpc][:hadoop][params[:service_name].gsub('-','_').to_sym][:restart_failed] = false
+          node.save
+        end
+      end
+      action :create
+      only_if { my_restart_lock?(lock_znode_path, zk_hosts, node[:fqdn]) }
+    end
+  end
+end

--- a/cookbooks/bcpc-hadoop/libraries/utils.rb
+++ b/cookbooks/bcpc-hadoop/libraries/utils.rb
@@ -257,6 +257,7 @@ end
 # of the service to be restarted for e.g "hadoop-hdfs-datanode" and is located by default at "/".
 # The imput parameters are service name along with the ZK path (znode name), string of zookeeper 
 # servers ("zk_host1:port,sk_host2:port"), and the fqdn of the node acquiring the lock
+# Return value : true or false
 #
 def acquire_restart_lock(znode_path, zk_hosts="localhost:2181",node_name)
   require 'zookeeper'
@@ -265,7 +266,7 @@ def acquire_restart_lock(znode_path, zk_hosts="localhost:2181",node_name)
   begin
     zk = Zookeeper.new(zk_hosts)
     if !zk.connected?
-      raise "acquire_restart_lock : unable to connect to ZooKeeper"
+      raise "acquire_restart_lock : unable to connect to ZooKeeper quorum #{zk_hosts}"
     end
     ret = zk.create(:path => znode_path, :data => node_name)
     if ret[:rc] == 0
@@ -285,6 +286,7 @@ end
 # This function is to check whether the lock to restart a particular service is held by a node.
 # The input parameters are the path to the znode used to restart a hadoop service, a string containing the 
 # host port values of the ZooKeeper nodes "host1:port, host2:port" and the fqdn of the host
+# Return value : true or false
 #
 def my_restart_lock?(znode_path,zk_hosts="localhost:2181",node_name)
   require 'zookeeper'
@@ -293,7 +295,7 @@ def my_restart_lock?(znode_path,zk_hosts="localhost:2181",node_name)
   begin
     zk = Zookeeper.new(zk_hosts)
     if !zk.connected?
-      raise "my_restart_lock?: unable to connect to ZooKeeper"
+      raise "my_restart_lock?: unable to connect to ZooKeeper quorum #{zk_hosts}"
     end
     ret = zk.get(:path => znode_path)
     val = ret[:data]
@@ -315,6 +317,7 @@ end
 # The input parameters are the name of the path to znode which was used to lock for restarting service,
 # string containing the zookeeper host and port ("host1:port,host2:port") and the fqdn
 # of the node trying to release the lock.
+# Return value : true or false based on whether the lock release was successful or not
 #
 def rel_restart_lock(znode_path, zk_hosts="localhost:2181",node_name)
   require 'zookeeper'
@@ -323,7 +326,7 @@ def rel_restart_lock(znode_path, zk_hosts="localhost:2181",node_name)
   begin
     zk = Zookeeper.new(zk_hosts)
     if !zk.connected?
-      raise "rel_restart_lock : unable to connect to ZooKeeper"
+      raise "rel_restart_lock : unable to connect to ZooKeeper quorum #{zk_hosts}"
     end
     if my_restart_lock?(znode_path, zk_hosts, node_name)
       ret = zk.delete(:path => znode_path)
@@ -346,13 +349,14 @@ end
 #
 # Function to get the node name which is holding a particular service restart lock
 # Input parameters: The path to the znode (lock) and the string of zookeeper hosts:port 
+# Return value    : The fqdn of the node which created the znode to restart or nil
 #
 def get_restart_lock_holder(znode_path, zk_hosts="localhost:2181")
   require 'zookeeper'
   begin
     zk = Zookeeper.new(zk_hosts)
     if !zk.connected?
-      raise "get_restart_lock_holder : unable to connect to ZooKeeper"
+      raise "get_restart_lock_holder : unable to connect to ZooKeeper quorum #{zk_hosts}"
     end
     ret = zk.get(:path => znode_path)
     if ret[:rc] == 0
@@ -366,4 +370,64 @@ def get_restart_lock_holder(znode_path, zk_hosts="localhost:2181")
     end
   end
   return val
+end
+#
+# Function to generate the full path of znode which will be used to create a restart lock znode
+# Input paramaters: The path in ZK where znodes are created for the retart locks and the lock name
+# Return value    : Fully formed path which can be used to create the znode 
+#
+def format_restart_lock_path(root, lock_name)
+  begin
+    if root.nil?
+      return "/#{lock_name}"
+    elsif root == "/"
+      return "/#{lock_name}"
+    else
+      return "#{root}/#{lock_name}"
+    end
+  end
+end
+#
+# Function to identify start time of a process
+# Input paramater: string to identify the process through pgrep command
+# Returned value : The starttime for the process. If multiple instances are returned from pgrep
+# command, time returned will be the earliest time of all the instances
+#
+def process_start_time(process_identifier)
+  require 'time'
+  begin
+    target_process_pid = `pgrep -f #{process_identifier}`
+    if target_process_pid == ""
+      return nil
+    else
+      target_process_pid_arr = Array.new()
+      target_process_pid_arr = target_process_pid.split("\n").map{|pid| (`ps --no-header -o start_time #{pid}`).strip}
+      start_time_arr = Array.new()
+      target_process_pid_arr.each do |t|
+        if t != ""
+          start_time_arr.push(Time.parse(t))
+        end
+      end
+      return start_time_arr.sort.first.to_s
+    end
+  end
+end
+#
+# Function to check whether a process was started manually after restart of the process failed during prev chef client run
+# Input paramaters : Last restart failure time, string to identify the process
+# Returned value   : true or false
+#
+def process_restarted_after_failure?(restart_failure_time, process_identifier)
+  require 'time'
+  begin
+    start_time = process_start_time(process_identifier)
+    if start_time.nil?
+      return false
+    elsif Time.parse(restart_failure_time).to_i < Time.parse(start_time).to_i
+      Chef::Log.info ("#{process_identifier} seem to be started at #{start_time} after last restart failure at #{restart_failure_time}") 
+      return true
+    else
+      return false
+    end
+  end
 end

--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -6,9 +6,7 @@ node.default['bcpc']['hadoop']['copylog']['datanode'] = {
     'docopy' => true
 }
 
-%w{hadoop-yarn-nodemanager
-   hadoop-hdfs-datanode
-   hadoop-mapreduce
+%w{hadoop-hdfs-datanode
    hadoop-client
    sqoop
    lzop
@@ -16,36 +14,6 @@ node.default['bcpc']['hadoop']['copylog']['datanode'] = {
   package pkg do
     action :upgrade
   end
-end
-
-link "/usr/lib/hadoop/lib/native/libgplcompression.la" do
-  to "/usr/lib/hadoop/lib/native/Linux-amd64-64/libgplcompression.la"
-end
-
-link "/usr/lib/hadoop/lib/native/libgplcompression.a" do
-  to "/usr/lib/hadoop/lib/native/Linux-amd64-64/libgplcompression.a"
-end
-
-link "/usr/lib/hadoop/lib/native/libgplcompression.so.0.0.0" do
-  to "/usr/lib/hadoop/lib/native/Linux-amd64-64/libgplcompression.so.0.0.0"
-end
-
-# Install YARN Bits
-template "/etc/hadoop/conf/container-executor.cfg" do
-  source "hdp_container-executor.cfg.erb"
-  owner "root"
-  group "yarn"
-  mode "0400"
-  variables(:mounts => node[:bcpc][:hadoop][:mounts])
-  action :create
-  notifies :run, "bash[verify-container-executor]", :immediate
-end
-
-bash "verify-container-executor" do
-  code "/usr/lib/hadoop-yarn/bin/container-executor --checksetup"
-  group "yarn"
-  action :nothing
-  only_if { File.exists?("/usr/lib/hadoop-yarn/bin/container-executor") }
 end
 
 # Install Sqoop Bits
@@ -75,7 +43,7 @@ link "/usr/lib/hive/lib/mysql.jar" do
   to "/usr/share/java/mysql.jar"
 end
 
-# Setup datanode and nodemanager bits
+# Setup HDFS datanode bits
 if node[:bcpc][:hadoop][:mounts].length <= node[:bcpc][:hadoop][:hdfs][:failed_volumes_tolerated]
   Chef::Application.fatal!("You have fewer #{node[:bcpc][:hadoop][:disks]} than #{node[:bcpc][:hadoop][:hdfs][:failed_volumes_tolerated]}! See comments of HDFS-4442.")
 end
@@ -96,35 +64,10 @@ node[:bcpc][:hadoop][:mounts].each do |i|
   end
 end
 
-# Build nodes for YARN log storage
-node[:bcpc][:hadoop][:mounts].each do |i|
-  directory "/disk/#{i}/yarn/" do
-    owner "yarn"
-    group "yarn"
-    mode 0755
-    action :create
-  end
-  %w{mapred-local local logs}.each do |d|
-    directory "/disk/#{i}/yarn/#{d}" do
-      owner "yarn"
-      group "hadoop"
-      mode 0755
-      action :create
-    end
-  end
-end
-
 dep = ["template[/etc/hadoop/conf/hdfs-site.xml]",
        "template[/etc/hadoop/conf/hadoop-env.sh]"]
 
 hadoop_service "hadoop-hdfs-datanode" do
   dependencies dep
   process_identifier "org.apache.hadoop.hdfs.server.datanode.DataNode"
-end
-
-service "hadoop-yarn-nodemanager" do
-  supports :status => true, :restart => true, :reload => false
-  action [:enable, :start]
-  subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
-  subscribes :restart, "template[/etc/hadoop/conf/yarn-site.xml]", :delayed
 end

--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -114,97 +114,12 @@ node[:bcpc][:hadoop][:mounts].each do |i|
   end
 end
 
-#
-# When there is a need to restart datanode, a lock need to be taken so that the restart is sequenced preventing all DNs being down at the sametime
-# If there is a failure in acquiring a lock with in a certian period, the restart is scheduled for the next run on chef-client on the node.
-# To determine whether the prev restart failed is the node attribute node[:bcpc][:hadoop][:datanode][:restart_failed] is set to true
-# This ruby block is to check whether this node attribute is set to true and if it is set then gets the DN restart process in motion.
-#
-ruby_block "handle_prev_datanode_restart_failure" do
-  block do
-    Chef::Log.info "Need to restart DN since it failed during the previous run. Another node's DN restart process failure is a possible reason"
-  end
-  action :create
-  only_if { node[:bcpc][:hadoop][:datanode][:restart_failed] }
-end
+dep = ["template[/etc/hadoop/conf/hdfs-site.xml]",
+       "template[/etc/hadoop/conf/hadoop-env.sh]"]
 
-#
-# Since string with all the zookeeper nodes is used multiple times this variable is populated once and reused reducing calls to Chef server
-#
-zk_hosts = (get_node_attributes(MGMT_IP_ATTR_SRCH_KEYS,"zookeeper_server","bcpc-hadoop").map{|zkhost| "#{zkhost['mgmt_ip']}:#{node[:bcpc][:hadoop][:zookeeper][:port]}"}).join(",")
-#
-# znode is used as the locking mechnism to control restart of services. The following code is to build the path
-# to create the znode before initiating the restart of HDFS datanode service 
-#
-if (! node[:bcpc][:hadoop][:restart_lock].attribute?(:root) or  node[:bcpc][:hadoop][:restart_lock][:root].nil?)
-  lock_znode_path = "/hadoop-hdfs-datanode"
-elsif (node[:bcpc][:hadoop][:restart_lock][:root] == "/")
-  lock_znode_path = "/hadoop-hdfs-datanode"
-else
-  lock_znode_path = "#{node[:bcpc][:hadoop][:restart_lock][:root]}/hadoop-hdfs-datanode"
-end
-#
-# All datanode restart situations like changes in config files or restart due to previous failures invokes this ruby_block
-# This ruby block tries to acquire a lock and if not able to acquire the lock, sets the restart_failed node attribute to true
-#
-ruby_block "acquire_lock_to_restart_datanode" do
-  block do
-    tries = 0
-    Chef::Log.info("#{node[:hostname]}: Acquring lock at #{lock_znode_path}")
-    while true 
-      lock = acquire_restart_lock(lock_znode_path, zk_hosts, node[:fqdn])
-      if lock
-        break
-      else
-        tries += 1
-        if tries >= node[:bcpc][:hadoop][:restart_lock_acquire][:max_tries]
-          Chef::Log.info("Couldn't acquire lock to restart datanode with in the #{node[:bcpc][:hadoop][:restart_lock_acquire][:max_tries] * node[:bcpc][:hadoop][:restart_lock_acquire][:sleep_time]} secs.")
-          Chef::Log.info("Node #{get_restart_lock_holder(lock_znode_path, zk_hosts)} may have died during datanode restart.")
-          node.set[:bcpc][:hadoop][:datanode][:restart_failed] = true
-          node.save
-          break
-        end
-        sleep(node[:bcpc][:hadoop][:restart_lock_acquire][:sleep_time])
-      end
-    end
-  end
-  action :nothing
-  subscribes :create, "template[/etc/hadoop/conf/hdfs-site.xml]", :immediate
-  subscribes :create, "template[/etc/hadoop/conf/hadoop-env.sh]", :immediate
-  subscribes :create, "template[/etc/hadoop/conf/topology]", :immediate
-  subscribes :create, "ruby_block[handle_prev_datanode_restart_failure]", :immediate
-end
-#
-# If lock to restart datanode is acquired by the node, this ruby_block executes which is primarily used to notify the datanode service to restart
-#
-ruby_block "coordinate_datanode_restart" do
-  block do
-    Chef::Log.info("Data node will be restarted in node #{node[:fqdn]}")
-  end
-  action :create
-  only_if { my_restart_lock?(lock_znode_path, zk_hosts, node[:fqdn]) }
-end
-
-service "hadoop-hdfs-datanode" do
-  supports :status => true, :restart => true, :reload => false
-  action [:enable, :start]
-  subscribes :restart, "ruby_block[coordinate_datanode_restart]", :immediate
-end
-
-#
-# Once the datanode service restart is complete, the following block releases the lock if the node executing is the one which holds the lock 
-#
-ruby_block "release_datanode_restart_lock" do
-  block do
-    Chef::Log.info("#{node[:hostname]}: Releasing lock at #{lock_znode_path}")
-    lock_rel = rel_restart_lock(lock_znode_path, zk_hosts, node[:fqdn])
-    if lock_rel
-      node.set[:bcpc][:hadoop][:datanode][:restart_failed] = false
-      node.save
-    end
-  end
-  action :create
-  only_if { my_restart_lock?(lock_znode_path, zk_hosts, node[:fqdn]) }
+hadoop_service "hadoop-hdfs-datanode" do
+  dependencies dep
+  process_identifier "org.apache.hadoop.hdfs.server.datanode.DataNode"
 end
 
 service "hadoop-yarn-nodemanager" do

--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -7,40 +7,10 @@ node.default['bcpc']['hadoop']['copylog']['datanode'] = {
 }
 
 %w{hadoop-hdfs-datanode
-   hadoop-client
-   sqoop
-   lzop
-   hadoop-lzo}.each do |pkg|
+   hadoop-client}.each do |pkg|
   package pkg do
     action :upgrade
   end
-end
-
-# Install Sqoop Bits
-template "/etc/sqoop/conf/sqoop-env.sh" do
-  source "sq_sqoop-env.sh.erb"
-  mode "0444"
-  action :create
-end
-
-# Install Hive Bits
-# workaround for hcatalog dpkg not creating the hcat user it requires
-user "hcat" do 
-  username "hcat"
-  system true
-  shell "/bin/bash"
-  home "/usr/lib/hcatalog"
-  supports :manage_home => false
-end
-
-%w{hive hcatalog libmysql-java}.each do |pkg|
-  package pkg do
-    action :upgrade
-  end
-end
-
-link "/usr/lib/hive/lib/mysql.jar" do
-  to "/usr/share/java/mysql.jar"
 end
 
 # Setup HDFS datanode bits

--- a/cookbooks/bcpc-hadoop/recipes/hive_client.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hive_client.rb
@@ -1,0 +1,20 @@
+# Install Hive Bits
+# workaround for hcatalog dpkg not creating the hcat user it requires
+user "hcat" do
+  username "hcat"
+  system true
+  shell "/bin/bash"
+  home "/usr/lib/hcatalog"
+  supports :manage_home => false
+end
+
+%w{hive hcatalog libmysql-java}.each do |pkg|
+  package pkg do
+    action :upgrade
+  end
+end
+
+link "/usr/lib/hive/lib/mysql.jar" do
+  to "/usr/share/java/mysql.jar"
+end
+

--- a/cookbooks/bcpc-hadoop/recipes/region_server.rb
+++ b/cookbooks/bcpc-hadoop/recipes/region_server.rb
@@ -25,10 +25,11 @@ link "/usr/lib/hbase/lib/native/Linux-amd64-64/libsnappy.so.1" do
   to "/usr/lib/libsnappy.so.1"
 end
 
-service "hbase-regionserver" do
-  supports :status => true, :restart => true, :reload => false
-  action [:enable, :start]
-  subscribes :restart, "template[/etc/hbase/conf/hbase-site.xml]", :delayed
-  subscribes :restart, "template[/etc/hbase/conf/hbase-policy.xml]", :delayed
-  subscribes :restart, "template[/etc/hbase/conf/hbase-env.sh]", :delayed
+rs_service_dep = ["template[/etc/hbase/conf/hbase-site.xml]",
+                  "template[/etc/hbase/conf/hbase-env.sh]",
+                  "template[/etc/hbase/conf/hbase-policy.xml]"] 
+
+hadoop_service "hbase-regionserver" do
+  dependencies rs_service_dep
+  process_identifier "org.apache.hadoop.hbase.regionserver.HRegionServer"
 end

--- a/cookbooks/bcpc-hadoop/recipes/yarn_nodemanager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/yarn_nodemanager.rb
@@ -16,26 +16,6 @@ template "/etc/sqoop/conf/sqoop-env.sh" do
   action :create
 end
 
-# Install Hive Bits
-# workaround for hcatalog dpkg not creating the hcat user it requires
-user "hcat" do
-  username "hcat"
-  system true
-  shell "/bin/bash"
-  home "/usr/lib/hcatalog"
-  supports :manage_home => false
-end
-
-%w{hive hcatalog libmysql-java}.each do |pkg|
-  package pkg do
-    action :upgrade
-  end
-end
-
-link "/usr/lib/hive/lib/mysql.jar" do
-  to "/usr/share/java/mysql.jar"
-end
-
 # Install YARN Bits
 template "/etc/hadoop/conf/container-executor.cfg" do
   source "hdp_container-executor.cfg.erb"

--- a/cookbooks/bcpc-hadoop/recipes/yarn_nodemanager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/yarn_nodemanager.rb
@@ -1,0 +1,50 @@
+
+%w{hadoop-yarn-nodemanager
+  hadoop-mapreduce}.each do |pkg|
+  package pkg do
+    action :upgrade
+  end
+end
+
+# Install YARN Bits
+template "/etc/hadoop/conf/container-executor.cfg" do
+  source "hdp_container-executor.cfg.erb"
+  owner "root"
+  group "yarn"
+  mode "0400"
+  variables(:mounts => node[:bcpc][:hadoop][:mounts])
+  action :create
+  notifies :run, "bash[verify-container-executor]", :immediate
+end
+
+bash "verify-container-executor" do
+  code "/usr/lib/hadoop-yarn/bin/container-executor --checksetup"
+  group "yarn"
+  action :nothing
+  only_if { File.exists?("/usr/lib/hadoop-yarn/bin/container-executor") }
+end
+
+# Build nodes for YARN log storage
+node[:bcpc][:hadoop][:mounts].each do |i|
+  directory "/disk/#{i}/yarn/" do
+    owner "yarn"
+    group "yarn"
+    mode 0755
+    action :create
+  end
+  %w{mapred-local local logs}.each do |d|
+    directory "/disk/#{i}/yarn/#{d}" do
+      owner "yarn"
+      group "hadoop"
+      mode 0755
+      action :create
+    end
+  end
+end
+
+yarn_dep = ["template[/etc/hadoop/conf/yarn-site.xml]"]
+
+hadoop_service "hadoop-yarn-nodemanager" do
+  dependencies yarn_dep
+  process_identifier "org.apache.hadoop.yarn.server.nodemanager.NodeManager"
+end

--- a/cookbooks/bcpc-hadoop/recipes/yarn_nodemanager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/yarn_nodemanager.rb
@@ -1,9 +1,39 @@
 
 %w{hadoop-yarn-nodemanager
-  hadoop-mapreduce}.each do |pkg|
+  hadoop-mapreduce
+  sqoop
+  lzop
+  hadoop-lzo}.each do |pkg|
   package pkg do
     action :upgrade
   end
+end
+
+# Install Sqoop Bits
+template "/etc/sqoop/conf/sqoop-env.sh" do
+  source "sq_sqoop-env.sh.erb"
+  mode "0444"
+  action :create
+end
+
+# Install Hive Bits
+# workaround for hcatalog dpkg not creating the hcat user it requires
+user "hcat" do
+  username "hcat"
+  system true
+  shell "/bin/bash"
+  home "/usr/lib/hcatalog"
+  supports :manage_home => false
+end
+
+%w{hive hcatalog libmysql-java}.each do |pkg|
+  package pkg do
+    action :upgrade
+  end
+end
+
+link "/usr/lib/hive/lib/mysql.jar" do
+  to "/usr/share/java/mysql.jar"
 end
 
 # Install YARN Bits

--- a/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
+++ b/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
@@ -62,11 +62,12 @@ file "#{node[:bcpc][:hadoop][:zookeeper][:data_dir]}/myid" do
   mode 0644
 end
 
-service "zookeeper-server" do
-  supports :status => true, :restart => true, :reload => false
-  action [:enable, :start]
-  subscribes :restart, "template[/etc/zookeeper/conf/zoo.cfg]", :delayed
-  subscribes :restart, "template[/usr/lib/zookeeper/bin/zkServer.sh]", :delayed
-  subscribes :restart, "template[/etc/default/zookeeper-server]", :delayed
-  subscribes :restart, "file[#{node[:bcpc][:hadoop][:zookeeper][:data_dir]}/myid]", :delayed
+zk_service_dep = ["template[/etc/zookeeper/conf/zoo.cfg]",
+                  "template[/usr/lib/zookeeper/bin/zkServer.sh]",
+                  "template[/etc/default/zookeeper-server]",
+                  "file[#{node[:bcpc][:hadoop][:zookeeper][:data_dir]}/myid]"]
+
+hadoop_service "zookeeper-server" do
+  dependencies zk_service_dep
+  process_identifier "org.apache.zookeeper.server.quorum.QuorumPeerMain"
 end

--- a/cookbooks/kafka-bcpc/attributes/default.rb
+++ b/cookbooks/kafka-bcpc/attributes/default.rb
@@ -3,8 +3,12 @@
 #######################################
 
 # Attribute to indidate whether an existing Hadoop Zookeeper
-# can be used. If not Kafka Zookeeper quorum need to be created 
+# can be used. If not Kafka Zookeeper quorum need to be created
 default[:use_hadoop_zookeeper_quorum] = false
+default[:bcpc][:kafka][:skip_restart_coordination] = true
+default[:bcpc][:kafka][:restart_failed] = false
+default[:bcpc][:kafka][:restart_failed_time] = ""
+
 #
 # Overwriting community kafka cookbook attributes 
 #
@@ -20,3 +24,7 @@ default[:kafka][:jmx_port] = node[:bcpc][:hadoop][:kafka][:jmx][:port]
 default[:kafka][:broker][:controlled][:shutdown][:enable] = true
 default[:kafka][:broker][:controlled][:shutdown][:max][:retries] = 3
 default[:kafka][:broker][:controlled][:shutdown][:retry][:backoff][:ms] = 5000
+#
+# Overwrite the community cookbook to restart Kafka servers with custom recipe for BCPC
+#
+default[:kafka][:start_coordination][:recipe] = 'kafka-bcpc::coordinate'

--- a/cookbooks/kafka-bcpc/recipes/coordinate.rb
+++ b/cookbooks/kafka-bcpc/recipes/coordinate.rb
@@ -1,0 +1,124 @@
+#
+# Cookbook Name:: kafka-bcpc
+# Recipe:: coordinate
+# Function:: Recipe to start/restart Kafka service
+#
+if node["bcpc"]["kafka"]["skip_restart_coordination"]
+  Chef::Log.info "Coordination of Kafka restart will be skipped as per user request."
+  
+  ruby_block 'coordinate-kafka-start' do
+    block do
+      Chef::Log.debug 'bcpc recipe to coordinate Kafka start is used'
+    end
+    action :nothing
+    notifies :restart, 'service[kafka]', :delayed
+  end
+
+  service 'kafka' do
+    provider kafka_init_opts[:provider]
+    supports start: true, stop: true, restart: true, status: true
+    action kafka_service_actions
+  end
+  
+else
+
+  ruby_block 'coordinate-kafka-start' do
+    block do
+      Chef::Log.debug 'bcpc recipe to coordinate Kafka start is used'
+    end
+    action :nothing
+  end
+
+  #
+  # When there is a need to restart kafka service, a lock need to be taken so that the restart is sequenced preventing all nodes being down at the sametime
+  # If there is a failure in acquiring a lock with in a certian period, the restart is scheduled for the next run on chef-client on the node.
+  # To determine whether the prev restart failed is the node attribute node[:bcpc][:kafka][:restart_failed] is set to true
+  # This ruby block is to check whether this node attribute is set to true and if it is set then gets the kafka service restart process in motion.
+  #
+  ruby_block "handle_prev_kafka_restart_failure" do
+    block do
+      Chef::Log.info "Need to restart kafka since it failed during the previous run. Another node's restart process failure is a possible reason"
+    end
+    action :create
+    only_if { node[:bcpc][:kafka][:restart_failed] and 
+            !process_restarted_after_failure?(node[:bcpc][:kafka][:restart_failed_time],"kafka.Kafka")}
+  end
+
+  #
+  # Since string with all the zookeeper nodes is used multiple times this variable is populated once and reused reducing calls to Chef server
+  #
+  zk_hosts = (node[:bcpc][:hadoop][:zookeeper][:servers].map{|zkhost| "#{zkhost['hostname']}:#{node[:bcpc][:hadoop][:zookeeper][:port]}"}).join(",")
+  
+  #
+  # znode is used as the locking mechnism to control restart of services. The following code is to build the path
+  # to create the znode before initiating the restart of Kafka service 
+  #
+  lock_znode_path = format_restart_lock_path(node[:bcpc][:hadoop][:restart_lock][:root],"kafka")
+
+  #
+  # All kafka service restart situations like changes in config files or restart due to previous failures invokes this ruby_block
+  # This ruby block tries to acquire a lock and if not able to acquire the lock, sets the restart_failed node attribute to true
+  #
+  ruby_block "acquire_lock_to_restart_kafka" do
+    require 'time'
+    block do
+      tries = 0
+      Chef::Log.info("#{node[:hostname]}: Acquring lock at #{lock_znode_path}")
+      while true 
+        lock = acquire_restart_lock(lock_znode_path, zk_hosts, node[:fqdn])
+        if lock
+          break
+        else
+          tries += 1
+          if tries >= node[:bcpc][:hadoop][:restart_lock_acquire][:max_tries]
+            failure_time = Time.now().to_s
+            Chef::Log.info("Couldn't acquire lock to restart Kafka with in the #{node[:bcpc][:hadoop][:restart_lock_acquire][:max_tries] * node[:bcpc][:hadoop][:restart_lock_acquire][:sleep_time]} secs. Failure time is #{failure_time}")
+            Chef::Log.info("Node #{get_restart_lock_holder(lock_znode_path, zk_hosts)} may have died during Kafka restart.")
+            node.set[:bcpc][:hadoop][:kafka][:restart_failed] = true
+            node.set[:bcpc][:hadoop][:kafka][:restart_failed_time] = failure_time
+            node.save
+            break
+          end
+          sleep(node[:bcpc][:hadoop][:restart_lock_acquire][:sleep_time])
+        end
+      end
+    end
+    action :nothing
+    subscribes :create, "ruby_block[coordinate-kafka-start]", :immediate
+    subscribes :create, "ruby_block[handle_prev_kafka_restart_failure]", :immediate
+  end
+  
+  #
+  # If lock to restart kafka service is acquired by the node, this ruby_block executes which is primarily used to notify kafka service to restart
+  #
+  ruby_block "coordinate_kafka_restart" do
+    block do
+      Chef::Log.info("Kafka will be restarted in node #{node[:fqdn]}")
+    end
+    action :create
+    only_if { my_restart_lock?(lock_znode_path, zk_hosts, node[:fqdn]) }
+    notifies :restart, 'service[kafka]', :immediate
+  end
+
+  service 'kafka' do
+    provider kafka_init_opts[:provider]
+    supports start: true, stop: true, restart: true, status: true
+    action kafka_service_actions
+  end
+  
+  #
+  # Once the Kafka service restart is complete, the following block releases the lock if the node executing is the one which holds the lock 
+  #
+  ruby_block "release_kafka_restart_lock" do
+    block do
+      Chef::Log.info("#{node[:hostname]}: Releasing lock at #{lock_znode_path}")
+      lock_rel = rel_restart_lock(lock_znode_path, zk_hosts, node[:fqdn])
+      if lock_rel
+        node.set[:bcpc][:kafka][:restart_failed] = false
+        node.save
+      end
+    end
+    action :create
+    only_if { my_restart_lock?(lock_znode_path, zk_hosts, node[:fqdn]) }
+  end
+end

--- a/roles/BCPC-Hadoop-Worker.json
+++ b/roles/BCPC-Hadoop-Worker.json
@@ -12,6 +12,7 @@
     "recipe[pam::default]",
     "recipe[bcpc-hadoop::datanode]",
     "recipe[bcpc-hadoop::yarn_nodemanager]",
+    "recipe[bcpc-hadoop::hive_client]",
     "recipe[bcpc-hadoop::httpfs]",
     "recipe[bcpc-hadoop::region_server]",
     "recipe[bcpc-hadoop::pig]",

--- a/roles/BCPC-Hadoop-Worker.json
+++ b/roles/BCPC-Hadoop-Worker.json
@@ -11,6 +11,7 @@
     "recipe[bcpc-hadoop::configs]",
     "recipe[pam::default]",
     "recipe[bcpc-hadoop::datanode]",
+    "recipe[bcpc-hadoop::yarn_nodemanager]",
     "recipe[bcpc-hadoop::httpfs]",
     "recipe[bcpc-hadoop::region_server]",
     "recipe[bcpc-hadoop::pig]",

--- a/roles/BCPC-Kafka-Head-Zookeeper.json
+++ b/roles/BCPC-Kafka-Head-Zookeeper.json
@@ -17,6 +17,7 @@
     "recipe[bcpc::default]",
     "recipe[bcpc::networking]",
     "recipe[bcpc-hadoop::disks]",
+    "recipe[bcpc-hadoop::default]",
     "recipe[kafka-bcpc::default]", 
     "recipe[kafka-bcpc::setattr]",
     "recipe[java::oracle]",


### PR DESCRIPTION
This PR is to implement rolling restart of the following hadoop components

1) HDFS Datanode. The original version is available in master. The latest changes abstracts the original logic into a definition so that it can be used by all the components.
2) Zookeeper server
3) Yarn node manager
4) HBase region server 
5) Kafka servers

There are other changes to create separate recipes for Yarn node manager and Hive components. Originally they were part of the datanode recipe. 