### PR TITLE
HDFS Fixes for HDFS Clients

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -59,5 +59,6 @@ service "hbase-master" do
   subscribes :restart, "template[/etc/hbase/conf/hbase-site.xml]", :delayed
   subscribes :restart, "template[/etc/hbase/conf/hbase-policy.xml]", :delayed
   subscribes :restart, "template[/etc/hbase/conf/hbase-env.sh]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
   subscribes :restart, "user_ulimit[hbase]", :delayed
 end

--- a/cookbooks/bcpc-hadoop/recipes/region_server.rb
+++ b/cookbooks/bcpc-hadoop/recipes/region_server.rb
@@ -46,5 +46,6 @@ service "hbase-regionserver" do
   subscribes :restart, "template[/etc/hbase/conf/hbase-site.xml]", :delayed
   subscribes :restart, "template[/etc/hbase/conf/hbase-policy.xml]", :delayed
   subscribes :restart, "template[/etc/hbase/conf/hbase-env.sh]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
   subscribes :restart, "user_ulimit[hbase]", :delayed
 end

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_hdfs-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_hdfs-site.xml.erb
@@ -162,4 +162,8 @@
     <name>dfs.namenode.handler.count</name>
     <value><%= node["bcpc"]["hadoop"]["namenode"]["handler"]["count"] %></value>
   </property>
+  <property>
+    <name>dfs.client.local.interfaces</name>
+    <value><%= node['bcpc']['floating']['ip'] %></value>
+  </property>
 </configuration>


### PR DESCRIPTION
For machines with VIP's it is possible that HDFS clients running on the machine may try to talk out the VIP -- something that will not work for getting packets back to the client. As such we need to ensure the hdfs-site.xml client options are specified. This is especially true for HBase masters. Also, at this time we do not restart HBase when hdfs-site.xml is changed; we should.