### PR TITLE
Changes in hbase init.d script for BIGTOP-1956

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/hdp_hbase-regionserver-initd.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_hbase-regionserver-initd.erb
@@ -194,18 +194,26 @@ multi_hbase_daemon() {
         exit 1
     fi
 
-    export HBASE_${UPPERCASE_HBASE_DAEMON}_OPTS=" "
-
     for OFFSET in ${OFFSETS} ; do
+        export HBASE_${UPPERCASE_HBASE_DAEMON}_OPTS=" "
         echo -n "$ACTION regionserver daemon $OFFSET: "
         export HBASE_IDENT_STRING="hbase-${OFFSET}"
         LOG_FILE="$HBASE_LOG_DIR/hbase-$HBASE_IDENT_STRING-regionserver-$HOSTNAME.pid"
         PID_FILE="$HBASE_PID_DIR/hbase-$HBASE_IDENT_STRING-regionserver.pid"
         HBASE_MULTI_ARGS="-D hbase.regionserver.port=`expr ${FIRST_PORT} + $OFFSET` \
                           -D hbase.regionserver.info.port=`expr ${FIRST_INFO_PORT} + ${OFFSET}`"
-        if [ "x$JMXPORT" != "x" ] ; then
-            export HBASE_${UPPERCASE_HBASE_DAEMON}_OPTS="`eval '$'HBASE_${UPPERCASE_HBASE_DAEMON}_OPTS` -Dcom.sun.management.jmxremote.port=`expr ${JMXPORT} + ${OFFSET}`"
+
+        if [ "x$JAVA_TMP_DIR" == "x" ] ; then
+            JAVA_TMP_DIR="/tmp/java_tmp_dir"
         fi
+        HBASE_TMP_DIR=" -Djava.io.tmpdir=${JAVA_TMP_DIR}/${OFFSET}"
+
+        if [ "x$JMXPORT" != "x" ] ; then
+            HBASE_JMX_PORT=" -Dcom.sun.management.jmxremote.port=`expr ${JMXPORT} + ${OFFSET}`"
+        fi
+
+        export HBASE_${UPPERCASE_HBASE_DAEMON}_OPTS="`eval '$'HBASE_${UPPERCASE_HBASE_DAEMON}_OPTS`$HBASE_TMP_DIR$HBASE_JMX_PORT"
+
         hbase_check_pidfile $PID_FILE
         STATUS=$?
         if [[ "$STATUS" == "0" && "$COMMAND" == "start" ]] ; then


### PR DESCRIPTION
Each RS on a host need to have a unique ``hbase.tmp.dir" in a multi RS environment so that there are no conflicts when an RS comes up. The change is to pass a unique tmp directory when bringing up each RS instance. 