### PR TITLE
Changes to parametrize HBase major compaction time interval

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -43,6 +43,8 @@ default["bcpc"]["hadoop"]["namenode"]["rpc"]["port"] = 8020
 default["bcpc"]["hadoop"]["namenode"]["http"]["port"] = 50070 
 default["bcpc"]["hadoop"]["namenode"]["https"]["port"] = 50470
 default["bcpc"]["hadoop"]["hbase"]["superusers"] = ["hbase"]
+# Interval in milli seconds when HBase major compaction need to be run. Disabled by default
+default["bcpc"]["hadoop"]["hbase"]["major_compact"]["time"] = 0
 default["bcpc"]["hadoop"]["hbase_master"]["jmx"]["port"] = 10101
 default["bcpc"]["hadoop"]["hbase_rs"]["jmx"]["port"] = 10102
 default["bcpc"]["hadoop"]["kafka"]["jmx"]["port"] = 9995

--- a/cookbooks/bcpc-hadoop/templates/default/hb_hbase-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hb_hbase-site.xml.erb
@@ -29,6 +29,11 @@
   </property>
 
   <property>
+    <name>hbase.hregion.majorcompaction</name>
+    <value><%= node["bcpc"]["hadoop"]["hbase"]["major_compact"]["time"] %></value>
+  </property>
+
+  <property>
     <name>fail.fast.expired.active.master</name>
     <value><%= @master_hosts.length > 1 ? "true" : "false" %></value>
   </property>


### PR DESCRIPTION
The changes will help customize when time based major compaction need to be run on a HBase cluster.