### PR TITLE
Update cluster-assign-roles to error if a worker fails to chef

### DIFF
--- a/cluster-assign-roles.sh
+++ b/cluster-assign-roles.sh
@@ -286,8 +286,8 @@ INSTALL_TYPE=$2
 MATCHKEY=${3-}
 
 shopt -s nocasematch
-if [[ ! "$INSTALL_TYPE" =~ (openstack|hadoop|kafka) ]]; then
-  printf "Error: Need install type of OpenStack, Hadoop or Kafka\n" > /dev/stderr
+if [[ ! "$INSTALL_TYPE" =~ (openstack|hadoop|kafka|basic) ]]; then
+  printf "Error: Need install type of OpenStack, Hadoop, Kafka or Basic\n" > /dev/stderr
   exit 1
 fi
 shopt -u nocasematch
@@ -315,11 +315,12 @@ fi
 shopt -s nocasematch
 if [[ "$INSTALL_TYPE" = "OpenStack" ]]; then
   openstack_install $hosts
-### Hadoop Install Method
 elif [[ "$INSTALL_TYPE" = "Hadoop" ]]; then
   hadoop_install $hosts
 elif [[ "$INSTALL_TYPE" = "Kafka" ]]; then
   kafka_install $hosts
+elif [[ "$INSTALL_TYPE" = "Basic" ]]; then
+  install_stub $(printf ${hosts// /\\n} | sort)
 fi
 
 printf "#### Install finished\n"


### PR DESCRIPTION
This fixes the issue where if a worker node fails to Chef then `cluster-assign-roles.sh` and particularly `tests/automated_install.sh` will think all is fine and well. If a machine fails to Chef one will get output akin to:
````
Install failed for machines:
bcpc-vm3.bcpc.example.com
````
Further, `cluster-assign-roles.sh` will return non-zero (specifically 1) to signal the failure.