### PR TITLE
jmxtrans run interval set to 15 seconds

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -185,3 +185,7 @@ default['bcpc']['hadoop']['copylog_enable'] = true
 # File rollup interval in secs for log data copied into HDFS through Flume
 #
 default['bcpc']['hadoop']['copylog_rollup_interval'] = 86400
+#
+# Some jmxtrans defaults
+#
+default['jmxtrans']['run_interval'] = "15"


### PR DESCRIPTION
Adjust the default kmxtrans SECONDS_BETWEEN_RUNS to be 15 as opposed to default 60