### PR TITLE
Start Kerberos services and define static hadoop group mapping

### DIFF
--- a/cookbooks/bach_krb5/recipes/krb5_server.rb
+++ b/cookbooks/bach_krb5/recipes/krb5_server.rb
@@ -13,14 +13,20 @@ end
 
 include_recipe "krb5::kadmin_init"
 
-kdc_resource = resources("service[krb5-kdc]")
-kdc_resource.supports(:status => true, :restart => true, :reload => false)
-kdc_resource.action([:enable, :start])
-kdc_resource.subscribes(:restart, "template #{node['krb5']['data_dir']}/kdc.conf", :delayed) 
+ruby_block 'start_kerberos_services' do
+  block do
+    kdc_resource = run_context.resource_collection.find("service[krb5-kdc]")
+    kdc_resource.supports(:status => true, :restart => true, :reload => false)
+    kdc_resource.action([:enable, :start])
+    kdc_resource.subscribes(:restart, "template #{node['krb5']['data_dir']}/kdc.conf", :delayed)
+    kdc_resource.run_action(:start)
 
-kadm_resource = resources("service[krb5-admin-server]")
-kadm_resource.supports(:status => true, :restart => true, :reload => false)
-kadm_resource.action([:enable, :start])
-kadm_resource.subscribes(:restart, "template node['krb5']['kdc_conf']['realms'][default_realm]['acl_file']", :delayed)
+    kadm_resource = run_context.resource_collection.find("service[krb5-admin-server]")
+    kadm_resource.supports(:status => true, :restart => true, :reload => false)
+    kadm_resource.action([:enable, :start])
+    kadm_resource.subscribes(:restart, "template node['krb5']['kdc_conf']['realms'][default_realm]['acl_file']", :delayed)
+    kadm_resource.run_action(:start)
+  end
+end
 
 include_recipe "bach_krb5::gems"

--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -48,6 +48,16 @@ end
 
 # Create all the resources to add them in resource collection
 node[:bcpc][:hadoop][:os][:group].keys.each do |group_name|
+  node[:bcpc][:hadoop][:os][:group][group_name][:members].each do|user_name|
+    user user_name do
+      home "/var/lib/hadoop-#{user_name}"
+      shell '/bin/bash'
+      system true
+      action :create
+      not_if { user_exists?(user_name) }
+    end
+  end
+
   group group_name do
     append true
     members node[:bcpc][:hadoop][:os][:group][group_name][:members]

--- a/cookbooks/bcpc-hadoop/recipes/journalnode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/journalnode.rb
@@ -61,6 +61,16 @@ end
 
 # Create all the resources to add them in resource collection
 node[:bcpc][:hadoop][:os][:group].keys.each do |group_name|
+  node[:bcpc][:hadoop][:os][:group][group_name][:members].each do|user_name|
+    user user_name do
+      home "/var/lib/hadoop-#{user_name}"
+      shell '/bin/bash'
+      system true
+      action :create
+      not_if { user_exists?(user_name) }
+    end
+  end
+
   group group_name do
     append true
     members node[:bcpc][:hadoop][:os][:group][group_name][:members]

--- a/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
@@ -35,6 +35,16 @@ end
 
 # Create all the resources to add them in resource collection
 node[:bcpc][:hadoop][:os][:group].keys.each do |group_name|
+  node[:bcpc][:hadoop][:os][:group][group_name][:members].each do|user_name|
+    user user_name do
+      home "/var/lib/hadoop-#{user_name}"
+      shell '/bin/bash'
+      system true
+      action :create
+      not_if { user_exists?(user_name) }
+    end
+  end
+
   group group_name do
     append true
     members node[:bcpc][:hadoop][:os][:group][group_name][:members]

--- a/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
@@ -33,6 +33,16 @@ end
 
 # Create all the resources to add them in resource collection
 node[:bcpc][:hadoop][:os][:group].keys.each do |group_name|
+  node[:bcpc][:hadoop][:os][:group][group_name][:members].each do|user_name|
+    user user_name do
+      home "/var/lib/hadoop-#{user_name}"
+      shell '/bin/bash'
+      system true
+      action :create
+      not_if { user_exists?(user_name) }
+    end
+  end
+
   group group_name do
     append true
     members node[:bcpc][:hadoop][:os][:group][group_name][:members]

--- a/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
@@ -31,6 +31,16 @@ end
 
 # Create all the resources to add them in resource collection
 node[:bcpc][:hadoop][:os][:group].keys.each do |group_name|
+  node[:bcpc][:hadoop][:os][:group][group_name][:members].each do|user_name|
+    user user_name do
+      home "/var/lib/hadoop-#{user_name}"
+      shell '/bin/bash'
+      system true
+      action :create
+      not_if { user_exists?(user_name) }
+    end
+  end
+
   group group_name do
     append true
     members node[:bcpc][:hadoop][:os][:group][group_name][:members]

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_core-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_core-site.xml.erb
@@ -116,4 +116,8 @@
     <value>*</value>
   </property>
 
+  <property>
+    <name>hadoop.user.group.static.mapping.overrides</name>
+    <value>hdfs=hadoop,hdfs;yarn=mapred,hadoop;</value>
+  </property>
 </configuration>


### PR DESCRIPTION
In current implementation `kerberos` packages are installed and services are configured using upstream cookbook `krb5`. However, the services are not started by upstream and to be able to configure Kerberization for `Hadoop` cluster services must be started. This PR makes sure that the services are started after `kerberos` packages are installed and `KDC` is configured on bootstrap node. 

Also, this PR adds static group to user mapping for `Hadoop` groups. 