### PR TITLE
Lower oozie memory requirements for VM clusters

### DIFF
--- a/environments/Test-Laptop.json
+++ b/environments/Test-Laptop.json
@@ -46,6 +46,9 @@
         "distribution" : {
           "version" : "HDP",
           "key" : "hortonworks.key"
+        },
+        "oozie": {
+          "memory_opts": "-Xmx512m -XX:MaxPermSize=64m"
         }
       },
       "repos" : {


### PR DESCRIPTION
PR #121 raised the default memory allocation for oozie server process to 2G heap and 256M perm. This allocation is not viable on VM clusters with about 3-5G total memory. This PR overrides the memory settings and set them to half for VM clusters.