### PR TITLE
Fix condition checks regarding oozie sharelib dir/lib update

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -14,6 +14,7 @@ default["bcpc"]["repos"]["hdp_utils"] = 'http://public-repo-1.hortonworks.com/HD
 default["bcpc"]["hadoop"]["disks"] = []
 default["bcpc"]["hadoop"]["oozie"]["admins"] = []
 default["bcpc"]["hadoop"]["oozie"]["memory_opts"] = "-Xmx2048m -XX:MaxPermSize=256m"
+default["bcpc"]["hadoop"]["oozie"]["sharelib_checksum"] = nil
 default["bcpc"]["hadoop"]["yarn"]["log-aggregation_retain-seconds"] = 60*60*24*31
 default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["avail_memory"]["ratio"] = 0.5
 default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["avail_memory"]["size"] = nil

--- a/cookbooks/bcpc-hadoop/libraries/utils.rb
+++ b/cookbooks/bcpc-hadoop/libraries/utils.rb
@@ -382,11 +382,11 @@ def group_exists?(group_name)
   chk_grp_cmd = "getent group #{group_name}"
   Chef::Log.debug("Executing command: #{chk_grp_cmd}")
   cmd = Mixlib::ShellOut.new(chk_grp_cmd, :timeout => 10).run_command
-  return  cmd.exitstatus == 0 ? true : false 
+  return cmd.exitstatus == 0 ? true : false 
 end
 
 def get_group_action(group_name)
-  return  group_exists?(group_name) ? :manage : :create 
+  return group_exists?(group_name) ? :manage : :create 
 end
 
 def has_vip?
@@ -394,4 +394,48 @@ def has_vip?
     "ip addr show", :timeout => 10
   ).run_command
   cmd.stderr.empty? && cmd.stdout.include?(node[:bcpc][:management][:vip])
+end
+
+# Internal: Check if oozie server is running on the given host.
+#
+# host - Endpoint (FQDN/IP) on which Oozie server is available.
+#
+# Examples
+#
+#   oozie_running?("f-bcpc-vm2.bcpc.example.com")
+#   # => true
+#
+# Returns true if oozie server is operational with 'NORMAL' status, false otherwise.
+def oozie_running?(host)
+    oozie_url = "sudo -u oozie oozie admin -oozie http://#{host}:11000/oozie -status"
+    cmd = Mixlib::ShellOut.new(
+      oozie_url, :timeout => 20
+    ).run_command
+    Chef::Log.debug("Oozie status: #{cmd.stdout}")
+    cmd.exitstatus == 0 && cmd.stdout.include?('NORMAL')
+end
+
+# Internal: Have the specified Oozie host update its ShareLib to the latest lib_<timestamp> 
+#           sharelib directory on hdfs:/user/oozie/share/lib/, without having to restart 
+#           that Oozie server. Oozie server, by default, uses the latest one when it (re)starts.
+#
+# host - Endpoint (FQDN/IP) on which Oozie server is available.
+#
+# Returns nothing. 
+def update_oozie_sharelib(host)
+  if oozie_running?(host) 
+    update_sharelib = "sudo -u oozie oozie admin -oozie http://#{host}:11000/oozie -sharelibupdate"
+    cmd = Mixlib::ShellOut.new(
+      update_sharelib, :timeout => 20
+    ).run_command
+    if cmd.exitstatus == 0
+      Chef::Log.info("Sharelibupdate: Updated sharelib on #{host}")
+    else
+      Chef::Log.info("Sharelibupdate: sharelibupdate command failed on #{host}")
+      Chef::Log.info("  stdout: #{cmd.stdout}")
+      Chef::Log.info("  stderr: #{cmd.stderr}")
+    end 
+  else
+    Chef::Log.info("Sharelibupdate: Oozie server not running on #{host}")
+  end
 end

--- a/cookbooks/bcpc-hadoop/recipes/oozie.rb
+++ b/cookbooks/bcpc-hadoop/recipes/oozie.rb
@@ -5,7 +5,6 @@ dpkg_autostart "oozie" do
   allow false
 end
 
-#%w{libmysql-java zip unzip extjs hadoop-lzo oozie oozie-client}.each do |pkg|
 %w{zip unzip extjs hadoop-lzo oozie oozie-client}.each do |pkg|
   package pkg do
     action :upgrade
@@ -20,7 +19,8 @@ end
 OOZIE_LIB_PATH='/usr/hdp/current/oozie'
 OOZIE_CLIENT_PATH='/usr/hdp/current/oozie-client'
 OOZIE_SERVER_PATH='/usr/hdp/current/oozie-server/oozie-server'
-HDFS_URL="hdfs://#{node.chef_environment}/"
+OOZIE_SHARELIB_TARBALL_PATH='/usr/hdp/2.2.0.0-2041/oozie/oozie-sharelib.tar.gz'
+HDFS_URL=node[:bcpc][:hadoop][:hdfs_url]
 
 directory "#{OOZIE_LIB_PATH}/libext" do
   owner "oozie"
@@ -37,16 +37,6 @@ directory "/var/run/oozie" do
   action :create
   recursive true
 end
-
-#bash "copy hadoop libs" do
-#  src_dir="/usr/hdp/2.2.0.0-2041/hadoop/lib"
-#  dst_dir="#{OOZIE_LIB_PATH}/libext/"
-#  code "for f in `ls *.jar`; do ln -s #{src_dir}/$f #{dst_dir}/$f; done"
-#  cwd src_dir
-#  user "oozie"
-#  # check if all source files are in destination directory
-#  not_if { (::Dir.entries("#{src_dir}") - ::Dir.entries("#{dst_dir}")).empty? }
-#end
 
 %w{/usr/share/HDP-oozie/ext-2.2.zip
    /usr/share/java/mysql-connector-java.jar
@@ -65,62 +55,21 @@ service "stop-oozie-for-war-setup" do
   supports :status => true, :restart => true, :reload => false
   service_name "oozie"
   supports :status => true, :restart => true, :reload => false
-  only_if {not File.exists?("#{OOZIE_SERVER_PATH}/webapps/oozie.war") or
-           File.mtime("#{OOZIE_CLIENT_PATH}/libext/") > File.mtime("#{OOZIE_SERVER_PATH}/webapps/oozie.war") }
+  only_if {
+    not File.exists?("#{OOZIE_SERVER_PATH}/webapps/oozie.war") or
+    File.mtime("#{OOZIE_CLIENT_PATH}/libext/") >
+      File.mtime("#{OOZIE_SERVER_PATH}/webapps/oozie.war")
+  }
 end
 
 bash "oozie_setup_war" do
-# code "#{OOZIE_LIB_PATH}/bin/oozie-setup.sh prepare-war"
   code "#{OOZIE_CLIENT_PATH}/bin/oozie-setup.sh prepare-war"
-  only_if {not File.exists?("#{OOZIE_SERVER_PATH}/webapps/oozie.war") or
-           File.mtime("#{OOZIE_CLIENT_PATH}/libext/") > File.mtime("#{OOZIE_SERVER_PATH}/webapps/oozie.war") }
   returns [0]
-end
-
-bash "make_shared_libs_dir" do
-  code <<EOH
-  hdfs dfs -mkdir -p #{HDFS_URL}/user/oozie/share/ && \
-  hdfs dfs -chown -R oozie #{HDFS_URL}/user/oozie/
-EOH
-  user "hdfs"
-  not_if "hdfs dfs -test #{HDFS_URL}/user/oozie/share/", :user => "hdfs"
-end
-
-#bash "untar_sharelib_files" do
-#  code <<EOH
-#  cd #{OOZIE_CLIENT_PATH}
-#  tar -xzf oozie-sharelib.tar.gz
-#EOH
-#  not_if { ::File.directory?("#{OOZIE_CLIENT_PATH}/share") }
-#end
-#
-#bash "oozie_create_shared_libs" do
-#  share_dir_url="#{HDFS_URL}/user/oozie/share/"
-#  code "#{OOZIE_CLIENT_PATH}/bin/oozie-setup.sh sharelib create -fs #{HDFS_URL} -locallib /usr/hdp/current/oozie-client/share"
-#  user "oozie"
-#  not_if "hdfs dfs -test -d #{HDFS_URL}/user/oozie/share/lib", :user => "hdfs"
-#end
-
-bash "oozie_update_shared_libs" do
-  share_dir_url="#{HDFS_URL}/user/oozie/share/"
-  #code "#{OOZIE_LIB_PATH}/bin/oozie-setup.sh sharelib update -fs #{HDFS_URL}"
-  code "#{OOZIE_CLIENT_PATH}/bin/oozie-setup.sh sharelib upgrade -fs #{HDFS_URL}"
-  user "oozie"
-  not_if "sudo -u hdfs hdfs dfs -test -d #{HDFS_URL}/user/oozie/share/lib", :user => "hdfs"
-  only_if "echo 'test'|sudo -u hdfs hdfs dfs -copyFromLocal - /tmp/oozie-test"
-  notifies :run,"bash[delete-oozie-temp-file]",:immediately
-  #not_if { require 'time'
-  # hdfs_mtime=`hdfs dfs -stat #{share_dir_url}`.strip
-  # Time.parse("#{hdfs_mtime} UTC") >
-  # File.mtime("#{OOZIE_CLIENT_PATH}/oozie-sharelib.tar.gz") }
-end
-
-bash "delete-oozie-temp-file" do
-  code <<-EOH
-    hdfs dfs -rm /tmp/oozie-test
-  EOH
-  user "hdfs"
-  action :nothing
+  only_if {
+    not File.exists?("#{OOZIE_SERVER_PATH}/webapps/oozie.war") or
+    File.mtime("#{OOZIE_CLIENT_PATH}/libext/") >
+      File.mtime("#{OOZIE_SERVER_PATH}/webapps/oozie.war")
+  }
 end
 
 directory "/etc/oozie/conf.#{node.chef_environment}/action-conf" do
@@ -139,6 +88,46 @@ directory "/etc/oozie/conf.#{node.chef_environment}/hadoop-conf" do
   recursive true
 end
 
+bash "make_oozie_user_dir" do
+  code <<-EOH
+    hdfs dfs -mkdir -p #{HDFS_URL}/user/oozie && \
+    hdfs dfs -chown -R oozie #{HDFS_URL}/user/oozie
+  EOH
+  user "hdfs"
+  not_if "hdfs dfs -test -d #{HDFS_URL}/user/oozie", :user => "hdfs"
+end
+
+bash "oozie_create_shared_libs" do
+  code "#{OOZIE_CLIENT_PATH}/bin/oozie-setup.sh sharelib create -fs #{HDFS_URL} -locallib #{OOZIE_SHARELIB_TARBALL_PATH}"
+  user "oozie"
+  not_if {
+    require 'digest'
+    chksum = node[:bcpc][:hadoop][:oozie][:sharelib_checksum]
+    not chksum.nil? and Digest::MD5.hexdigest(File.read(OOZIE_SHARELIB_TARBALL_PATH)) == chksum
+  } 
+  only_if "echo 'test'| hdfs dfs -copyFromLocal - /tmp/oozie-test && hdfs dfs -rm -skipTrash /tmp/oozie-test", :user => "hdfs"
+  notifies :run, "ruby_block[update_sharelib_checksum]", :immediately
+end
+
+ruby_block "update_sharelib_checksum" do
+  block do
+    require 'digest'
+    node.set[:bcpc][:hadoop][:oozie][:sharelib_checksum] = 
+      Digest::MD5.hexdigest(File.read(OOZIE_SHARELIB_TARBALL_PATH))
+  end
+  action :nothing
+  notifies :run, "ruby_block[notify_sharelib_update]", :immediately
+end
+
+ruby_block "notify_sharelib_update" do
+  block do
+    node[:bcpc][:hadoop][:oozie_hosts].each do |oozie_host|
+      update_oozie_sharelib(float_host(oozie_host[:hostname]))
+    end
+  end
+  action :nothing
+end
+
 template "/etc/oozie/conf.#{node.chef_environment}/action-conf/hive.xml" do
   mode 0644
   source "ooz_action_hive.xml.erb"
@@ -155,15 +144,14 @@ ruby_block "oozie-database-creation" do
   block do
     if not system " #{cmd} 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"oozie\"' | grep oozie" then
       code = <<-EOF
-                CREATE DATABASE oozie;
-                GRANT #{privs} ON oozie.* TO 'oozie'@'%' IDENTIFIED BY '#{get_config('mysql-oozie-password')}';
-                GRANT #{privs} ON oozie.* TO 'oozie'@'localhost' IDENTIFIED BY '#{get_config('mysql-oozie-password')}';
-                FLUSH PRIVILEGES;
+        CREATE DATABASE oozie;
+        GRANT #{privs} ON oozie.* TO 'oozie'@'%' IDENTIFIED BY '#{get_config('mysql-oozie-password')}';
+        GRANT #{privs} ON oozie.* TO 'oozie'@'localhost' IDENTIFIED BY '#{get_config('mysql-oozie-password')}';
+        FLUSH PRIVILEGES;
       EOF
       IO.popen("mysql -uroot -p#{get_config!('password','mysql-root','os')}", "r+") do |db|
         db.write code
       end
-      #system "sudo -u oozie #{OOZIE_CLIENT_PATH}/bin/ooziedb.sh create -sqlfile #{OOZIE_CLIENT_PATH}/oozie.sql -run Validate DB Connection"
       system "sudo -u oozie /usr/hdp/current/oozie-server/bin/ooziedb.sh create -sqlfile /usr/hdp/current/oozie-server/oozie.sql -run Validate DB Connection"
       self.resolve_notification_references
     end
@@ -181,20 +169,16 @@ end
 ruby_block "Oozie Down" do
   i = 0
   block do
-    status=`sudo -u oozie oozie admin -oozie http://"#{float_host(node[:fqdn])}":11000/oozie -status 2>&1` 
-    while not /NORMAL/ =~ status and $?.to_i
-      status=`sudo -u oozie oozie admin -oozie http://"#{float_host(node[:fqdn])}":11000/oozie -status 2>&1` 
-      if $?.to_i != 0 and i < 10
+    while not oozie_running?(float_host(node[:fqdn])) 
+      if i < 10
         sleep(0.5)
         i += 1
-        Chef::Log.debug("Oozie is down - #{status}")
-      elsif $?.to_i != 0
-        raise Chef::Application.fatal! "Oozie is reported as down for more than 5 seconds -- #{status}"
+        Chef::Log.debug("Oozie is down")
       else
-        Chef::Log.debug("Oozie status is not failing - #{status}")
+        raise Chef::Application.fatal! "Oozie is reported as down for more than 5 seconds"
       end
     end
-    Chef::Log.debug("Oozie is up - #{status}")
+    Chef::Log.debug("Oozie is up")
   end
-  not_if "sudo -u oozie oozie admin -oozie http://#{float_host(node[:fqdn])}:11000/oozie -status"
+  not_if { oozie_running?(float_host(node[:fqdn])) }
 end


### PR DESCRIPTION
I observed on a test VM cluster that a new oozie sharelib directory (hdfs:///user/oozie/share/lib/lib_<timestamp>) was created on every chef-client run. This PR fixes a few conditional errors in the code which manages the sharelib directory.

Fixes Issue #178 