### PR TITLE
Provide a silencer for BlockStateChange NN log entries

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/hdp_log4j.properties.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_log4j.properties.erb
@@ -206,3 +206,6 @@ log4j.additivity.org.apache.hadoop.mapred.JobInProgress$JobSummary=false
 #log4j.appender.RMSUMMARY.MaxBackupIndex=20
 #log4j.appender.RMSUMMARY.layout=org.apache.log4j.PatternLayout
 #log4j.appender.RMSUMMARY.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n
+
+# Leverage HDFS-4080 to silence BlockStateChange messages
+log4j.logger.BlockStateChange=WARN


### PR DESCRIPTION
This PR provides a way to lessen NN logging due to `BlockStateChange` messages as discussed in [HDFS-4080](https://issues.apache.org/jira/browse/HDFS-4080).