### PR TITLE
For disconnected clusters, do not install ubuntu-tools repo in role[B…

### DIFF
--- a/roles/BCPC-Hadoop-Head.json
+++ b/roles/BCPC-Hadoop-Head.json
@@ -5,6 +5,7 @@
     "role[Basic]",
     "recipe[bcpc::chef_vault_install]",
     "recipe[bcpc::default]",
+    "recipe[bcpc::ubuntu_tools_repo]",
     "recipe[bcpc-hadoop::default]",
     "recipe[bcpc::networking]",
     "recipe[bcpc::mysql]",

--- a/roles/BCPC-Hadoop-Worker.json
+++ b/roles/BCPC-Hadoop-Worker.json
@@ -5,6 +5,7 @@
     "role[Basic]",
     "recipe[bcpc::chef_vault_install]",
     "recipe[bcpc::default]",
+    "recipe[bcpc::ubuntu_tools_repo]",
     "recipe[bcpc-hadoop::default]",
     "recipe[bcpc::networking]",
     "recipe[bcpc-hadoop::disks]",

--- a/roles/BCPC-Kafka-Head-Server.json
+++ b/roles/BCPC-Kafka-Head-Server.json
@@ -6,6 +6,7 @@
     "recipe[bcpc::default]",
     "recipe[bcpc::networking]",
     "recipe[bcpc-hadoop::disks]",
+    "recipe[bcpc::ubuntu_tools_repo]",
     "recipe[bcpc-hadoop::default]",
     "recipe[kafka-bcpc::default]", 
     "recipe[kafka-bcpc::setattr]",

--- a/roles/BCPC-Kafka-Head-Zookeeper.json
+++ b/roles/BCPC-Kafka-Head-Zookeeper.json
@@ -17,6 +17,7 @@
     "recipe[bcpc::default]",
     "recipe[bcpc::networking]",
     "recipe[bcpc-hadoop::disks]",
+    "recipe[bcpc::ubuntu_tools_repo]",
     "recipe[kafka-bcpc::default]", 
     "recipe[kafka-bcpc::setattr]",
     "recipe[java::oracle]",

--- a/roles/Basic.json
+++ b/roles/Basic.json
@@ -7,7 +7,6 @@
       "recipe[bcpc::graphite_handler]",
       "recipe[apt]",
       "recipe[ubuntu]",
-      "recipe[bcpc::ubuntu_tools_repo]",
       "recipe[ntp]",
       "recipe[chef-client::delete_validation]",
       "recipe[chef-client::config]"


### PR DESCRIPTION
For disconnected cluster bootstrap nodes, by convention, we tend to run `role[Basic]` first then run recipes later in the Chef run. One issue with having the support tool in Basic is that the `bcpc::apache-mirror` recipe will not have yet run which configures the end-point for mirrored repos.

For something as big as Canonical there needs to be an independent repo but for all other small (<10GB) repos, we usually can simply drop them into place.

This begs, we should probably have `role[Basic]` and `role[Cluster-Basic]` one being for absolutely all machines and one being only for cluster nodes.