### PR TITLE
Prevent RM from restarting every chef-run. Restart YARN on env change

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -104,12 +104,6 @@ user "hcat" do
   supports :manage_home => false
 end
 
-#%w{hive hcatalog libmysql-java}.each do |pkg|
-#  package pkg do
-#    action :upgrade
-#  end
-#end
-
 package 'hive-hcatalog' do
   action :upgrade
 end
@@ -259,6 +253,7 @@ service "hadoop-yarn-nodemanager" do
   supports :status => true, :restart => true, :reload => false
   action [:enable, :start]
   subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/yarn-env.sh]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/yarn-site.xml]", :delayed
   subscribes :restart, "user_ulimit[yarn]", :delayed
 end

--- a/cookbooks/bcpc-hadoop/recipes/hadoop_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hadoop_config.rb
@@ -55,7 +55,7 @@ end
   hadoop-env.sh}.each do |t|
  template "/etc/hadoop/conf/#{t}" do
    source "hdp_#{t}.erb"
-   mode 0644
+   mode 0555
    variables(:nn_hosts => node[:bcpc][:hadoop][:nn_hosts],
              :zk_hosts => node[:bcpc][:hadoop][:zookeeper][:servers],
              :jn_hosts => node[:bcpc][:hadoop][:jn_hosts],

--- a/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
@@ -41,11 +41,6 @@ end
   end
 end
 
-template "/etc/hadoop/conf/yarn-env.sh" do
-  source "hdp_yarn-env.sh.erb"
-  mode 0655
-end
-
 template "/etc/init.d/hadoop-yarn-resourcemanager" do
   source "hdp_hadoop-yarn-resourcemanager-initd.erb"
   mode 0655
@@ -77,6 +72,7 @@ service "hadoop-yarn-resourcemanager" do
   action [:enable, :start]
   supports :status => true, :restart => true, :reload => false
   subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/yarn-env.sh]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/yarn-site.xml]", :delayed
 end
 

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
@@ -115,7 +115,7 @@
   </property>
 
   <property>
-    <name>yarn.nodemanager.aux-services.mapreduce.shuffle.class</name>
+    <name>yarn.nodemanager.aux-services.mapreduce_shuffle.class</name>
     <value>org.apache.hadoop.mapred.ShuffleHandler</value>
   </property>
 

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
@@ -101,12 +101,9 @@
     <value><%= float_host(node[:hostname]) %></value>
   </property>
 
-  <property>
-    <description>Classpath for typical applications.</description>
+<property>
     <name>yarn.application.classpath</name>
-    <value>
-      /etc/hadoop/conf,/usr/lib/hadoop/*,/usr/lib/hadoop/lib/*,/usr/lib/hadoop-hdfs/*,/usr/lib/hadoop-hdfs/lib/*,/usr/lib/hadoop-yarn/*,/usr/lib/hadoop-yarn/lib/*,/usr/lib/hadoop-mapreduce/*,/usr/lib/hadoop-mapreduce/lib/*,/usr/lib/pig/*,/usr/lib/pig/lib/*,$HADOOP_CONF_DIR,/usr/hdp/2.2.0.0-2041/hadoop-client/*,/usr/hdp/2.2.0.0-2041/hadoop-client/lib/*,/usr/hdp/2.2.0.0-2041/hadoop-hdfs-client/*,/usr/hdp/2.2.0.0-2041/hadoop-hdfs-client/lib/*,/usr/hdp/2.2.0.0-2041/hadoop-yarn-client/*,/usr/hdp/2.2.0.0-2041/hadoop-yarn-client/lib/*
-    </value>
+    <value>/etc/hadoop/conf,/usr/hdp/current/hadoop-client/*,/usr/hdp/current/hadoop-client/lib/*,/usr/hdp/current/hadoop-hdfs-client/*,/usr/hdp/current/hadoop-hdfs-client/lib/*,/usr/hdp/current/hadoop-yarn-client/*,/usr/hdp/current/hadoop-yarn-client/lib/*</value>
   </property>
 
   <property>


### PR DESCRIPTION
This PR fixes following issues:
* Prevents `YARN ResourceManager` from restarting on every chef-run by removing duplicate template resource
* Subscribes `ResourceManager` and `NodeManager` to restart if `yarn-env.sh` changes. 
* Correct the value for `aux` service class in `yarn-site.xml` from `mapreduce.shuffle` to mapreduce_shuffle` to match with what is defined in `yarn.nodemanager.aux-services`