### PR TITLE
Added i386 trusty repos to mirror.list

### DIFF
--- a/cookbooks/bcpc/templates/default/apt-mirror.mirror.list.erb
+++ b/cookbooks/bcpc/templates/default/apt-mirror.mirror.list.erb
@@ -38,13 +38,18 @@ deb http://us.archive.ubuntu.com/ubuntu precise-security main/debian-installer r
 
 deb http://us.archive.ubuntu.com/ubuntu precise-updates main/debian-installer restricted/debian-installer universe/debian-installer multiverse/debian-installer
 
+# Trusty 
 deb http://us.archive.ubuntu.com/ubuntu trusty main restricted universe multiverse
+deb-i386 http://us.archive.ubuntu.com/ubuntu trusty main restricted universe multiverse
 
 deb http://us.archive.ubuntu.com/ubuntu trusty-updates main restricted universe multiverse
+deb-i386 http://us.archive.ubuntu.com/ubuntu trusty-updates main restricted universe multiverse
 
 deb http://us.archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse
+deb-i386 http://us.archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse
 
 deb http://us.archive.ubuntu.com/ubuntu trusty-security main restricted universe multiverse
+deb-i386 http://us.archive.ubuntu.com/ubuntu trusty-security main restricted universe multiverse
 
 deb http://ceph.com/debian-dumpling precise main
 deb-i386 http://ceph.com/debian-dumpling precise main


### PR DESCRIPTION
This PR addes `deb-i386` trusy repo to the list of repos to be mirrored. 