### PR TITLE
change carbon ulimit before startup

### DIFF
--- a/cookbooks/bcpc/attributes/graphite.rb
+++ b/cookbooks/bcpc/attributes/graphite.rb
@@ -3,6 +3,7 @@ default['bcpc']['graphite']['relay_port'] = 2013
 default['bcpc']['graphite']['web_port'] = 8888
 default['bcpc']['graphite']['log']['retention'] = 15
 default['bcpc']['graphite']['timezone'] = "'America/New_York'"
+default['bcpc']['graphite']['carbon_fileno_limit'] = 4096
 default['bcpc']['graphite']['local_data_dir'] = "/opt/graphite/storage/whisper"
 default['bcpc']['graphite']['carbon']['storage'] = { 
   "carbon"=>{ "pattern" => "^carbon\\.", "retentions"=>"60:90d" },

--- a/cookbooks/bcpc/templates/default/init.d-carbon.erb
+++ b/cookbooks/bcpc/templates/default/init.d-carbon.erb
@@ -38,6 +38,7 @@ start(){
         if [ "${INSTANCE}" == "${CARBON_DAEMON}" ]; then
             INSTANCE="a";
         fi;
+        ulimit -Sn  <%= node['bcpc']['graphite']['carbon_fileno_limit'] %>
         echo "Starting carbon-${CARBON_DAEMON}:${INSTANCE}..."
         bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} start;
 


### PR DESCRIPTION
In a few cases we have noticed carbon processes running out of open files, this results in massive logging.  While the logs are very useful we want to try to eliminate this condition from happening, by making file limits configurable.  4096 seems like a good place to start