### PR TITLE
Roll the Chef admin user key on baremetal reconfigure

### DIFF
--- a/Vagrantfile.baremetal
+++ b/Vagrantfile.baremetal
@@ -82,6 +82,9 @@ Vagrant.configure("2") do |config|
       chef.provisioning_path="/home/vagrant/chef-bcpc/"
     end
 
+    # Rekey the admin user
+    bootstrap.vm.provision :shell, :inline => "cd /home/vagrant/chef-bcpc; sudo mv /etc/chef-server/admin.pem /tmp/old_admin.pem; sudo knife user reregister admin -u admin -k /tmp/old_admin.pem | sudo tee /etc/chef-server/admin.pem > /dev/null"
+
     bootstrap.vm.provision :shell, :inline => "cd /home/vagrant/chef-bcpc; sudo knife environment from file environments/#{env_name}.json -u admin -k /etc/chef-server/admin.pem"
     bootstrap.vm.provision :shell, :inline => "cd /home/vagrant/chef-bcpc; sudo chef-client -E #{env_name} -c .chef/knife.rb"
 


### PR DESCRIPTION
Today one using Vagrantfile.baremetal to reconfigure a Vagrant box for baremetal bootstrap may think they are cleaning all cruft leftover but the admin user's PEM file is not today regenerated. This should fix that.