### PR TITLE
Run chef-client with custom client.rb

### DIFF
--- a/setup_chef_bootstrap_node.sh
+++ b/setup_chef_bootstrap_node.sh
@@ -30,3 +30,8 @@ fi
 
 knife node run_list add $(hostname -f) 'role[BCPC-Bootstrap]' -c .chef/knife.rb
 sudo chef-client -c .chef/knife.rb
+
+# Create a symlink in /etc/chef/client.d/ to knife.rb so that one can run chef-client
+# on the bootstrap node without having to specify -c .chef/knife.rb later. This will
+# make sure that the chef-client service runs without issues.
+sudo ln -s $(pwd)/.chef/knife.rb /etc/chef/client.d/knife.rb

--- a/setup_chef_cookbooks.sh
+++ b/setup_chef_cookbooks.sh
@@ -30,7 +30,6 @@ o = Ohai::System.new
 o.all_plugins
  
 log_level                :info
-log_location             STDOUT
 node_name                o[:fqdn]
 client_key               "$(pwd)/.chef/#{o[:fqdn]}.pem"
 validation_client_name   'chef-validator'

--- a/setup_chef_cookbooks.sh
+++ b/setup_chef_cookbooks.sh
@@ -56,7 +56,7 @@ EOF
 cd cookbooks
 
 # allow versions on cookbooks via "cookbook version"
-for cookbook in "apt 2.4.0" python build-essential ubuntu cron "chef-client 3.0.6" chef-vault ntp yum logrotate yum-epel sysctl chef_handler 7-zip windows ark sudo ulimit pam ohai "poise 1.0.12" graphite_handler java maven; do
+for cookbook in "apt 2.4.0" python build-essential ubuntu cron "chef-client 4.2.4" chef-vault ntp yum logrotate yum-epel sysctl chef_handler 7-zip windows ark sudo ulimit pam ohai "poise 1.0.12" graphite_handler java maven; do
   if [[ ! -d ${cookbook% *} ]]; then
      # unless the proxy was defined this knife config will be the same as the one generated above
     knife cookbook site download $cookbook --config ../.chef/knife.rb


### PR DESCRIPTION
This fixes issue #169.

The PR updates the version of chef-client pinned in [setup_chef_cookbooks.sh](https://github.com/bloomberg/chef-bach/blob/master/setup_chef_cookbooks.sh#L60). It also creates a symlink in /etc/chef/client.d/ to the [custom knife.rb](https://github.com/bloomberg/chef-bach/blob/master/setup_chef_cookbooks.sh#L26-L56) we use on the bootstrap node.