### PR TITLE
Install required package for Zabbix compile/build

### DIFF
--- a/build_bins.sh
+++ b/build_bins.sh
@@ -41,7 +41,7 @@ mkdir -p $APT_REPO_BINS
 apt-get -y update
 
 # Install tools needed for packaging
-apt-get -y install git rubygems make pbuilder python-mock python-configobj python-support cdbs python-all-dev python-stdeb libmysqlclient-dev libldap2-dev ruby-dev gcc patch rake ruby1.9.3 ruby1.9.1-dev python-pip python-setuptools dpkg-dev apt-utils haveged libtool autoconf automake autotools-dev unzip rsync autogen
+apt-get -y install git rubygems make pkg-config pbuilder python-mock python-configobj python-support cdbs python-all-dev python-stdeb libmysqlclient-dev libldap2-dev ruby-dev gcc patch rake ruby1.9.3 ruby1.9.1-dev python-pip python-setuptools dpkg-dev apt-utils haveged libtool autoconf automake autotools-dev unzip rsync autogen
 if [[ -z `gem list --local fpm | grep fpm | cut -f1 -d" "` ]]; then
   gem install fpm --no-ri --no-rdoc
 fi


### PR DESCRIPTION
This PR fixes current build process where `build_bins.sh` fails to compile `Zabbix` from source as it is missing `pkg-config` package that is required for the build. 