### PR TITLE
Jmxtrans cookbook url update

### DIFF
--- a/setup_chef_cookbooks.sh
+++ b/setup_chef_cookbooks.sh
@@ -69,5 +69,5 @@ done
 if [[ ! -d kafka ]]; then
   git clone https://github.com/mthssdrbrg/kafka-cookbook.git kafka
 fi
-[[ -d jmxtrans ]] || git clone https://github.com/bijugs/jmxtrans-cookbook.git jmxtrans
+[[ -d jmxtrans ]] || git clone https://github.com/jmxtrans/jmxtrans-cookbook.git jmxtrans
 [[ -d cobblerd ]] || git clone https://github.com/cbaenziger/cobbler-cookbook.git cobblerd -b cobbler_profile


### PR DESCRIPTION
Jmxtrans cookbook github repo got moved under the [jmxtrans](https://github.com/jmxtrans) project organization. This pull request is to update the URL to download the cookbook from the new location.