### PR TITLE
Add a motd for useful BACH variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ python_server.log
 vbox/
 bins/
 cookbooks/*/
+!cookbooks/bach_common
 !cookbooks/bcpc
 !cookbooks/bcpc-hadoop
 !cookbooks/bcpc_jmxtrans

--- a/cookbooks/bach_common/Berksfile
+++ b/cookbooks/bach_common/Berksfile
@@ -1,0 +1,4 @@
+# -*- mode: enh-ruby -*-
+source "https://supermarket.chef.io"
+
+metadata

--- a/cookbooks/bach_common/metadata.rb
+++ b/cookbooks/bach_common/metadata.rb
@@ -1,0 +1,9 @@
+name             'bach_common'
+maintainer       'Bloomberg LP'
+maintainer_email 'compute@bloomberg.net'
+license          'All rights reserved'
+description      'bach_common contains common recipes for the BACH cookbooks'
+long_description 'bach_common contains common recipes for the BACH cookbooks'
+version          '0.1.0'
+
+supports 'ubuntu', '12.04'

--- a/cookbooks/bach_common/recipes/motd.rb
+++ b/cookbooks/bach_common/recipes/motd.rb
@@ -1,0 +1,38 @@
+#
+# Cookbook Name:: bach_common
+# Recipe:: motd
+#
+# This recipe puts useful environment values into the message of the
+# day.  This way users will be reminded of important values when they
+# ssh into cluster nodes.
+#
+
+# Disable the dynamic motd entries we won't use.
+# (by marking them non-executable)
+[
+ '10-help-text',
+ '50-landscape-sysinfo',
+ '51-cloudguest',
+ '90-updates-available',
+ '91-release-upgrade',
+ '95-hwe-eol',
+ '98-cloudguest',
+ '98-fsck-at-reboot',
+ '98-reboot-required',
+ '99-footer',
+].map{ |motd_file| "/etc/update-motd.d/#{motd_file}" }.each do |motd_path|
+  if(File.exists?(motd_path))
+    file motd_path do
+      mode 0444
+    end
+  end
+end
+
+# Add a template for BACH variables
+template '/etc/update-motd.d/01-bach-variables' do
+  source 'motd/bach-variables.erb'
+  mode 0555
+end
+
+# Force a motd update (no-op on 12.04, necessary on 14.04)
+execute 'run-parts /etc/update-motd.d/'

--- a/cookbooks/bach_common/templates/default/motd/bach-variables.erb
+++ b/cookbooks/bach_common/templates/default/motd/bach-variables.erb
@@ -1,0 +1,35 @@
+#!/bin/bash
+# -*- mode: shell-script -*-
+#
+# 01-bach-variables
+# 
+# Print relevant BACH variables and hardware info on login.
+#
+
+<% mfg = node['dmi']['system']['manufacturer']
+   product = node['dmi']['system']['product_name']
+   gb = (node['memory']['total'].to_f / 1024 / 1024).round
+   cores = node[:cpu]['0'][:cores].to_i * node[:cpu][:real] %>
+
+cat << EOF
+
+You have logged into a member of a BACH cluster.
+
+<% if node[:virtualization][:role] == 'guest' %>
+This is a virtual machine with <%= gb %> GB of RAM and <%= cores %> CPU cores.
+<% else %>
+This system is a <%= mfg %> <%= product %>.
+It is equipped with <%= gb %> GB of RAM and <%= cores %> CPU cores.
+<% end %>
+
+Environment: <%= node.chef_environment %>
+Zabbix URL: https://<%= node[:bcpc][:management][:vip] %>:<%= node[:bcpc][:zabbix][:web_port] %>
+Graphite URL: https://<%= node[:bcpc][:management][:vip] %>:<%= node[:bcpc][:graphite][:web_port] %>
+Bootstrap node IP: <%= node[:bcpc][:bootstrap][:server] %>
+Roles:
+<% node.run_list.each do |entry| %>
+<%= "  - #{entry.to_s}" %>
+<% end %>
+
+EOF
+

--- a/roles/Basic.json
+++ b/roles/Basic.json
@@ -4,6 +4,7 @@
     },
     "json_class": "Chef::Role",
     "run_list": [
+      "recipe[bach_common::motd]",
       "recipe[bcpc::graphite_handler]",
       "recipe[apt]",
       "recipe[ubuntu]",


### PR DESCRIPTION
This PR fixes issue #237.

```
Welcome to Ubuntu 12.04.5 LTS (GNU/Linux 3.2.0-86-virtual x86_64)

You have logged into a member of a BACH cluster.

Environment: Test-Laptop
Bootstrap node IP: 10.0.100.3
Roles:
  - role[BCPC-Bootstrap]
```