### PR TITLE
Support Trusty APT mirrors

### DIFF
--- a/cookbooks/bcpc/templates/default/apt-mirror.mirror.list.erb
+++ b/cookbooks/bcpc/templates/default/apt-mirror.mirror.list.erb
@@ -38,6 +38,14 @@ deb http://us.archive.ubuntu.com/ubuntu precise-security main/debian-installer r
 
 deb http://us.archive.ubuntu.com/ubuntu precise-updates main/debian-installer restricted/debian-installer universe/debian-installer multiverse/debian-installer
 
+deb http://us.archive.ubuntu.com/ubuntu trusty main restricted universe multiverse
+
+deb http://us.archive.ubuntu.com/ubuntu trusty-updates main restricted universe multiverse
+
+deb http://us.archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse
+
+deb http://us.archive.ubuntu.com/ubuntu trusty-security main restricted universe multiverse
+
 deb http://ceph.com/debian-dumpling precise main
 deb-i386 http://ceph.com/debian-dumpling precise main
 


### PR DESCRIPTION
This adds support for Trusty APT mirrors. Ideally, we would follow something using the `mirrors.txt` file (akin to this [Gist](https://gist.github.com/PeteLawrence/9052977) by Pete Lawrence) but it seems `apt-mirror` on Precise reports the following using `mirrror://` with a `mirrors.txt`:
````
Proceed indexes: [Psh: 1: cannot open mirrors.ubuntu.com/mirrors.txt//dists/trusty/main/binary-amd64/Packages.gz: No such file
apt-mirror: can't open index in proceed_index_gz at /usr/bin/apt-mirror line 460.
````