### PR TITLE
Changes to tune Linux kernel tcp parameters

### DIFF
--- a/cookbooks/bcpc/definitions/kernel_module.rb
+++ b/cookbooks/bcpc/definitions/kernel_module.rb
@@ -1,0 +1,18 @@
+define :kernel_module, :action => :install, :search_name => nil do
+
+  params[:search_name] ||= params[:name]
+
+  if params[:action] == :install
+    bash "install module #{params[:name]}" do
+      code "modprobe #{params[:name]}"
+      not_if "lsmod | grep #{params[:name]}"
+    end
+  end
+
+  if params[:action] == :uninstall
+    bash "uninstall module #{params[:name]}" do
+      code "modprobe -r #{params[:name]}"
+      not_if "lsmod | grep #{params[:search_name]}"
+    end
+  end
+end

--- a/cookbooks/bcpc/recipes/networking.rb
+++ b/cookbooks/bcpc/recipes/networking.rb
@@ -223,3 +223,33 @@ bash "disable-noninteractive-pam-logging" do
     code "sed --in-place 's/^\\(session\\s*required\\s*pam_unix.so\\)/#\\1/' /etc/pam.d/common-session-noninteractive"
     only_if "grep -e '^session\\s*required\\s*pam_unix.so' /etc/pam.d/common-session-noninteractive"
 end
+
+kernel_module "ip_conntrack" do
+  action :install
+  search_name "nf_conntrack_ipv4"
+end
+
+include_recipe 'sysctl::default'
+sysctl_param 'net.ipv4.ip_local_port_range' do
+  value "32768 65535"
+end
+
+sysctl_param 'net.ipv4.tcp_tw_recycle' do
+  value 1
+end
+
+sysctl_param 'net.ipv4.tcp_tw_reuse' do
+  value 1
+end
+
+sysctl_param 'net.ipv4.netfilter.ip_conntrack_tcp_timeout_fin_wait' do
+  value 10
+end
+
+sysctl_param 'net.ipv4.netfilter.ip_conntrack_tcp_timeout_time_wait' do
+  value 5
+end
+
+sysctl_param 'net.ipv4.netfilter.ip_conntrack_tcp_timeout_established' do
+  value 60
+end


### PR DESCRIPTION
There are two commits in this PR.

1) A generic definition which can be used to install/uninstall kernel modules.
2) Changes to kernel TCP parameters to reduce/reuse sockets in TIME_WAIT status which may be causing connection failures to datanodes from Hbase region servers when there is high volume read requests.

**Note**: At this stage this PR is made available for review and comments. These changes are tested on VM cluster. Will be performing tests on a physical cluster.  
