### PR TITLE
fix chef-vault cookbook version issue

### DIFF
--- a/setup_chef_cookbooks.sh
+++ b/setup_chef_cookbooks.sh
@@ -56,7 +56,7 @@ EOF
 cd cookbooks
 
 # allow versions on cookbooks via "cookbook version"
-for cookbook in "apt 2.4.0" python build-essential ubuntu cron "chef-client 4.2.4" chef-vault ntp yum logrotate yum-epel sysctl chef_handler 7-zip "windows 1.36.6" ark sudo ulimit pam ohai "poise 1.0.12" graphite_handler java maven "krb5 2.0.0"; do
+for cookbook in "apt 2.4.0" python build-essential ubuntu cron "chef-client 4.2.4" "chef-vault 1.3.0" ntp yum logrotate yum-epel sysctl chef_handler 7-zip "windows 1.36.6" ark sudo ulimit pam ohai "poise 1.0.12" graphite_handler java maven "krb5 2.0.0"; do
   if [[ ! -d ${cookbook% *} ]]; then
      # unless the proxy was defined this knife config will be the same as the one generated above
     knife cookbook site download $cookbook --config ../.chef/knife.rb


### PR DESCRIPTION
Set chef-vault cookbook used here to be 1.3.0, because version 1.3.1 needs ruby 2.0 support, without it will break the cluster build at cookbook upload stage