### PR TITLE
Override hannibal hbase parameters to support HDP 2.2

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hannibal.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hannibal.rb
@@ -34,3 +34,4 @@ if ("mysql" == node[:hannibal][:db]) then
 end
 
 node.override[:hannibal][:zookeeper_quorum] = node[:bcpc][:hadoop][:zookeeper][:servers] 
+node.override[:hannibal][:hbase_rs][:info_port] = 60300

--- a/cookbooks/hannibal/attributes/default.rb
+++ b/cookbooks/hannibal/attributes/default.rb
@@ -6,7 +6,7 @@ default[:hannibal][:local_tarball] = true
 default[:hannibal][:download_url] = 'https://github.com/sentric/hannibal/releases/download/v.0.10.1'
 default[:hannibal][:repo][:url] = 'https://github.com/kiiranh/hannibal.git'
 default[:hannibal][:repo][:branch] = 'next'
-default[:hannibal][:hbase_version] = 0.96
+default[:hannibal][:hbase_version] = 0.98
 
 default[:hannibal][:install_dir] = '/usr/lib'
 default[:hannibal][:service_dir] = '/etc/init'


### PR DESCRIPTION
This fixes issue #130. The PR updates hbase version from 0.96 to 0.98 and overrides the hbase.regionserver.info.port to 60300 which we default to in HDP 2.2.

Tested on my vbox VM cluster. 