### PR TITLE
Added bootstrap hostname attribute to environment file 

### DIFF
--- a/environments/Test-Laptop.json
+++ b/environments/Test-Laptop.json
@@ -32,6 +32,7 @@
       "bootstrap": {
         "interface" : "eth0",
         "pxe_interface" : "eth1",
+        "hostname" : "bcpc-bootstrap",
         "server" : "10.0.100.3",
         "dhcp_subnet" : "10.0.100.0",
         "dhcp_range" : "10.0.100.14 10.0.100.250"


### PR DESCRIPTION
This PR fixes the bug introduced by PR #189 where `Vagrantfile` expects `hostname` for `bootstrap` host to be present. 