### PR TITLE
Enable GC logging for Hive processes

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hive.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hive.rb
@@ -1,3 +1,4 @@
 default[:bach][:hive][:metastore][:port] = 9083
 default[:bach][:hive][:hiveserver2][:port] = 10000
 default[:bcpc][:hive][:heap][:size]=1024
+default[:bcpc][:hive][:gc_opts] = " -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:/var/log/hive/gc/gc.log-$$-$(hostname)-$(date +'%Y%m%d%H%M').log -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime"

--- a/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
@@ -108,11 +108,18 @@ template "/etc/init.d/hive-server2" do
   mode 0655
 end
 
+directory "/var/log/hive/gc" do
+  action :create
+  mode 0755
+  user "hive"
+end
+
 service "hive-metastore" do
   action [:enable, :start]
   subscribes :restart, "template[/etc/hive/conf/hive-site.xml]", :delayed
   subscribes :restart, "template[/etc/hive/conf/hive-log4j.properties]", :delayed
   subscribes :restart, "bash[extract-mysql-connector]", :delayed
+  subscribes :restart, "directory[/var/log/hive/gc]", :delayed
 end
 
 service "hive-server2" do
@@ -121,4 +128,5 @@ service "hive-server2" do
   subscribes :restart, "template[/etc/hive/conf/hive-site.xml]", :delayed
   subscribes :restart, "template[/etc/hive/conf/hive-log4j.properties]", :delayed
   subscribes :restart, "bash[extract-mysql-connector]", :delayed
+  subscribes :restart, "directory[/var/log/hive/gc]", :delayed
 end

--- a/cookbooks/bcpc-hadoop/templates/default/hv_hive-env.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hv_hive-env.sh.erb
@@ -6,8 +6,9 @@ export HIVE_CONF_DIR=/etc/hive/conf.<%= node.chef_environment %>
 # export HIVE_AUX_JARS_PATH=
 export HIVE_AUX_JARS_PATH=/usr/hdp/current/hive-webhcat/share/hcatalog/hive-hcatalog-core.jar
 
-export JAVA_HOME=<%= node["bcpc"]["hadoop"]["java"] %>
+export JAVA_HOME=<%= node[:bcpc][:hadoop][:java] %>
 export HADOOP_HEAPSIZE=<%=node[:bcpc][:hive][:heap][:size] %>
+export HADOOP_OPTS="<%= node[:bcpc][:hive][:gc_opts]%>"
 export HIVE_LOG_DIR=/var/log/hive
 export HIVE_PID_DIR=/var/run/hive
 export HIVE_IDENT_STRING=hive


### PR DESCRIPTION
This PR enables `GC` logging for `Hive` processes. This is tested on development cluster.
* Before `GC` logging was enabled
````
hive     11755     1  0 11:21 ?        00:01:19 /usr/lib/jvm/java-7-oracle-amd64/bin/java -Xmx1024m -Djava.net.preferIPv4Stack=true -Dhive.log.dir=/var/log/hive -Dhive.log.file=hive-metastore.log -Dhive.log.threshold=INFO -Dhdp.version=2.2.0.0-2041 -Dhadoop.log.dir=/var/log/hadoop-hdfs -Dhadoop.log.file=hadoop.log -Dhadoop.home.dir=/usr/hdp/2.2.0.0-2041/hadoop -Dhadoop.id.str=hive -Dhadoop.root.logger=INFO,console -Djava.library.path=:/usr/hdp/2.2.0.0-2041/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.2.0.0-2041/hadoop/lib/native -Dhadoop.policy.file=hadoop-policy.xml -Djava.net.preferIPv4Stack=true -Dhadoop.security.logger=INFO,NullAppender org.apache.hadoop.util.RunJar /usr/hdp/2.2.0.0-2041/hive/lib/hive-service-0.14.0.2.2.0.0-2041.jar org.apache.hadoop.hive.metastore.HiveMetaStore

hive     11921     1  0 11:21 ?        00:00:53 /usr/lib/jvm/java-7-oracle-amd64/bin/java -Xmx1024m -Djava.net.preferIPv4Stack=true -Dhive.log.dir=/var/log/hive -Dhive.log.file=hive-server2.log -Dhive.log.threshold=INFO -Dhdp.version=2.2.0.0-2041 -Dhadoop.log.dir=/var/log/hadoop-hdfs -Dhadoop.log.file=hadoop.log -Dhadoop.home.dir=/usr/hdp/2.2.0.0-2041/hadoop -Dhadoop.id.str=hive -Dhadoop.root.logger=INFO,console -Djava.library.path=:/usr/hdp/2.2.0.0-2041/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.2.0.0-2041/hadoop/lib/native -Dhadoop.policy.file=hadoop-policy.xml -Djava.net.preferIPv4Stack=true -Dhadoop.security.logger=INFO,NullAppender org.apache.hadoop.util.RunJar /usr/hdp/2.2.0.0-2041/hive/lib/hive-service-0.14.0.2.2.0.0-2041.jar org.apache.hive.service.server.HiveServer2 --hiveconf hive.aux.jars.path=file:///usr/hdp/current/hive-webhcat/share/hcatalog/hive-hcatalog-core.jar
root     28121 28067  0 15:28 pts/0    00:00:00 grep --color=auto hive
````
* After `GC` logging was enabled
````
hive      1618     1 99 15:32 ?        00:00:18 /usr/lib/jvm/java-7-oracle-amd64/bin/java -Xmx1024m -Djava.net.preferIPv4Stack=true -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:/var/log/hive/gc/gc.log-1618-bcpc-vm2-201508061532.log -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -Dhdp.version=2.2.0.0-2041 -Dhadoop.log.dir=/var/log/hadoop-hdfs -Dhadoop.log.file=hadoop.log -Dhadoop.home.dir=/usr/hdp/2.2.0.0-2041/hadoop -Dhadoop.id.str=hive -Dhadoop.root.logger=INFO,console -Djava.library.path=:/usr/hdp/2.2.0.0-2041/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.2.0.0-2041/hadoop/lib/native -Dhadoop.policy.file=hadoop-policy.xml -Djava.net.preferIPv4Stack=true -Dhadoop.security.logger=INFO,NullAppender org.apache.hadoop.util.RunJar /usr/hdp/2.2.0.0-2041/hive/lib/hive-service-0.14.0.2.2.0.0-2041.jar org.apache.hadoop.hive.metastore.HiveMetaStore

hive      1781     1 89 15:32 ?        00:00:08 /usr/lib/jvm/java-7-oracle-amd64/bin/java -Xmx1024m -Djava.net.preferIPv4Stack=true -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:/var/log/hive/gc/gc.log-1781-bcpc-vm2-201508061532.log -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -Dhdp.version=2.2.0.0-2041 -Dhadoop.log.dir=/var/log/hadoop-hdfs -Dhadoop.log.file=hadoop.log -Dhadoop.home.dir=/usr/hdp/2.2.0.0-2041/hadoop -Dhadoop.id.str=hive -Dhadoop.root.logger=INFO,console -Djava.library.path=:/usr/hdp/2.2.0.0-2041/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.2.0.0-2041/hadoop/lib/native -Dhadoop.policy.file=hadoop-policy.xml -Djava.net.preferIPv4Stack=true -Dhadoop.security.logger=INFO,NullAppender org.apache.hadoop.util.RunJar /usr/hdp/2.2.0.0-2041/hive/lib/hive-service-0.14.0.2.2.0.0-2041.jar org.apache.hive.service.server.HiveServer2 --hiveconf hive.aux.jars.path=file:///usr/hdp/current/hive-webhcat/share/hcatalog/hive-hcatalog-core.jar
root      1994 28067  0 15:32 pts/0    00:00:00 grep --color=auto hive
````
