### PR TITLE
Make graphite whisper(data) directory configurable

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -145,6 +145,7 @@ default['bcpc']['graphite']['relay_port'] = 2013
 default['bcpc']['graphite']['web_port'] = 8888
 default['bcpc']['graphite']['log']['retention'] = 15
 default['bcpc']['graphite']['timezone'] = "'America/New_York'"
+default['bcpc']['graphite']['local_data_dir'] = "/opt/graphite/storage/whisper"
 
 default[:bcpc][:ports][:apache][:radosgw] = 8080
 default[:bcpc][:ports][:apache][:radosgw_https] = 8443

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -123,7 +123,6 @@ default['bcpc']['cinder_dbname'] = "cinder"
 default['bcpc']['glance_dbname'] = "glance"
 default['bcpc']['horizon_dbname'] = "horizon"
 default['bcpc']['keystone_dbname'] = "keystone"
-default['bcpc']['graphite_dbname'] = "graphite"
 default['bcpc']['pdns_dbname'] = "pdns"
 default['bcpc']['zabbix_dbname'] = "zabbix"
 
@@ -141,21 +140,11 @@ default['bcpc']['zabbix']['scripts']['mail'] = "/usr/local/bin/zbx_mail.sh"
 default['bcpc']['zabbix']['scripts']['query_graphite'] = "/usr/local/bin/query_graphite.py"
 
 default['bcpc']['keepalived']['config_template'] = "keepalived.conf_openstack"
-default['bcpc']['graphite']['relay_port'] = 2013
-default['bcpc']['graphite']['web_port'] = 8888
-default['bcpc']['graphite']['log']['retention'] = 15
-default['bcpc']['graphite']['timezone'] = "'America/New_York'"
-default['bcpc']['graphite']['local_data_dir'] = "/opt/graphite/storage/whisper"
 
 default[:bcpc][:ports][:apache][:radosgw] = 8080
 default[:bcpc][:ports][:apache][:radosgw_https] = 8443
 default[:bcpc][:ports][:haproxy][:radosgw] = 80
 default[:bcpc][:ports][:haproxy][:radosgw_https] = 443
-default[:bcpc][:graphite][:carbon][:storage] = { 
-  "carbon"=>{ "pattern" => "^carbon\\.", "retentions"=>"60:90d" },
-  "default"=>{ "pattern" =>".*", "retentions" => "15s:7d,1m:30d,5m:90d" },
-  "hbase"=>{ "pattern" => "^jmx\\.hbase_rs\\.*\\.hb*\\.", "retentions" => "15s:15d" } 
-}
 
 #################################################
 #  attributes for chef vault download and install

--- a/cookbooks/bcpc/attributes/graphite.rb
+++ b/cookbooks/bcpc/attributes/graphite.rb
@@ -1,0 +1,11 @@
+default['bcpc']['graphite_dbname'] = "graphite"
+default['bcpc']['graphite']['relay_port'] = 2013
+default['bcpc']['graphite']['web_port'] = 8888
+default['bcpc']['graphite']['log']['retention'] = 15
+default['bcpc']['graphite']['timezone'] = "'America/New_York'"
+default['bcpc']['graphite']['local_data_dir'] = "/opt/graphite/storage/whisper"
+default['bcpc']['graphite']['carbon']['storage'] = { 
+  "carbon"=>{ "pattern" => "^carbon\\.", "retentions"=>"60:90d" },
+  "default"=>{ "pattern" =>".*", "retentions" => "15s:7d,1m:30d,5m:90d" },
+  "hbase"=>{ "pattern" => "^jmx\\.hbase_rs\\.*\\.hb*\\.", "retentions" => "15s:15d" } 
+}

--- a/cookbooks/bcpc/recipes/graphite.rb
+++ b/cookbooks/bcpc/recipes/graphite.rb
@@ -74,6 +74,14 @@ end
 
 mysql_servers = get_node_attributes(MGMT_IP_GRAPHITE_WEBPORT_ATTR_SRCH_KEYS,"mysql","bcpc")
 
+# Directory resource sets owner and group only to the leaf directory.
+# All other directories will be owned by root
+directory "#{node['bcpc']['graphite']['local_data_dir']}" do
+    owner "www-data"
+    group "www-data"
+    recursive true
+end
+
 template "/opt/graphite/conf/carbon.conf" do
     source "carbon.conf.erb"
     owner "root"
@@ -174,5 +182,5 @@ end
 bash "cleanup-old-logs" do
   action :run
   user "root"
-  code "find /opt/graphite/storage/ -name *.wsp -mtime +#{node['bcpc']['graphite']['log']['retention']} -type f -exec rm {} \\;"
+  code "find #{node['bcpc']['graphite']['local_data_dir']} -name *.wsp -mtime +#{node['bcpc']['graphite']['log']['retention']} -type f -exec rm {} \\;"
 end

--- a/cookbooks/bcpc/templates/default/carbon.conf.erb
+++ b/cookbooks/bcpc/templates/default/carbon.conf.erb
@@ -34,7 +34,7 @@
 #   LOG_DIR        = /var/log/carbon/
 #   PID_DIR        = /var/run/
 #
-#LOCAL_DATA_DIR = /opt/graphite/storage/whisper/
+LOCAL_DATA_DIR = <%= node['bcpc']['graphite']['local_data_dir'] %> 
 
 # Specify the user to drop privileges to
 # If this is blank carbon runs as the user that invokes it

--- a/cookbooks/bcpc/templates/default/graphite.local_settings.py.erb
+++ b/cookbooks/bcpc/templates/default/graphite.local_settings.py.erb
@@ -67,7 +67,7 @@ MEMCACHE_HOSTS = ['<%="#{node[:bcpc][:graphite][:ip]}"%>:11211']
 
 ## Data directories
 # NOTE: If any directory is unreadable in DATA_DIRS it will break metric browsing
-#WHISPER_DIR = '/opt/graphite/storage/whisper'
+WHISPER_DIR = '<%= node['bcpc']['graphite']['local_data_dir'] %>' 
 #RRD_DIR = '/opt/graphite/storage/rrd'
 #DATA_DIRS = [WHISPER_DIR, RRD_DIR] # Default: set from the above variables
 #LOG_DIR = '/opt/graphite/storage/log/webapp'


### PR DESCRIPTION
This PR provides ability to specify/change the location to store graphite whisper data. Whisper files can take up huge amounts of space (in 100's of GBs) based on what metrics are configured to be collected and the number of data points to be collected. With this PR, one can set the data directory to be on a separate disk/partition so that whisper data does not fill up root disk.