### PR TITLE
Build Zabbix 2.2.9 from official Github mirror instead of 2.2.2 from SourceForge

### DIFF
--- a/build_bins.sh
+++ b/build_bins.sh
@@ -197,12 +197,12 @@ if [ ! -f zabbix-agent.tar.gz ] || [ ! -f zabbix-server.tar.gz ]; then
     # Create a zabbix source distribution from the official git mirror.
     rm -rf /tmp/zabbix-${ZABBIX_VERSION}
     git clone https://github.com/zabbix/zabbix /tmp/zabbix-${ZABBIX_VERSION}
-    cd /tmp/zabbix-${ZABBIX_VERSION}
+    pushd /tmp/zabbix-${ZABBIX_VERSION}
     git checkout tags/${ZABBIX_VERSION}
     ./bootstrap.sh
     ./configure
     make dbschema
-    cd -
+    popd
     tar -czf zabbix-${ZABBIX_VERSION}.tar.gz -C /tmp zabbix-${ZABBIX_VERSION}
 
     # Actually build zabbix.


### PR DESCRIPTION
Cluster builds are currently failing because Sourceforge is unavailable.  Example output from build_bins.sh:

```
+ '[' '!' -f zabbix-agent.tar.gz ']'
+ curl -k -x http://devproxy.bloomberg.com:82 -L -O http://sourceforge.net/projects/zabbix/files/ZABBIX%20Latest%20Stable/2.2.2/zabbix-2.2.2.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

100   639  100   639    0     0   1345      0 --:--:-- --:--:-- --:--:--  1345
+ tar zxf zabbix-2.2.2.tar.gz

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
+ echo '############## BUILD BINS RETURNED 2 ##############'
############## BUILD BINS RETURNED 2 ##############
+ exit 1
Build step 'Execute shell' marked build as failure
Archiving artifacts
Warning: you have no plugins providing access control for builds, so falling back to legacy behavior of permitting any downstream builds to be triggered
Finished: FAILURE
```

This pull request builds a Zabbix 2.2.9 using the official Github mirror of Zabbix SVN.   (No 2.2.2 was available via the mirror.) 

The output files from build_bins.sh have the same names as before: `zabbix-server.tar.gz` and `zabbix-agent.tar.gz`.  Assuming 2.2.2 and 2.2.9 are reasonably compatible, no further changes should be required.