### PR TITLE
Move sqoop material into its own cookbook

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,29 @@
+# -*- mode: enh-ruby -*-
+source "https://supermarket.chef.io"
+
+metadata
+
+cookbook 'bach_bootstrap', path: "./cookbooks/bach_bootstrap"
+cookbook 'bach_common', path: "./cookbooks/bach_common"
+cookbook 'bach_repository', path: "./cookbooks/bach_repository"
+cookbook 'bach_spark', path: "./cookbooks/bach_spark"
+cookbook 'bach_sqoop', path: "./cookbooks/bach_sqoop"
+cookbook 'bcpc', path: "./cookbooks/bcpc"
+cookbook 'bcpc-hadoop', path: "./cookbooks/bcpc-hadoop"
+cookbook 'bcpc_jmxtrans', path: "./cookbooks/bcpc_jmxtrans"
+cookbook 'hannibal', path: "./cookbooks/hannibal"
+cookbook 'kafka-bcpc', path: "./cookbooks/kafka-bcpc"
+
+# chef-vault forked, pending acceptance of a PR.
+cookbook 'chef-vault',
+  git: 'https://github.com/http-418/chef-vault'
+
+# cobblerd 0.3.0 isn't on the supermarket.
+cookbook 'cobblerd', 
+  git: 'https://github.com/bloomberg/cobbler-cookbook',
+  revision: '868334b4b4d3c760e9669a0adba0279e89d523bc'
+
+# jmxtrans 1.0+ isn't on the supermarket.
+cookbook 'jmxtrans', 
+  git: 'https://github.com/jmxtrans/jmxtrans-cookbook',
+  revision: 'd8ee2396eca91ef8e0e558490bde075869b787de'

--- a/cookbooks/bach_sqoop/README.md
+++ b/cookbooks/bach_sqoop/README.md
@@ -16,15 +16,11 @@ Only a default recipe is included.  The default recipe installs Sqoop, creates i
 Attributes
 ==========
 
-<ol>
-  <li>node[:bach][:sqoop][:install_dir]<br/>
-    <p>The Sqoop install directory.  Default: <tt>/usr/lib/sqoop</tt></p>
-  </li>
-  <li>node[:bach][:sqoop][:install_dir]<br/>
-    <p>The Sqoop library directory, where JDBC jars will be installed. Default: <tt>/usr/lib/sqoop/lib</tt></p>
-  </li>
-  <li>node[:bach][:sqoop][:jdbc_jars]<br/>
-    <p>This attribute is a hash.  The keys are the filenames for JDBC jars.  Each value is another hash, containing an 'url' key and a 'checksum' key.</p>
-	<p>See <tt>attributes/default.rb</tt> for an example value.</p>
-  </li>
-</ol>
+1. node[:bach][:sqoop][:install_dir]
+The Sqoop install directory.  Default: <tt>/usr/lib/sqoop</tt>
+
+2. node[:bach][:sqoop][:install_dir]
+The Sqoop library directory, where JDBC jars will be installed. Default: <tt>/usr/lib/sqoop/lib</tt>
+
+3. node[:bach][:sqoop][:jdbc_jars]
+This attribute is a hash.  The keys are the filenames for JDBC jars.  Each value is another hash, containing an 'url' key and a 'checksum' key. See <tt>attributes/default.rb</tt> for an example value.

--- a/cookbooks/bach_sqoop/README.md
+++ b/cookbooks/bach_sqoop/README.md
@@ -1,0 +1,1 @@
+Cookbook to install Apache Sqoop on data nodes.

--- a/cookbooks/bach_sqoop/README.md
+++ b/cookbooks/bach_sqoop/README.md
@@ -1,1 +1,30 @@
-Cookbook to install Apache Sqoop on data nodes.
+Overview
+========
+
+This cookbook installs Apache Sqoop and needed JDBC jars. The Sqoop packages come from Hortonworks via 'apt'.  JDBC jars are downloaded directly.
+
+Requirements
+============
+
+This cookbook has been tested with Chef 11 and 12.
+
+Recipes
+=======
+
+Only a default recipe is included.  The default recipe installs Sqoop, creates its library directory, and installs any JDBC jars to the library directory.
+
+Attributes
+==========
+
+<ol>
+  <li>node[:bach][:sqoop][:install_dir]<br/>
+    <p>The Sqoop install directory.  Default: <tt>/usr/lib/sqoop</tt></p>
+  </li>
+  <li>node[:bach][:sqoop][:install_dir]<br/>
+    <p>The Sqoop library directory, where JDBC jars will be installed. Default: <tt>/usr/lib/sqoop/lib</tt></p>
+  </li>
+  <li>node[:bach][:sqoop][:jdbc_jars]<br/>
+    <p>This attribute is a hash.  The keys are the filenames for JDBC jars.  Each value is another hash, containing an 'url' key and a 'checksum' key.</p>
+	<p>See <tt>attributes/default.rb</tt> for an example value.</p>
+  </li>
+</ol>

--- a/cookbooks/bach_sqoop/attributes/default.rb
+++ b/cookbooks/bach_sqoop/attributes/default.rb
@@ -1,0 +1,33 @@
+#
+# Copyright 2015, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default[:bach][:sqoop][:install_dir] = '/usr/lib/sqoop'
+
+default[:bach][:sqoop][:lib_dir] =
+  default[:bach][:sqoop][:install_dir] + '/lib'
+
+# Place JDBC jars in this hash.
+# They will be installed to the sqoop lib_dir.
+default[:bach][:sqoop][:jdbc_jars] =
+  {
+   'mysql-connector-java.jar' =>
+     {
+      'url' =>
+        'http://search.maven.org/remotecontent?filepath=mysql/mysql-connector-java/5.1.36/mysql-connector-java-5.1.36.jar',
+      'checksum' =>
+        '7ba5290be5844b5bbdae3e4bee7e6a86b62b5feeacd224b60e66530df40a307a'
+     }                                   
+  }

--- a/cookbooks/bach_sqoop/attributes/default.rb
+++ b/cookbooks/bach_sqoop/attributes/default.rb
@@ -31,3 +31,5 @@ default[:bach][:sqoop][:jdbc_jars] =
         '7ba5290be5844b5bbdae3e4bee7e6a86b62b5feeacd224b60e66530df40a307a'
      }                                   
   }
+
+default[:bach][:sqoop][:zookeeper_conf_dir] = '/etc/zookeeper/conf'

--- a/cookbooks/bach_sqoop/metadata.rb
+++ b/cookbooks/bach_sqoop/metadata.rb
@@ -2,7 +2,7 @@
 
 name             'bach_sqoop'
 maintainer       'Bloomberg Finance L.P.'
-description      'Cookbook to setup Apache Spark'
+description      'Cookbook to setup Apache Sqoop'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 

--- a/cookbooks/bach_sqoop/metadata.rb
+++ b/cookbooks/bach_sqoop/metadata.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+
+name             'bach_sqoop'
+maintainer       'Bloomberg Finance L.P.'
+description      'Cookbook to setup Apache Spark'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'
+
+%w(ubuntu).each do |os|
+  supports os
+end

--- a/cookbooks/bach_sqoop/recipes/default.rb
+++ b/cookbooks/bach_sqoop/recipes/default.rb
@@ -1,0 +1,49 @@
+#
+# Cookbook Name:: bach_sqoop
+# Recipe:: default
+#
+# Copyright 2015, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package 'sqoop' do
+  action [:install, :upgrade]
+end
+
+# Install Sqoop Bits
+template "/etc/sqoop/conf/sqoop-env.sh" do
+  source "sq_sqoop-env.sh.erb"
+  mode "0444"
+  action :create
+end
+
+directory node[:bach][:sqoop][:install_dir] do
+  action :create
+  mode 0555
+end
+
+directory node[:bach][:sqoop][:lib_dir] do
+  action :create
+  mode 0555
+end
+
+# Download any JDBC jars required for database connectivity.
+jdbc_hash = node[:bach][:sqoop][:jdbc_jars]
+jdbc_hash.keys.each do|jar_file|
+  remote_file node[:bach][:sqoop][:lib_dir] + '/' + jar_file do
+    source jdbc_hash[jar_file]['url']
+    checksum jdbc_hash[jar_file]['checksum']
+    mode 0444
+  end
+end

--- a/cookbooks/bach_sqoop/templates/default/sq_sqoop-env.sh.erb
+++ b/cookbooks/bach_sqoop/templates/default/sq_sqoop-env.sh.erb
@@ -34,9 +34,7 @@ export HBASE_HOME=/usr/lib/hbase
 export HIVE_HOME=/usr/lib/hive
 
 #Set the path for where zookeper config dir is
-<% if (node[:bcpc][:hadoop][:zookeeper][:conf_dir] rescue nil) %>
 export ZOOCFGDIR=<%= node[:bcpc][:hadoop][:zookeeper][:conf_dir] %>
-<% end %>
 
 # add libthrift in hive to sqoop class path first so hive imports work
 export SQOOP_USER_CLASSPATH="`ls ${HIVE_HOME}/lib/libthrift-*.jar 2> /dev/null`:${SQOOP_USER_CLASSPATH}"

--- a/cookbooks/bach_sqoop/templates/default/sq_sqoop-env.sh.erb
+++ b/cookbooks/bach_sqoop/templates/default/sq_sqoop-env.sh.erb
@@ -1,4 +1,6 @@
- Licensed to the Apache Software Foundation (ASF) under one or more
+# -*- mode: shell-script -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0
@@ -32,7 +34,9 @@ export HBASE_HOME=/usr/lib/hbase
 export HIVE_HOME=/usr/lib/hive
 
 #Set the path for where zookeper config dir is
+<% if (node[:bcpc][:hadoop][:zookeeper][:conf_dir] rescue nil) %>
 export ZOOCFGDIR=<%= node[:bcpc][:hadoop][:zookeeper][:conf_dir] %>
+<% end %>
 
 # add libthrift in hive to sqoop class path first so hive imports work
 export SQOOP_USER_CLASSPATH="`ls ${HIVE_HOME}/lib/libthrift-*.jar 2> /dev/null`:${SQOOP_USER_CLASSPATH}"

--- a/cookbooks/bcpc-hadoop/metadata.rb
+++ b/cookbooks/bcpc-hadoop/metadata.rb
@@ -7,6 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.1.0"
 
 depends "bcpc", ">= 0.5.0"
+depends "bach_sqoop"
 depends "dpkg_autostart"
 depends "sysctl"
 depends "pam"

--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -161,7 +161,9 @@ if node[:bcpc][:hadoop][:mounts].length <= node[:bcpc][:hadoop][:hdfs][:failed_v
   Chef::Application.fatal!("You have fewer #{node[:bcpc][:hadoop][:disks]} than #{node[:bcpc][:hadoop][:hdfs][:failed_volumes_tolerated]}! See comments of HDFS-4442.")
 end
 
-# Sqoop.
+# Add Sqoop.
+node.default[:bach][:sqoop][:zookeeper_conf_dir] = 
+  node[:bcpc][:hadoop][:zookeeper][:conf_dir]
 include_recipe 'bach_sqoop'
 
 # Build nodes for HDFS storage

--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -10,7 +10,6 @@ node.default['bcpc']['hadoop']['copylog']['datanode'] = {
    hadoop-hdfs-datanode
    hadoop-mapreduce
    hadoop-client
-   sqoop
    lzop
    hadoop-lzo}.each do |pkg|
   package pkg do
@@ -134,13 +133,6 @@ bash "verify-container-executor" do
   only_if { File.exists?("/usr/lib/hadoop-yarn/bin/container-executor") }
 end
 
-# Install Sqoop Bits
-template "/etc/sqoop/conf/sqoop-env.sh" do
-  source "sq_sqoop-env.sh.erb"
-  mode "0444"
-  action :create
-end
-
 # Install Hive Bits
 # workaround for hcatalog dpkg not creating the hcat user it requires
 user "hcat" do 
@@ -168,6 +160,9 @@ end
 if node[:bcpc][:hadoop][:mounts].length <= node[:bcpc][:hadoop][:hdfs][:failed_volumes_tolerated]
   Chef::Application.fatal!("You have fewer #{node[:bcpc][:hadoop][:disks]} than #{node[:bcpc][:hadoop][:hdfs][:failed_volumes_tolerated]}! See comments of HDFS-4442.")
 end
+
+# Sqoop.
+include_recipe 'bach_sqoop'
 
 # Build nodes for HDFS storage
 node[:bcpc][:hadoop][:mounts].each do |i|


### PR DESCRIPTION
This PR moves the sqoop installation from bcpc::data-node to its own cookbook, bach_sqoop.

It also adds support for installing JDBC jar files into Sqoop's lib directory from arbitrary URLs.  The list of URLs and checksums is communicated via node attributes.