### PR TITLE
lower the mapred requirements to be within yarn-site limits

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/hdp_mapred-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_mapred-site.xml.erb
@@ -82,4 +82,34 @@
   <% end %>
   <% end %>
 
+  <property> 
+      <name>mapreduce.map.memory.mb</name> 
+      <value><%= node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb'].round %></value> 
+  </property> 
+
+  <property> 
+      <name>mapreduce.map.java.opts</name> 
+      <value><%="-Xmx#{(0.8 * node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb']).round}m" %></value> 
+  </property> 
+
+  <property> 
+      <name>mapreduce.reduce.memory.mb</name> 
+      <value><%= 2 * node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb'].round %></value>
+  </property> 
+
+  <property> 
+      <name>mapreduce.reduce.java.opts</name> 
+      <value><%="-Xmx#{(0.8 * 2 * node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb']).round}m" %></value>
+  </property> 
+
+  <property> 
+      <name>yarn.app.mapreduce.am.resource.mb</name> 
+      <value><%= 2 * node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb'].round %></value> 
+  </property> 
+
+  <property>
+    <name>yarn.app.mapreduce.am.command-opts</name>
+    <value><%="-Xmx#{ (0.8 * 2 * node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb']).round}m" %></value> 
+  </property>
+
 </configuration>

--- a/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-site.xml.erb
@@ -351,4 +351,35 @@
     <name>oozie.service.ProxyUserService.proxyuser.hue.groups</name>
     <value>*</value>
   </property>
+
+  <property>
+      <name>oozie.launcher.mapreduce.map.memory.mb</name>
+      <value><%= node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb'].round %></value>
+  </property>
+
+  <property>
+      <name>oozie.launcher.mapreduce.map.java.opts</name>
+      <value><%="-Xmx#{(0.8 * node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb']).round}m" %></value>
+  </property>
+
+  <property>
+      <name>oozie.launcher.mapreduce.reduce.memory.mb</name>
+      <value><%= 2 * node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb'].round %></value>
+  </property>
+
+  <property>
+      <name>oozie.launcher.mapreduce.reduce.java.opts</name>
+      <value><%="-Xmx#{(0.8 * 2 * node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb']).round}m" %></value>
+  </property>
+
+  <property>
+      <name>oozie.launcher.yarn.app.mapreduce.am.resource.mb</name>
+      <value><%= 2 * node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb'].round %></value>
+  </property>
+
+  <property>
+    <name>oozie.launcher.yarn.app.mapreduce.am.command-opts</name>
+    <value><%="-Xmx#{ (0.8 * 2 * node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb']).round}m" %></value>
+  </property>
+
 </configuration>


### PR DESCRIPTION
This chnage ensures that we do not exceed yarn-site allocations
**Testing**
You will be able to run ````hadoop jar /usr/hdp/2.2.0.0-2041/hadoop-mapreduce/hadoop-mapreduce-examples.jar pi 1 100```` without having to specify mapred properties on the command line.

Attached supporting docs for oozie testing