### PR TITLE
Fix standby namenode restart.

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
@@ -28,7 +28,6 @@ directory "/var/log/hadoop-hdfs/gc/" do
   user "hdfs"
   group "hdfs"
   action :create
-  notifies :restart, "service[hadoop-hdfs-namenode]", :delayed
 end
 
 user_ulimit "hdfs" do


### PR DESCRIPTION
This commit prevents a restart of the standby namenode.   If the restart is executed on a fresh cluster, the standby namenode halts with an error.