### PR TITLE
Replace zkformatted with znode_exists?, update mapreduce classpath and set mysql strict sync

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
@@ -77,7 +77,8 @@ bash "format-zk-hdfs-ha" do
   action :run
   user "hdfs"
   notifies :restart, "service[generally run hadoop-hdfs-namenode]", :delayed
-  not_if { zk_formatted? }
+  zks = node[:bcpc][:hadoop][:zookeeper][:servers].map{|zkh| "#{zkh[:hostname]}:#{node[:bcpc][:hadoop][:zookeeper][:port]}"}.join(",")
+  not_if { znode_exists?("/hadoop-ha/#{node.chef_environment}", zks) }
 end
 
 service "hadoop-hdfs-zkfc" do

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_mapred-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_mapred-site.xml.erb
@@ -27,7 +27,7 @@
 
   <property>
     <name>mapreduce.application.classpath</name>
-    <value>$PWD/mr-framework/hadoop/share/hadoop/mapreduce/*:$PWD/mr-framework/hadoop/share/hadoop/mapreduce/lib/*:$PWD/mr-framework/hadoop/share/hadoop/common/*:$PWD/mr-framework/hadoop/share/hadoop/common/lib/*:$PWD/mr-framework/hadoop/share/hadoop/yarn/*:$PWD/mr-framework/hadoop/share/hadoop/yarn/lib/*:$PWD/mr-framework/hadoop/share/hadoop/hdfs/*:$PWD/mr-framework/hadoop/share/hadoop/hdfs/lib/*:/usr/hdp/2.2.0.0-2041/hadoop/lib/hadoop-lzo-0.6.0.jar</value>
+    <value>$PWD/mr-framework/hadoop/share/hadoop/mapreduce/*,$PWD/mr-framework/hadoop/share/hadoop/mapreduce/lib/*,$PWD/mr-framework/hadoop/share/hadoop/common/*,$PWD/mr-framework/hadoop/share/hadoop/common/lib/*,$PWD/mr-framework/hadoop/share/hadoop/yarn/*,$PWD/mr-framework/hadoop/share/hadoop/yarn/lib/*,$PWD/mr-framework/hadoop/share/hadoop/hdfs/*,$PWD/mr-framework/hadoop/share/hadoop/hdfs/lib/*,/usr/hdp/2.2.0.0-2041/hadoop/lib/hadoop-lzo-0.6.0.jar,$HADOOP_CONF_DIR</value>
   </property>
 
   <property>

--- a/cookbooks/bcpc/templates/default/wsrep.cnf.erb
+++ b/cookbooks/bcpc/templates/default/wsrep.cnf.erb
@@ -107,7 +107,7 @@ wsrep_auto_increment_control=1
 wsrep_drupal_282555_workaround=0
 
 # enable "strictly synchronous" semantics for read operations
-wsrep_causal_reads=0
+wsrep_sync_wait=1
 
 # Command to call when node status or cluster membership changes.
 # Will be passed all or some of the following options:


### PR DESCRIPTION
This PR fixes:
* Issue with call to method `znode_exists()?` and passes correct hostname to verify existence of a `znode`.
* Changed `mapreduce.application.classpath` to be a comma-separated list instead of a colon-separated list.
* Turns on strict synchronization of mysql databases for `READ` operations.