### PR TITLE
fix for issue #272

### DIFF
--- a/cookbooks/bcpc/recipes/graphite.rb
+++ b/cookbooks/bcpc/recipes/graphite.rb
@@ -182,11 +182,11 @@ end
 bash "cleanup-old-whisper-files" do
   action :run
   user "root"
-  code "find #{node['bcpc']['graphite']['local_data_dir']} -name *.wsp -mtime +#{node['bcpc']['graphite']['']['retention']} -type f -exec rm {} \\;"
+  code "find #{node['bcpc']['graphite']['local_data_dir']} -name '*.wsp' -mtime +#{node['bcpc']['graphite']['data']['retention']} -type f -exec rm {} \\;"
 end
 
 bash "cleanup-old-logs" do
   action :run
   user "root"
-  code "find #{node['bcpc']['graphite']['local_log_dir']} -name *.wsp -mtime +#{node['bcpc']['graphite']['log']['retention']} -type f -exec rm {} \\;"
+  code "find #{node['bcpc']['graphite']['local_log_dir']} -name '*.log*' -mtime +#{node['bcpc']['graphite']['log']['retention']} -type f -exec rm {} \\;"
 end


### PR DESCRIPTION
Previously a separate resource has been defined to clean up graphite and carbon log files, however the file name pattern was never chnaged