### PR TITLE
Prevent hbase master/regionserver from restarting every chef-client run

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -48,11 +48,6 @@ link "/usr/hdp/current/hbase-master/lib/native/Linux-amd64-64/libsnappy.so" do
   to "/usr/lib/libsnappy.so.1"
 end
 
-template "/etc/hbase/conf/hbase-env.sh" do
-  source "hb_hbase-env.sh.erb"
-  mode 0655
-end
-
 template "/etc/init.d/hbase-master" do
   source "hdp_hbase-master-initd.erb"
   mode 0655

--- a/cookbooks/bcpc-hadoop/recipes/region_server.rb
+++ b/cookbooks/bcpc-hadoop/recipes/region_server.rb
@@ -29,11 +29,6 @@ link "/usr/hdp/current/hbase-regionserver/lib/native/Linux-amd64-64/libsnappy.so
   to "/usr/lib/libsnappy.so.1"
 end
 
-template "/etc/hbase/conf/hbase-env.sh" do
-  source "hb_hbase-env.sh.erb"
-  mode 0655
-end
-
 template "/etc/default/hbase" do
   source "hdp_hbase.default.erb"
   mode 0655


### PR DESCRIPTION
This PR fixes issue #193 where `HBase Master/Regionserver` restart on every chef-client run. 