### PR TITLE
Disable chef-client certs verification

### DIFF
--- a/environments/Test-Laptop.json
+++ b/environments/Test-Laptop.json
@@ -65,6 +65,9 @@
     "chef_client": {
       "server_url": "http://10.0.100.3:4000",
       "cache_path": "/var/chef/cache",
+      "config": {
+         "verify_api_cert": false
+      },
       "backup_path": "/var/chef/backup",
       "validation_client_name": "chef-validator",
       "run_path": "/var/chef"


### PR DESCRIPTION
Latest chef-client enables server certs verification by default (https://github.com/opscode-cookbooks/chef-client/commit/7b1e1266a5e6f38bd9b040ee473e43b11f715a40)
Disabling this by default in the environment.

This has been tested on local VM cluster and production clusters.