### PR TITLE
cleanup stale logs as well as whisper files

### DIFF
--- a/cookbooks/bcpc/attributes/graphite.rb
+++ b/cookbooks/bcpc/attributes/graphite.rb
@@ -2,8 +2,10 @@ default['bcpc']['graphite_dbname'] = "graphite"
 default['bcpc']['graphite']['relay_port'] = 2013
 default['bcpc']['graphite']['web_port'] = 8888
 default['bcpc']['graphite']['log']['retention'] = 15
+default['bcpc']['graphite']['data']['retention'] = 15
 default['bcpc']['graphite']['timezone'] = "'America/New_York'"
 default['bcpc']['graphite']['local_data_dir'] = "/opt/graphite/storage/whisper"
+default['bcpc']['graphite']['local_log_dir'] = "/opt/graphite/storage/log"
 default['bcpc']['graphite']['carbon']['storage'] = { 
   "carbon"=>{ "pattern" => "^carbon\\.", "retentions"=>"60:90d" },
   "default"=>{ "pattern" =>".*", "retentions" => "15s:7d,1m:30d,5m:90d" },

--- a/cookbooks/bcpc/recipes/graphite.rb
+++ b/cookbooks/bcpc/recipes/graphite.rb
@@ -179,8 +179,14 @@ bash "graphite-database-sync" do
     notifies :restart, "service[apache2]", :immediately
 end
 
+bash "cleanup-old-whisper-files" do
+  action :run
+  user "root"
+  code "find #{node['bcpc']['graphite']['local_data_dir']} -name *.wsp -mtime +#{node['bcpc']['graphite']['']['retention']} -type f -exec rm {} \\;"
+end
+
 bash "cleanup-old-logs" do
   action :run
   user "root"
-  code "find #{node['bcpc']['graphite']['local_data_dir']} -name *.wsp -mtime +#{node['bcpc']['graphite']['log']['retention']} -type f -exec rm {} \\;"
+  code "find #{node['bcpc']['graphite']['local_log_dir']} -name *.log* -mtime +#{node['bcpc']['graphite']['log']['retention']} -type f -exec rm {} \\;"
 end

--- a/cookbooks/bcpc/templates/default/carbon.conf.erb
+++ b/cookbooks/bcpc/templates/default/carbon.conf.erb
@@ -35,7 +35,7 @@
 #   PID_DIR        = /var/run/
 #
 LOCAL_DATA_DIR = <%= node['bcpc']['graphite']['local_data_dir'] %> 
-
+LOG_DIR =  <%= node['bcpc']['graphite']['local_log_dir'] %>
 # Specify the user to drop privileges to
 # If this is blank carbon runs as the user that invokes it
 # This user must have write access to the local data directory


### PR DESCRIPTION
define a separate resource for log cleanup, separate local_log_dir and local_data_dir settings in attributes/graphite.rb
explicitly defined a LOG_DIR setting in cabon.conf template