### PR TITLE
Force build_bins.sh to install fpm v1.3.3

### DIFF
--- a/build_bins.sh
+++ b/build_bins.sh
@@ -43,7 +43,7 @@ apt-get -y update
 # Install tools needed for packaging
 apt-get -y install git rubygems make pkg-config pbuilder python-mock python-configobj python-support cdbs python-all-dev python-stdeb libmysqlclient-dev libldap2-dev ruby-dev gcc patch rake ruby1.9.3 ruby1.9.1-dev python-pip python-setuptools dpkg-dev apt-utils haveged libtool autoconf automake autotools-dev unzip rsync autogen
 if [[ -z `gem list --local fpm | grep fpm | cut -f1 -d" "` ]]; then
-  gem install fpm --no-ri --no-rdoc
+  gem install fpm --no-ri --no-rdoc -v 1.3.3
 fi
 
 # Download jmxtrans zip file


### PR DESCRIPTION
The current version of fpm, 1.4, no longer works on Ruby 1.8.  This is not surprising, since Ruby 1.8 is no longer maintained.  Today, if you try to do a build, fpm will fail to package our python libs:

```
+ fpm --python-install-bin /opt/graphite/bin -s python -t deb carbon-0.9.10/setup.py
/usr/lib/ruby/1.8/find.rb:39:in `find': no block given (LocalJumpError)
	from /usr/lib/ruby/1.8/find.rb:38:in `catch'
	from /usr/lib/ruby/1.8/find.rb:38:in `find'
	from /var/lib/gems/1.8/gems/fpm-1.4.0/lib/fpm/package/deb.rb:671:in `add_path'
	from /var/lib/gems/1.8/gems/fpm-1.4.0/lib/fpm/package/deb.rb:692:in `write_conffiles'
	from /var/lib/gems/1.8/gems/fpm-1.4.0/lib/fpm/package/deb.rb:590:in `write_control_tarball'
	from /var/lib/gems/1.8/gems/fpm-1.4.0/lib/fpm/package/deb.rb:389:in `output'
	from /var/lib/gems/1.8/gems/fpm-1.4.0/lib/fpm/command.rb:475:in `execute'
	from /var/lib/gems/1.8/gems/clamp-0.6.5/lib/clamp/command.rb:67:in `run'
	from /var/lib/gems/1.8/gems/fpm-1.4.0/lib/fpm/command.rb:535:in `run'
	from /var/lib/gems/1.8/gems/clamp-0.6.5/lib/clamp/command.rb:132:in `run'
	from /var/lib/gems/1.8/gems/fpm-1.4.0/bin/fpm:8
	from /usr/local/bin/fpm:19:in `load'
```
 
In order to keep our build process working on ubuntu 12.04's system ruby, we'll explicitly install fpm 1.3.3.