### PR TITLE
Dynamically set oozie(catalina) jvm opts

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -13,6 +13,7 @@ default["bcpc"]["repos"]["hortonworks"] = 'http://public-repo-1.hortonworks.com/
 default["bcpc"]["repos"]["hdp_utils"] = 'http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.20/repos/ubuntu12'
 default["bcpc"]["hadoop"]["disks"] = []
 default["bcpc"]["hadoop"]["oozie"]["admins"] = []
+default["bcpc"]["hadoop"]["oozie"]["memory_opts"] = "-Xmx2048m -XX:MaxPermSize=256m"
 default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["avail_memory"]["ratio"] = 0.8
 default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["avail_memory"]["size"] = nil
 default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["avail_vcpu"]["ratio"] = 0.8

--- a/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-env.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-env.sh.erb
@@ -18,7 +18,7 @@ export OOZIE_CATALINA_HOME=/usr/lib/bigtop-tomcat
 export CATALINA_TMPDIR=/tmp
 export CATALINA_PID=/var/run/oozie/oozie.pid
 export CATALINA_BASE=/usr/hdp/current/oozie-client/oozie-server
-export CATALINA_OPTS=-Xmx1024m
+export CATALINA_OPTS="<%= node["bcpc"]["hadoop"]["oozie"]["memory_opts"] %>"
 export OOZIE_HTTPS_PORT=11443
 export OOZIE_HTTPS_KEYSTORE_PASS=<%=get_config("oozie-keystore-password") %>
 export CATALINA_OPTS="$CATALINA_OPTS -Doozie.https.port=${OOZIE_HTTPS_PORT}"


### PR DESCRIPTION
This PR adds an attribute to set catalina memory opts. This is tested and deployed on prod cluster with override in environment to "\"-Xmx2048m -XX:MaxPermSize=256m\"".