### PR TITLE
Change to regularly clean ZooKeeper snapshot files

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/zookeeper.rb
+++ b/cookbooks/bcpc-hadoop/attributes/zookeeper.rb
@@ -43,3 +43,9 @@ default[:bcpc][:hadoop][:zookeeper][:leader_connect][:port] = 2888
 
 #Port for leader election in the Quorum
 default[:bcpc][:hadoop][:zookeeper][:leader_elect][:port] = 3888
+
+#Number of ZooKeeper snapshots to be retained
+default[:bcpc][:hadoop][:zookeeper][:snap][:retain_count] = 5
+
+#ZooKeeper snapshot purge interval in hours
+default[:bcpc][:hadoop][:zookeeper][:snap][:purge_interval] = 24

--- a/cookbooks/bcpc-hadoop/templates/default/zk_zoo.cfg.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/zk_zoo.cfg.erb
@@ -42,3 +42,10 @@ jaasLoginRenew=3600000
 kerberos.removeHostFromPrincipal=true
 kerberos.removeRealmFromPrincipal=true
 <% end %>
+
+#Number of ZooKeeper snapshots to be retained
+autopurge.snapRetainCount=<%= node[:bcpc][:hadoop][:zookeeper][:snap][:retain_count] %>
+
+#ZooKeeper snapshot purge interval in hours
+autopurge.purgeInterval=<%= node[:bcpc][:hadoop][:zookeeper][:snap][:purge_interval] %>
+


### PR DESCRIPTION
The change will help balance between disk space use and the number of ZK snapshots for data recovery.