### PR TITLE
Don't print to STDOUT in Vagrantfile.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,17 +17,17 @@ else
   base_dir = File.expand_path("./environments")
 end
 
-puts "Base directory is : #{base_dir}"
+$stderr.puts "Base directory is : #{base_dir}"
 
 json_file = Dir[File.join("#{base_dir}/../environments/",'*.json')]
 
 if json_file.empty?
-  puts "No environment file found to parse. Please make sure at least one environment file exists."
+  $stderr.puts "No environment file found to parse. Please make sure at least one environment file exists."
   exit
 end
 
 if json_file.length > 1
-  puts "More than one environment file found."
+  $stderr.puts "More than one environment file found."
   exit
 end
 


### PR DESCRIPTION
The existing branch breaks Jenkins builds by including `puts` statements in VagrantFile.  When `vagrant ssh-config` is run, the output isn't a valid SSH config.  e.g.

```
+ scp -rF ssh_config 'bootstrap:~/chef-bcpc/bins' .
ssh_config: line 1: Bad configuration option: base
ssh_config: terminating, 1 bad configuration options
Build step 'Execute shell' marked build as failure
```

This PR replaces `puts` calls with `$stderr.puts`