### PR TITLE
patch to wait for chef solr update when adding a new node

### DIFF
--- a/find_resources.rb
+++ b/find_resources.rb
@@ -15,7 +15,8 @@ this_host = Chef::Config[:node_name]
 # load the ohai data of the node 
 include Chef::DSL::DataQuery
 ohai = Ohai::System.new
-data = search(:node,"name:#{ARGV[0]}")[0].node.automatic_attrs
+node_obj = LoadNodeContext.search_node(ARGV[0])
+data = node_obj[0].node.automatic_attrs
 ohai.data = data
 
 # build the node

--- a/load_node_context.rb
+++ b/load_node_context.rb
@@ -19,8 +19,6 @@ module LoadNodeContext
    class << self
      attr_accessor :client_type
      attr_accessor :options
-     attr_accessor :env
-     attr_writer   :editor
    end
 
    def self.start
@@ -33,7 +31,7 @@ module LoadNodeContext
    def self.setup_logger
      Chef::Config[:log_level] ||= :warn
      Chef::Config[:log_level] = :warn if Chef::Config[:log_level] == :auto
-     Chef::Log.init(STDERR)
+     Chef::Log.init(STDOUT)
      Mixlib::Authentication::Log.logger = Ohai::Log.logger = Chef::Log.logger
      Chef::Log.level = Chef::Config[:log_level] || :warn
    end
@@ -45,6 +43,15 @@ module LoadNodeContext
    def self.parse_opts
      @options = Options.new
      @options.parse_opts
+   end
+
+   def self.search_node(node_name)
+     node = nil
+     while node.nil?
+       puts "searching #{ node_name } on chef server..."
+       node = search(:node,"name:#{ node_name }")
+     end
+     return node
    end
 
    class Options


### PR DESCRIPTION
When adding a new node to a cluster, executing C-A-R.sh would get failure because of chef solr still not updated yet for the new node. Making it wait for the chef solr is what the patch does here until it make "chef node search" work. This checking process runs in a loop, jump out only if "chef node search" return not nil value. 