### PR TITLE
Pin windows cookbook to 1.36.6

### DIFF
--- a/setup_chef_cookbooks.sh
+++ b/setup_chef_cookbooks.sh
@@ -56,7 +56,7 @@ EOF
 cd cookbooks
 
 # allow versions on cookbooks via "cookbook version"
-for cookbook in "apt 2.4.0" python build-essential ubuntu cron "chef-client 4.2.4" chef-vault ntp yum logrotate yum-epel sysctl chef_handler 7-zip windows ark sudo ulimit pam ohai "poise 1.0.12" graphite_handler java maven; do
+for cookbook in "apt 2.4.0" python build-essential ubuntu cron "chef-client 4.2.4" chef-vault ntp yum logrotate yum-epel sysctl chef_handler 7-zip "windows 1.36.6" ark sudo ulimit pam ohai "poise 1.0.12" graphite_handler java maven; do
   if [[ ! -d ${cookbook% *} ]]; then
      # unless the proxy was defined this knife config will be the same as the one generated above
     knife cookbook site download $cookbook --config ../.chef/knife.rb


### PR DESCRIPTION
Versions 1.37.0 and later contain metadata.rb that is incompatible
with our release of chef 11.x.

Builds fail in the chef bootstrap process:
```
ERROR: knife encountered an unexpected error
This may be a bug in the 'cookbook upload' knife command or plugin
Please collect the output of this command with the `-VV` option before filing a bug report.
Exception: NoMethodError: undefined method `source_url' for #<Chef::Cookbook::Metadata:0x000000034cf448>
+ echo '############## bootstrap_chef.sh returned 100 ##############'
############## bootstrap_chef.sh returned 100 ##############
+ exit 1
```

This commit pins the `windows` cookbook at the last version with compatible metadata.