### PR TITLE
mark max_allowed_packet as loose

### DIFF
--- a/cookbooks/bcpc/templates/default/wsrep.cnf.erb
+++ b/cookbooks/bcpc/templates/default/wsrep.cnf.erb
@@ -16,7 +16,7 @@
 [mysqld_safe]
 
 [client]
-max_allowed_packet=32M
+loose-max_allowed_packet=32M
 
 [mysql]
 max_allowed_packet=32M


### PR DESCRIPTION
prepending loose- in front of configuration parameters that mysqladmin is not aware of will prevent it form exiting with error.  Instead it will only issue a warning.  Issue #171 