### PR TITLE
Ensure hdfs and yarn users are in appropriate hdfs and hadoop groups

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -38,6 +38,40 @@ user_ulimit "yarn" do
   process_limit 65536
 end
 
+# need to ensure hdfs user is in hadoop and hdfs
+# groups. Packages will not add hdfs if it
+# is already created at install time (e.g. if
+# machine is using LDAP for users).
+# Similarly, yarn needs to be in the hadoop
+# group to run the LCE and in the mapred group
+# for log aggregation
+group 'hadoop' do
+  # use manage as if the group does not exist
+  # we do not want an exception
+  action :manage
+  members ['hdfs', 'yarn']
+  append true
+end
+group 'hdfs' do
+  # use manage as if the group does not exist
+  # we do not want an exception
+  action :manage
+  members 'hdfs'
+  append true
+end
+group 'mapred' do
+  # use manage as if the group does not exist
+  # we do not want an exception
+  action :manage
+  members 'yarn'
+  append true
+end
+
+directory "/var/run/hadoop-hdfs" do
+  owner "hdfs"
+  group "root"
+end
+
 template "/etc/init.d/hadoop-hdfs-datanode" do
   source "hdp_hadoop-hdfs-datanode-initd.erb"
   mode 0655

--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -141,6 +141,7 @@ user "hcat" do
   shell "/bin/bash"
   home "/usr/lib/hcatalog"
   supports :manage_home => false
+  not_if { user_exists? "hcat" }
 end
 
 package 'hive-hcatalog' do

--- a/cookbooks/bcpc-hadoop/recipes/hive.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hive.rb
@@ -12,6 +12,7 @@ user "hcat" do
   shell "/bin/bash"
   home "/usr/lib/hcatalog"
   supports :manage_home => false
+  not_if { user_exists? "hcat" }
 end
 
 %w{hive hcatalog}.each do |pkg|

--- a/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
@@ -11,6 +11,11 @@ package "hadoop-lzo" do
   action :upgrade
 end
 
+user_ulimit "hive" do
+  filehandle_limit 32769
+  process_limit 65536
+end
+
 link "/usr/hdp/2.2.0.0-2041/hadoop/lib/hadoop-lzo-0.6.0.jar" do
   to "/usr/lib/hadoop/lib/hadoop-lzo-0.6.0.jar"
 end

--- a/cookbooks/bcpc-hadoop/recipes/journalnode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/journalnode.rb
@@ -54,6 +54,25 @@ node[:bcpc][:hadoop][:mounts].each do |d|
   end
 end
 
+# need to ensure hdfs user is in hadoop and hdfs
+# groups. Packages will not add hdfs if it
+# is already created at install time (e.g. if
+# machine is using LDAP for users).
+group 'hadoop' do
+  # use manage as if the group does not exist
+  # we do not want an exception
+  action :manage
+  members ['hdfs']
+  append true
+end
+group 'hdfs' do
+  # use manage as if the group does not exist
+  # we do not want an exception
+  action :manage
+  members 'hdfs'
+  append true
+end
+
 template "hadoop-hdfs-journalnode" do
   path "/etc/init.d/hadoop-hdfs-journalnode"
   source "hdp_hadoop-hdfs-journalnode-initd.erb"

--- a/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
@@ -28,6 +28,25 @@ node.default['bcpc']['hadoop']['copylog']['namenode_master_out'] = {
   end
 end
 
+# need to ensure hdfs user is in hadoop and hdfs
+# groups. Packages will not add hdfs if it
+# is already created at install time (e.g. if
+# machine is using LDAP for users).
+group 'hadoop' do
+  # use manage as if the group does not exist
+  # we do not want an exception
+  action :manage
+  members ['hdfs']
+  append true
+end
+group 'hdfs' do
+  # use manage as if the group does not exist
+  # we do not want an exception
+  action :manage
+  members 'hdfs'
+  append true
+end
+
 directory "/var/log/hadoop-hdfs/gc/" do
   user "hdfs"
   group "hdfs"

--- a/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
@@ -26,6 +26,25 @@ node.default['bcpc']['hadoop']['copylog']['namenode_out'] = {
   end
 end
 
+# need to ensure hdfs user is in hadoop and hdfs
+# groups. Packages will not add hdfs if it
+# is already created at install time (e.g. if
+# machine is using LDAP for users).
+group 'hadoop' do
+  # use manage as if the group does not exist
+  # we do not want an exception
+  action :manage
+  members ['hdfs']
+  append true
+end
+group 'hdfs' do
+  # use manage as if the group does not exist
+  # we do not want an exception
+  action :manage
+  members 'hdfs'
+  append true
+end
+
 directory "/var/log/hadoop-hdfs/gc/" do
   user "hdfs"
   group "hdfs"

--- a/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
@@ -24,6 +24,25 @@ node.default['bcpc']['hadoop']['copylog']['namenode_standby_out'] = {
   end
 end
 
+# need to ensure hdfs user is in hadoop and hdfs
+# groups. Packages will not add hdfs if it
+# is already created at install time (e.g. if
+# machine is using LDAP for users).
+group 'hadoop' do
+  # use manage as if the group does not exist
+  # we do not want an exception
+  action :manage
+  members ['hdfs']
+  append true
+end
+group 'hdfs' do
+  # use manage as if the group does not exist
+  # we do not want an exception
+  action :manage
+  members 'hdfs'
+  append true
+end
+
 directory "/var/log/hadoop-hdfs/gc/" do
   user "hdfs"
   group "hdfs"


### PR DESCRIPTION
This provides group membership for machines which already have hdfs and yarn users but not th necessary group membership for proper cluster operation.

**HDFS**: Needs to be in group hadoop (for proper updating of /var/log/); and should be in its self-named group for sanity's safe
**YARN**: Needs to be in group hadoop (for proper operation of the Linux Container Executor)

If one does not have this patch, one will see the datanode fail to start with errors in `/var/log/hadoop-hdfs/jsvc.err` like:
````
Initializing secure datanode resources
log4j:ERROR setFile(null,true) call failed.
java.io.FileNotFoundException: /var/log/hadoop-hdfs/hadoop-hdfs-datanode-hostname.log (Permission denied)
[...]
Opened info server at hostname/1.2.3.4:1006
Starting regular datanode initialization
Service exit with a return value of 1
````