### PR TITLE
Run LCE containers as the user who submitted the application

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
@@ -156,6 +156,11 @@
   </property>
 
   <property>
+    <name>yarn.nodemanager.linux-container-executor.nonsecure-mode.limit-users</name>
+    <value>false</value>
+  </property>
+
+  <property>
     <name>yarn.nodemanager.resource.memory-mb</name>
     <value><%= node['bcpc']['hadoop']['yarn']['nodemanager']['avail_memory']['size'] or
                [1024, (node['memory']['total'].to_i * node['bcpc']['hadoop']['yarn']['nodemanager']['avail_memory']['ratio']/1024).floor].max %></value>


### PR DESCRIPTION
This fixes issue #179. This enables yarn containers launched as part of an Oozie workflow to be run as the submitting user.