### PR TITLE
Set a higher value for Flume channel 

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/flume_flume-conf.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/flume_flume-conf.erb
@@ -1,5 +1,6 @@
 <%= @agent_name %>.channels = memoryChannel
 <%= @agent_name %>.channels.memoryChannel.type = memory
+<%= @agent_name %>.channels.memoryChannel.capacity = 10000
 <%= @agent_name %>.sources = pstream
 <%= @agent_name %>.sources.pstream.channels = memoryChannel
 <%= @agent_name %>.sources.pstream.type = exec


### PR DESCRIPTION
This change is to change the Flume channel capacity to a higher value so that ``flume agents`` can store entries when logs they are monitoring are written at a higher rate. Refer issue #122 .