### PR TITLE
Provide Hadoop ecosystem ulimits via LWRP

### DIFF
--- a/cookbooks/bcpc-hadoop/metadata.rb
+++ b/cookbooks/bcpc-hadoop/metadata.rb
@@ -11,3 +11,4 @@ depends "dpkg_autostart"
 depends "sysctl"
 depends "pam"
 depends 'java', '>= 1.28.0'
+depends 'ulimit'

--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -18,6 +18,21 @@ node.default['bcpc']['hadoop']['copylog']['datanode'] = {
   end
 end
 
+user_ulimit "hdfs" do
+  filehandle_limit 32769
+  process_limit 65536
+end
+
+user_ulimit "mapred" do
+  filehandle_limit 32769
+  process_limit 65536
+end
+
+user_ulimit "yarn" do
+  filehandle_limit 32769
+  process_limit 65536
+end
+
 template "/etc/init.d/hadoop-hdfs-datanode" do
   source "hdp_hadoop-hdfs-datanode-initd.erb"
   mode 0655
@@ -204,6 +219,7 @@ ruby_block "acquire_lock_to_restart_datanode" do
   subscribes :create, "template[/etc/hadoop/conf/hdfs-site.xml]", :immediate
   subscribes :create, "template[/etc/hadoop/conf/hadoop-env.sh]", :immediate
   subscribes :create, "template[/etc/hadoop/conf/topology]", :immediate
+  subscribes :create, "user_ulimit[hdfs]", :immediate
   subscribes :create, "ruby_block[handle_prev_datanode_restart_failure]", :immediate
 end
 #
@@ -244,4 +260,5 @@ service "hadoop-yarn-nodemanager" do
   action [:enable, :start]
   subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/yarn-site.xml]", :delayed
+  subscribes :restart, "user_ulimit[yarn]", :delayed
 end

--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -25,6 +25,10 @@ phoenix
   end
 end
 
+user_ulimit "hbase" do
+  filehandle_limit 32769
+end
+
 service "hbase-thrift" do
   action :disable
 end 
@@ -60,4 +64,5 @@ service "hbase-master" do
   subscribes :restart, "template[/etc/hbase/conf/hbase-site.xml]", :delayed
   subscribes :restart, "template[/etc/hbase/conf/hbase-policy.xml]", :delayed
   subscribes :restart, "template[/etc/hbase/conf/hbase-env.sh]", :delayed
+  subscribes :restart, "user_ulimit[hbase]", :delayed
 end

--- a/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
@@ -27,6 +27,11 @@ node.default['bcpc']['hadoop']['copylog']['namenode_master_out'] = {
   end
 end
 
+user_ulimit "hdfs" do
+  filehandle_limit 32769
+  process_limit 65536
+end
+
 node[:bcpc][:hadoop][:mounts].each do |d|
   directory "/disk/#{d}/dfs/nn" do
     owner "hdfs"
@@ -93,15 +98,16 @@ bash "initialize-shared-edits" do
 end
 
 service "generally run hadoop-hdfs-namenode" do
-   action [:enable, :start]
-   supports :status => true, :restart => true, :reload => false
-   service_name "hadoop-hdfs-namenode"
-   subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
-   subscribes :restart, "template[/etc/hadoop/conf/hdfs-policy.xml]", :delayed
-   subscribes :restart, "template[/etc/hadoop/conf/hdfs-site_HA.xml]", :delayed
-   subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
-   subscribes :restart, "template[/etc/hadoop/conf/topology]", :delayed
-   subscribes :restart, "bash[initialize-shared-edits]", :immediately
+  action [:enable, :start]
+  supports :status => true, :restart => true, :reload => false
+  service_name "hadoop-hdfs-namenode"
+  subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/hdfs-policy.xml]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/hdfs-site_HA.xml]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/topology]", :delayed
+  subscribes :restart, "user_ulimit[hdfs]", :delayed
+  subscribes :restart, "bash[initialize-shared-edits]", :immediately
 end
 
 ## We need to bootstrap the standby and journal node transaction logs

--- a/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
@@ -25,6 +25,11 @@ node.default['bcpc']['hadoop']['copylog']['namenode_out'] = {
   end
 end
 
+user_ulimit "hdfs" do
+  filehandle_limit 32769
+  process_limit 65536
+end
+
 node[:bcpc][:hadoop][:mounts].each do |d|
   directory "/disk/#{d}/dfs/nn" do
     owner "hdfs"
@@ -60,6 +65,7 @@ service "hadoop-hdfs-namenode" do
   subscribes :restart, "template[/etc/hadoop/conf/hdfs-policy.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/topology]", :delayed
+  subscribes :restart, "user_ulimit[hdfs]", :delayed
 end
 
 bash "reload hdfs nodes" do

--- a/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
@@ -24,6 +24,11 @@ node.default['bcpc']['hadoop']['copylog']['namenode_standby_out'] = {
   end
 end
 
+user_ulimit "hdfs" do
+  filehandle_limit 32769
+  process_limit 65536
+end
+
 node[:bcpc][:hadoop][:mounts].each do |d|
   directory "/disk/#{d}/dfs/nn" do
     owner "hdfs"
@@ -73,6 +78,7 @@ if @node['bcpc']['hadoop']['hdfs']['HA'] == true then
     subscribes :restart, "template[/etc/hadoop/conf/hdfs-policy.xml]", :delayed
     subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
     subscribes :restart, "template[/etc/hadoop/conf/topology]", :delayed
+    subscribes :restart, "user_ulimit[hdfs]", :delayed
   end
 else
   Chef::Log.info "Not running standby namenode services yet -- HA disabled!"

--- a/cookbooks/bcpc-hadoop/recipes/region_server.rb
+++ b/cookbooks/bcpc-hadoop/recipes/region_server.rb
@@ -16,6 +16,10 @@ node.default['bcpc']['hadoop']['copylog']['region_server_out'] = {
   end
 end
 
+user_ulimit "hbase" do
+  filehandle_limit 32769
+end
+
 directory "/usr/hdp/current/hbase-regionserver/lib/native/Linux-amd64-64" do
   recursive true
   action :create
@@ -47,4 +51,5 @@ service "hbase-regionserver" do
   subscribes :restart, "template[/etc/hbase/conf/hbase-site.xml]", :delayed
   subscribes :restart, "template[/etc/hbase/conf/hbase-policy.xml]", :delayed
   subscribes :restart, "template[/etc/hbase/conf/hbase-env.sh]", :delayed
+  subscribes :restart, "user_ulimit[hbase]", :delayed
 end

--- a/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
+++ b/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
@@ -11,6 +11,10 @@ package  "zookeeper-server" do
   notifies :create, "ruby_block[Compare_zookeeper_server_start_shell_script]", :immediately
 end
 
+user_ulimit "zookeeper" do
+  filehandle_limit 32769
+end
+
 template "/tmp/zkServer.sh" do
   source "zk_zkServer.sh.orig.erb"
   mode 0644
@@ -80,4 +84,5 @@ service "zookeeper-server" do
   subscribes :restart, "template[#{node[:bcpc][:hadoop][:zookeeper][:conf_dir]}/zookeeper-env.sh]", :delayed
   subscribes :restart, "template[/usr/lib/zookeeper/bin/zkServer.sh]", :delayed
   subscribes :restart, "file[#{node[:bcpc][:hadoop][:zookeeper][:data_dir]}/myid]", :delayed
+  subscribes :restart, "user_ulimit[zookeeper]", :delayed
 end


### PR DESCRIPTION
This pull request replicates what used to be delivered into /etc/security/limits.d in HDP2.0 to be provided by Chef. (For reference those files have now moved to `/usr/hdp/<version>/etc/security/limits.d` but I think we can manage better not playing musical files.)