### PR TITLE
Set ARCH type to ADM64 for support tools and correct Apache Alias

### DIFF
--- a/cookbooks/bcpc/recipes/ubuntu_tools_repo.rb
+++ b/cookbooks/bcpc/recipes/ubuntu_tools_repo.rb
@@ -2,6 +2,7 @@ apt_repository "canonical-support-tools" do
   uri node['bcpc']['repos']['ubuntu-tools']
   distribution node['bcpc']['ubuntu']['version']
   components ["main"]
+  arch "amd64"
   key "ubuntu-support-tools.key" 
 end
 

--- a/cookbooks/bcpc/templates/default/apache-mirror.erb
+++ b/cookbooks/bcpc/templates/default/apache-mirror.erb
@@ -90,7 +90,7 @@
     Alias /ubuntu-cloud /var/spool/apt-mirror/mirror/ubuntu-cloud.archive.canonical.com/ubuntu
     Alias /rabbitmq /var/spool/apt-mirror/mirror/www.rabbitmq.com/debian
     Alias /ubuntu /var/spool/apt-mirror/mirror/us.archive.ubuntu.com/ubuntu
-    Alias /canonical-support /var/spool/apt-mirror/mirror/launchpad.net/support-tools
+    Alias /canonical-support /var/spool/apt-mirror/mirror/ppa.launchpad.net/canonical-support/support-tools/ubuntu
     Alias /ceph-apache /var/spool/apt-mirror/mirror/gitbuilder.ceph.com/apache2-deb-precise-x86_64-basic/ref/master
     Alias /ceph-fcgi /var/spool/apt-mirror/mirror/gitbuilder.ceph.com/libapache-mod-fastcgi-deb-precise-x86_64-basic/ref/master
     Alias /hdp /var/spool/apt-mirror/mirror/public-repo-1.hortonworks.com/HDP/ubuntu12/2.x/GA/2.2.0.0


### PR DESCRIPTION
This PR fixes two things:
* Sets `support_tool` repository to only support `amd64` type.
* Corrects the `URL` for `canonical-support` `apache` alias. 