### PR TITLE
Route alarm to a owner specified by the zabbix trigger definition

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -98,6 +98,9 @@ default["bcpc"]["hadoop"]["zabbix"]["trend_days"] = 15
 default["bcpc"]["hadoop"]["zabbix"]["cron_check_time"] = 240
 default["bcpc"]["hadoop"]["zabbix"]["mail_source"] = "zabbix.zbx_mail.sh.erb"
 default["bcpc"]["hadoop"]["zabbix"]["cookbook"] = nil 
+
+# Graphite queries which specify property to query and alarming trigger, severity
+# and owner who the trigger is routed to for resolution
 default["bcpc"]["hadoop"]["graphite"]["queries"] = {
    'namenode' => [
     {
@@ -109,7 +112,8 @@ default["bcpc"]["hadoop"]["graphite"]["queries"] = {
       'trigger_name' => "NameNodeAvailability",
       'trigger_enable' => true,
       'trigger_desc' => "Namenode service seems to be down",
-      'severity' => 2
+      'severity' => 2,
+      'route_to' => "admin"
     },
     {
       'type'  => "jmx",
@@ -127,7 +131,8 @@ default["bcpc"]["hadoop"]["graphite"]["queries"] = {
       'trigger_name' => "HBaseMasterAvailability",
       'trigger_dep' => ["NameNodeAvailability"],
       'trigger_desc' => "HBase master seems to be down",
-      'severity' => 1
+      'severity' => 1,
+      'route_to' => "admin"
     },
     {
       'type'  => "jmx",
@@ -146,7 +151,8 @@ default["bcpc"]["hadoop"]["graphite"]["queries"] = {
       'trigger_enable' => true,
       'trigger_dep' => ["HBaseMasterAvailability"],
       'trigger_desc' => "HBase region server seems to be down",
-      'severity' => 2
+      'severity' => 2,
+      'route_to' => "admin"
     }
   ]
 }

--- a/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
+++ b/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
@@ -157,7 +157,7 @@ ruby_block "zabbix_monitor" do
                       'conditions' => [{"conditiontype" => 3,"operator" => 2,"value" => "#{trigger_attr['trigger_name']}"}, 
                                        {"conditiontype" => 5,"operator" => 0,"value" => 1}, 
                                        {"conditiontype" => 16,"operator" => 7}], 
-                      'operations' => [{"operationtype" => 1,"opcommand" => {"command" => "#{node['bcpc']['zabbix']['scripts']['mail']} {TRIGGER.NAME} #{node.chef_environment} #{trigger_attr['severity']} '#{trigger_attr['trigger_desc']}' #{trigger_host}","type" => "0","execute_on" => "1"}, 
+                      'operations' => [{"operationtype" => 1,"opcommand" => {"command" => "#{node['bcpc']['zabbix']['scripts']['mail']} {TRIGGER.NAME} #{node.chef_environment} #{trigger_attr['severity']} '#{trigger_attr['trigger_desc']}' #{trigger_host} #{trigger_attr['route_to']}" ,"type" => "0","execute_on" => "1"},
                       "opcommand_hst" => [ "hostid" => 0]}]})
           else
             Chef::Log.debug "Trigger #{trigger_attr['trigger_name']} already defined"

--- a/cookbooks/bcpc-hadoop/templates/default/zabbix.zbx_mail.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/zabbix.zbx_mail.sh.erb
@@ -4,5 +4,6 @@ cluster_name=$2
 severity=$3
 description=$4
 host=$5
+owner=$6
 
-logger -t "Zabbix-Trigger-Action" <<< "Please attend to severity $severity issue with $trigger_name on $cluster_name:$host; problem description=$description"
+logger -t "Zabbix-Trigger-Action" <<< "@$owner: Please attend to severity $severity issue with $trigger_name on $cluster_name:$host; problem description=$description"


### PR DESCRIPTION
This PR provides granularity for directing a zabbix alarm to an user/account specified for each zabbix trigger. 

This has been tested on a vbox vm cluster.