### PR TITLE
Bonding

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -91,12 +91,6 @@ default['bcpc']['floating']['gateway'] = "192.168.43.2"
 default['bcpc']['floating']['available_subnet'] = "192.168.43.128/25"
 default['bcpc']['floating']['interface'] = "eth2"
 
-default['bcpc']['fixed']['cidr'] = "1.127.0.0/16"
-default['bcpc']['fixed']['vlan_start'] = "1000"
-default['bcpc']['fixed']['num_networks'] = "100"
-default['bcpc']['fixed']['network_size'] = "256"
-default['bcpc']['fixed']['vlan_interface'] = node[:bcpc][:floating][:interface]
-
 default['bcpc']['ntp_servers'] = [ "pool.ntp.org" ]
 default['bcpc']['dns_servers'] = [ "8.8.8.8", "8.8.4.4" ]
 

--- a/cookbooks/bcpc/recipes/default.rb
+++ b/cookbooks/bcpc/recipes/default.rb
@@ -22,8 +22,9 @@ require 'ipaddr'
 mgmt_cidr = IPAddr.new(node['bcpc']['management']['cidr'])
 
 ifs=node[:network][:interfaces].keys
-# create a hash of ipaddresses
-ips= ifs.map{|a|node[:network][:interfaces][a][:addresses]}.reduce({}, :merge)
+# create a hash of ipaddresses -- skip interfaces without addresses
+ips= ifs.map{ |a| node[:network][:interfaces][a].attribute?(:addresses) and
+                     node[:network][:interfaces][a][:addresses] or {}}.reduce({}, :merge)
 
 # select the first IP address which is on the management network
 node.set['bcpc']['management']['ip'] = ips.select {|ip,v| v['family'] == "inet" and

--- a/cookbooks/bcpc/templates/default/bcpc-routing.erb
+++ b/cookbooks/bcpc/templates/default/bcpc-routing.erb
@@ -13,10 +13,12 @@ ip route add <%=@node["bcpc"]["management"]["cidr"]%> \
          dev <%=@node["bcpc"]["management"]["interface"]%> \
          scope link src <%=@node["bcpc"]["management"]["ip"]%> \
          table main
+<% if node[:bcpc][:management][:interface] != node[:bcpc][:storage][:interface] %>
 ip route add <%=@node["bcpc"]["storage"]["cidr"]%> \
          dev <%=@node["bcpc"]["storage"]["interface"]%> \
          scope link src <%=@node["bcpc"]["storage"]["ip"]%> \
          table main
+<% end %>
 
 # Build routing table for management network
 ip route flush table mgmt
@@ -28,18 +30,13 @@ ip route add <%=@node["bcpc"]["management"]["cidr"]%> \
          scope link src <%=@node["bcpc"]["management"]["ip"]%> \
          table mgmt
 
-# Enable VMs to get to the VIP via the float interface
-ip rule del pref 9000
-ip rule del pref 9001
-ip rule add from <%=@node["bcpc"]["fixed"]["cidr"]%> to <%=@node["bcpc"]["management"]["vip"]%> pref 9000 table main
-ip rule add from <%=@node["bcpc"]["management"]["vip"]%> to <%=@node["bcpc"]["fixed"]["cidr"]%> pref 9001 table main
-
 # Activate this routing table for management traffic
 ip rule del pref 10000
 ip rule del pref 10001
 ip rule add from <%=@node["bcpc"]["management"]["cidr"]%> pref 10000 table mgmt
 ip rule add to <%=@node["bcpc"]["management"]["cidr"]%> pref 10001 table mgmt
 
+<% if node[:bcpc][:management][:interface] != node[:bcpc][:storage][:interface] %>
 # Build routing table for storage network
 ip route flush table storage
 ip route add default via <%=@node["bcpc"]["storage"]["gateway"]%> \
@@ -55,6 +52,7 @@ ip rule del pref 10002
 ip rule del pref 10003
 ip rule add from <%=@node["bcpc"]["storage"]["cidr"]%> pref 10002 table storage
 ip rule add to <%=@node["bcpc"]["storage"]["cidr"]%> pref 10003 table storage
+<% end %>
 
 # Drop all routes to other networks from the main routing table
 # XXX: The following line is intentionally duplicated to remove multiple default routes
@@ -62,14 +60,18 @@ ip route del default dev <%=@node["bcpc"]["management"]["interface"]%> \
          table main
 ip route del default dev <%=@node["bcpc"]["management"]["interface"]%> \
          table main
+<% if node[:bcpc][:management][:interface] != node[:bcpc][:storage][:interface] %>
 ip route del default dev <%=@node["bcpc"]["storage"]["interface"]%> \
          table main
+<% end %>
 ip route del <%=@node["bcpc"]["management"]["cidr"]%> \
          dev <%=@node["bcpc"]["management"]["interface"]%> \
          table main
+<% if node[:bcpc][:management][:interface] != node[:bcpc][:storage][:interface] %>
 ip route del <%=@node["bcpc"]["storage"]["cidr"]%> \
          dev <%=@node["bcpc"]["storage"]["interface"]%> \
          table main
+<% end %>
 
 # Flush the route cache to make sure these are active
 ip route flush cache

--- a/cookbooks/bcpc/templates/default/network.iface.erb
+++ b/cookbooks/bcpc/templates/default/network.iface.erb
@@ -4,13 +4,28 @@
 #
 ################################################
 
+<% @slaves.each do |slave| %>
+auto <%= slave %>
+iface <%= slave %> inet manual
+bond-master <%= @interface %>
+<% end %>
+
 auto <%= @interface %>
 iface <%= @interface %> inet static
- address <%= @ip %>
+ address  <%= @ip %>
  netmask <%= @netmask %>
  gateway <%= @gateway %>
  metric <%= @metric %>
-<% if @dns %>
+ <% if @dns %>
  dns-nameservers <%= @dns.join(' ') %>
  dns-search <%="#{node[:bcpc][:domain_name]}"%>
-<% end %>
+ <% end %>
+ <% if @slaves %>
+ bond-mode 4
+ bond-miimon 100
+ bond-lacp-rate 1
+ bond-slaves <%= @slaves.join(" ") %>
+ <% end %>
+ <% if @mtu %>
+ mtu <%= @mtu %>
+ <% end %>

--- a/cookbooks/bcpc/templates/default/network.iface.erb
+++ b/cookbooks/bcpc/templates/default/network.iface.erb
@@ -4,7 +4,7 @@
 #
 ################################################
 
-<% @slaves.each do |slave| %>
+<% (@slaves or []).each do |slave| %>
 auto <%= slave %>
 iface <%= slave %> inet manual
 bond-master <%= @interface %>
@@ -12,7 +12,7 @@ bond-master <%= @interface %>
 
 auto <%= @interface %>
 iface <%= @interface %> inet static
- address  <%= @ip %>
+ address <%= @ip %>
  netmask <%= @netmask %>
  gateway <%= @gateway %>
  metric <%= @metric %>


### PR DESCRIPTION
This commit allows one to create a bonded interface for your machines.

To use this code, one provides a `slaves` attribute in their network's definition. One should also provide which interface to use (e.g. `bond0`, `bond1`).

For example:
````
"floating": {
        "interface": "bond0",
        "slaves": ["eth1", "eth2"],
        "netmask": "255.255.0.0",
        "cidr": "192.168.0.0/24",
        "gateway": "192.168.0.1",
        "vip": "192.168.0.6",
        "mtu": "9000"
      }
````