### PR TITLE
Remove zabbix-work recipe from the run_list

### DIFF
--- a/roles/BCPC-Hadoop-Head.json
+++ b/roles/BCPC-Hadoop-Head.json
@@ -12,7 +12,6 @@
     "recipe[bcpc::keepalived]",
     "recipe[bcpc::haproxy]",
     "recipe[bcpc::zabbix-head]",
-    "recipe[bcpc::zabbix-work]",
     "recipe[bcpc::diamond]",
     "recipe[bcpc::graphite]",
     "recipe[bcpc::powerdns]",

--- a/roles/BCPC-Hadoop-Worker.json
+++ b/roles/BCPC-Hadoop-Worker.json
@@ -20,7 +20,6 @@
     "recipe[bcpc-hadoop::tez]",
     "recipe[bcpc-hadoop::mahout]",
     "recipe[bcpc-hadoop::oozie_client]",
-    "recipe[bcpc::zabbix-work]",
     "recipe[bcpc::diamond]",
     "recipe[bcpc_jmxtrans]"
   ],


### PR DESCRIPTION
This PR removes `zabbix-work` recipe from the run list of `BCPC-Hadoop-Worker` and BCPC-Hadoop-Head` roles and fixes issue #291
