### PR TITLE
Fir journal node directory permissions

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/journalnode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/journalnode.rb
@@ -22,6 +22,18 @@ if get_config("namenode_txn_fmt") then
 end
 
 node[:bcpc][:hadoop][:mounts].each do |d|
+# Per chef-documentation for directory resource's recursive attribute:
+# For the owner, group, and mode attributes, the value of this attribute applies only to the leaf directory
+# Hence, we create "/disk/#{d}/dfs/jn/" to have "jn" dir owned by hdfs and then
+# create "/disk/#{d}/dfs/jn/#{node.chef_environment}" owned by hdfs. 
+# This way the jn/{environment} dir tree is owned by hdfs
+  directory "/disk/#{d}/dfs/jn/" do
+    owner "hdfs"
+    group "hdfs"
+    mode 0755
+    action :create
+    recursive true
+  end
 
   directory "/disk/#{d}/dfs/jn/#{node.chef_environment}" do
     owner "hdfs"


### PR DESCRIPTION
Under #132, `directory "/disk/#{d}/dfs/jn/" do` was removed thinking it was redundant. But because of that the directory was created with owner as root and journal node service failed to come up. This PR adds the directory resource back.

Tested on vbox vm cluster. Chef completes successfully. 