### PR TITLE
Add missing 'end' to get_group_action method

### DIFF
--- a/cookbooks/bcpc-hadoop/libraries/utils.rb
+++ b/cookbooks/bcpc-hadoop/libraries/utils.rb
@@ -387,3 +387,4 @@ end
 
 def get_group_action(group_name)
   return  group_exists?(group_name) ? :manage : :create 
+end


### PR DESCRIPTION
This PR adds missing `end` to `get_group_action` method. 