### PR TITLE
Make chef-vaulting backward compatible

### DIFF
--- a/cookbooks/bcpc/recipes/haproxy.rb
+++ b/cookbooks/bcpc/recipes/haproxy.rb
@@ -29,10 +29,12 @@ end
 
 bootstrap = get_all_nodes.select{|s| s.hostname.include? 'bootstrap'}[0].fqdn
 
+nodes = get_nodes_for("haproxy").map!{ |x| x['fqdn'] }.join(",")
+
 chef_vault_secret "haproxy-stats" do
   data_bag 'os'
   raw_data({ 'password' => haproxy_stats_password })
-  admins "#{ node['fqdn'] },#{ bootstrap }"
+  admins "#{ nodes },#{ bootstrap }"
   search '*:*'
   action :nothing
 end.run_action(:create_if_missing)


### PR DESCRIPTION
fix the issue resulting from rechefing the old existed cluster without using C-A-R.sh after pulling in new change to chef vaulting haproxy-stats password.