### PR TITLE
Graphite to zabbix optimization

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/monitoring.rb
+++ b/cookbooks/bcpc-hadoop/attributes/monitoring.rb
@@ -4,6 +4,10 @@ default["bcpc"]["hadoop"]["zabbix"]["cron_check_time"] = 240
 default["bcpc"]["hadoop"]["zabbix"]["mail_source"] = "zabbix.zbx_mail.sh.erb"
 default["bcpc"]["hadoop"]["zabbix"]["cookbook"] = nil 
 
+# Interval within which chef-client is expected to run
+default["bcpc"]["hadoop"]["zabbix"]["chef_client_check_interval"] =
+  "#{((node['chef_client']['interval'].to_i + node['chef_client']['splay'].to_i) * 2 / 60).ceil}m"
+
 # Override Graphite/Zabbix queries/triggers here
 default["bcpc"]["hadoop"]["graphite"]["basic_queries"] = {} # Basic OS/Node Queries
 default["bcpc"]["hadoop"]["graphite"]["service_queries"] = {} # Service specific queries

--- a/cookbooks/bcpc-hadoop/files/default/query_graphite.py
+++ b/cookbooks/bcpc-hadoop/files/default/query_graphite.py
@@ -5,53 +5,53 @@ import json
 import sys
 
 def query_graphite(url):
-    """Function to make query to graphite to retrive monitoring data
-    Returns data for the query in json format. Refer document
-    http://graphite.readthedocs.org/en/1.0/url-api.html for details
-    Accepts url formatted to make a query to graphite. Time out to get
-    a valid response from graphite URL is 30 seconds 
-    Keyword arguments:
-    url: graphite jsp api url along with the query parameter 
-    """
-    req = urllib2.Request(url)
-    response = urllib2.urlopen(req,timeout=30)
-    res = response.read()
-    data = json.loads(res)
-    return data
+  """Function to make query to graphite to retrive monitoring data
+  Returns data for the query in json format. Refer document
+  http://graphite.readthedocs.org/en/1.0/url-api.html for details
+  Accepts url formatted to make a query to graphite. Time out to get
+  a valid response from graphite URL is 30 seconds
+  Keyword arguments:
+  url: graphite jsp api url along with the query parameter
+  """
+  req = urllib2.Request(url)
+  response = urllib2.urlopen(req,timeout=30)
+  res = response.read()
+  data = json.loads(res)
+  return data
 
 def write_data(zbxhost, zbxkey, data):
-    """Function to parse the json object retruned by graphite query
-    and generate data in the format zabbix_sender protocol needs
-    Refer to zabbix sender man pages for details.
-    https://www.zabbix.com/documentation/1.8/manpages/zabbix_sender
-    Accepts host name defined in zabbix, the zabbix item defined in
-    the zabbix host to which the data corresponds to  and the data 
-    Keyword arguments:
-    zbxhost: the zabbix host name to which the data will be attached to
-    zbxkey: the zabbix key to which the data will be attached to
-    data: json data returned from querying graphite. Sample data
-    [{   
-      "target": "entries",
-        "datapoints": [
-          [1.0, 1311836008],
-          [2.0, 1311836009]
-        ]
-    }]
-    """
-    for entry in data:
-        for key,value in entry.iteritems():
-            if key == 'datapoints':
-               for v in value:
-                 if (v[0] is None):
-                   val = '0'
-                 else:
-                   val = str(v[0])
-                 out = "%s %s %s %s" % (zbxhost,zbxkey,str(v[1]),val)
-                 sys.stdout.write(out+'\n')
+  """Function to parse the json object retruned by graphite query
+  and generate data in the format zabbix_sender protocol needs
+  Refer to zabbix sender man pages for details.
+  https://www.zabbix.com/documentation/1.8/manpages/zabbix_sender
+  Accepts host name defined in zabbix, the zabbix item defined in
+  the zabbix host to which the data corresponds to  and the data
+  Keyword arguments:
+  zbxhost: the zabbix host name to which the data will be attached to
+  zbxkey: the zabbix key to which the data will be attached to
+  data: json data returned from querying graphite. Sample data
+  [{
+    "target": "entries",
+      "datapoints": [
+        [1.0, 1311836008],
+        [2.0, 1311836009]
+      ]
+  }]
+  """
+  for entry in data:
+    for key,value in entry.iteritems():
+      if key == 'datapoints':
+        for v in value:
+          if (v[0] is None):
+            val = 0.0
+          else:
+            val = v[0]
+          out = "%s %s %s %0.1f" % (zbxhost,zbxkey,str(v[1]),val)
+          sys.stdout.write(out+'\n')
 
 if __name__ == "__main__":
-    with open("/usr/local/etc/query_graphite.config","r") as fin:
-        config = json.load(fin)
-        for entry in config["queries"]:
-            graphite_data=query_graphite(entry["graphite_url"])
-            write_data(entry["zabbix_host"],entry["zabbix_key"],graphite_data)
+  with open("/usr/local/etc/query_graphite.config","r") as fin:
+    config = json.load(fin)
+    for entry in config["queries"]:
+      graphite_data=query_graphite(entry["graphite_url"])
+      write_data(entry["zabbix_host"],entry["zabbix_key"],graphite_data)

--- a/cookbooks/bcpc-hadoop/libraries/utils.rb
+++ b/cookbooks/bcpc-hadoop/libraries/utils.rb
@@ -388,3 +388,10 @@ end
 def get_group_action(group_name)
   return  group_exists?(group_name) ? :manage : :create 
 end
+
+def has_vip?
+  cmd = Mixlib::ShellOut.new(
+    "ip addr show dev #{node[:bcpc][:management][:interface]}", :timeout => 10
+  ).run_command
+  cmd.stderr.empty? && cmd.stdout.include?(node[:bcpc][:management][:vip])
+end

--- a/cookbooks/bcpc-hadoop/recipes/graphite_queries.rb
+++ b/cookbooks/bcpc-hadoop/recipes/graphite_queries.rb
@@ -1,18 +1,37 @@
 # Get a list of cluster nodes to monitor
 monitored_nodes_objs = get_all_nodes.select { |n| not n.hostname =~ /bootstrap/ }.compact
 
-# Graphite queries which specify property to query and alarming trigger, severity(maps to zabbix's api -> trigger -> priority)
-# and owner who the trigger is routed to for resolution
-# Queries are structured as they appear in graphite dashboard
-# Refer Zabbix API(https://www.zabbix.com/documentation/2.2/manual/api/reference/) for the various attributes used
-# The following list is supposed to be a skeleton which should be extended/edited according to the deployment scenario
-# By default items, triggers actions are disabled and won't be monitored. To enable them, set "enable=true" in the json structure
-triggers = {}
+# Graphite queries which specify property to query and alarming trigger,
+# severity(maps to zabbix's api -> trigger -> priority)and owner who the
+# trigger is routed to for resolution. Queries are structured as they appear in
+# graphite dashboard.
+# Refer Zabbix API(https://www.zabbix.com/documentation/2.2/manual/api/reference/)
+# for the various attributes used. The following list is supposed to be a
+# skeleton which should be extended/edited according to the deployment scenario
+# By default items, triggers actions are disabled and won't be monitored.
+# To enable them, set "enable=true" in the json structure
+triggers = {
+  'bcpc-bootstrap' => {
+    'chef_client_success_bcpc-bootstrap' => {
+      'type' => "chef",
+      'query' => "success",
+      'trigger_val' => "max(#{node["bcpc"]["hadoop"]["zabbix"]["chef_client_check_interval"]}, 0)",
+      'trigger_cond' => "=0",
+      'trigger_name' => "bcpc-bootstrap_ChefClientFailure",
+      'enable' => true,
+      'trigger_desc' => "Chef-client seems to be failing/stopped",
+      'severity' => 2,
+      'route_to' => "admin"
+    }
+  }
+}
+
 monitored_nodes_objs.each do |node_obj|
   host = node_obj.hostname
   # Copy overrrides
-  if not node_obj["bcpc"]["hadoop"]["graphite"].nil? and not node_obj["bcpc"]["hadoop"]["graphite"]["basic_queries"].nil? and not node_obj["bcpc"]["hadoop"]["graphite"]["basic_queries"].empty?
-    #triggers[host] = JSON.parse(node_obj["bcpc"]["hadoop"]["graphite"]["basic_queries"].to_json)
+  if not node_obj["bcpc"]["hadoop"]["graphite"].nil? and
+    not node_obj["bcpc"]["hadoop"]["graphite"]["basic_queries"].nil? and
+    not node_obj["bcpc"]["hadoop"]["graphite"]["basic_queries"].empty?
     triggers[host] = node_obj["bcpc"]["hadoop"]["graphite"]["basic_queries"].dup
   else
     triggers[host] = {}
@@ -36,10 +55,12 @@ monitored_nodes_objs.each do |node_obj|
     triggers[host]["chef_client_success_#{host}"] = {
       'type' => "chef",
       'query' => "success",
-      'trigger_val' => "max(#{((node['chef_client']['interval'].to_i + node['chef_client']['splay'].to_i) / 30).ceil}m, 0)",
-      'value_type' => 3,
+      'trigger_val' => "max(" +
+        "#{node["bcpc"]["hadoop"]["zabbix"]["chef_client_check_interval"]}, 0" +
+      ")",
+      'value_type' => 0,
       'trigger_cond' => "=0",
-      'trigger_name' => "#{host}_ChefClientSuccess",
+      'trigger_name' => "#{host}_ChefClientFailure",
       'trigger_dep' => ["#{host}_NodeAvailability"],
       'enable' => true,
       'trigger_desc' => "Chef-client seems to be failing/stopped",
@@ -49,20 +70,33 @@ monitored_nodes_objs.each do |node_obj|
   end
 
   # Fetch disks for this node.
-  # Use the same logic as diamond(https://github.com/python-diamond/Diamond/blob/master/src/collectors/diskspace/diskspace.py#L137-L165)
+  # Use the same logic as diamond (https://github.com/python-diamond/Diamond/..
+  # ..blob/master/src/collectors/diskspace/diskspace.py#L137-L165)
   # to filter out unwanted disks/mounts
-  disk_size_hash = node_obj.filesystem.map { |fs,props| [props['mount'],props['kb_size']] }.compact.uniq
-  disk_size_hash = disk_size_hash.reject{ |mount,kb_size| kb_size.nil? }.reject{ |mount,kb_size| mount.start_with?('/dev') || mount.start_with?('/sys') || mount.start_with?('/proc') || mount.start_with?('/run') || mount.start_with?('/boot') }
-  # Format the mount names like diamond(https://github.com/python-diamond/Diamond/blob/master/src/collectors/diskspace/diskspace.py#L196-L197) and convert size to GB
-  disk_size_hash = disk_size_hash.map{ |mount,kb_size| tmp = mount.gsub('/', '_').gsub('.', '_').gsub('\\', ''); [tmp == '_' ? 'root':tmp, (kb_size.to_i / 1024 / 1024).ceil] }
-  
+  disk_size_hash = node_obj.filesystem
+    .map { |fs,props| [props['mount'],props['kb_size']] }.compact.uniq
+  disk_size_hash = disk_size_hash.reject { |mount,kb_size| kb_size.nil? }
+    .reject {
+      |mount,kb_size| mount.start_with?('/dev') || mount.start_with?('/sys') ||
+      mount.start_with?('/proc') || mount.start_with?('/run') ||
+      mount.start_with?('/boot') || mount.start_with?('/tmp')
+    }
+
+  # Format the mount names like diamond (https://github.com/python-diamond/..
+  # ..Diamond/blob/master/src/collectors/diskspace/diskspace.py#L196-L197)
+  # and convert size to GB
+  disk_size_hash = disk_size_hash.map {
+    |mount,kb_size| tmp = mount.gsub('/', '_').gsub('.', '_').gsub('\\', '');
+    [tmp == '_' ? 'root':tmp, (kb_size.to_f / 1024.0 / 1024.0).round(2)]
+  }
+
   disk_size_hash.each do |disk,size|
     if triggers[host]["#{disk}_space_avail_#{host}"].nil?
       triggers[host]["#{disk}_space_avail_#{host}"] = {
         'type' => "servers",
         'query' => "diskspace.#{disk}.byte_avail",
         'trigger_val' => "max(61,0)",
-        'value_type' => 3,
+        'value_type' => 0,
         'trigger_cond' => "=0",
         'trigger_name' => "#{host}_#{disk}_Availability",
         'trigger_dep' => ["#{host}_NodeAvailability"],
@@ -72,17 +106,17 @@ monitored_nodes_objs.each do |node_obj|
         'route_to' => "admin"
       }
     end
-    
+
     if triggers[host]["#{disk}_space_used_#{host}"].nil?
       triggers[host]["#{disk}_space_used_#{host}"] = {
         'type' => "servers",
         'query' => "diskspace.#{disk}.byte_used",
         'trigger_val' => "max(61,0)",
-        'value_type' => 3,
-        'trigger_cond' => ">#{(size * 0.80).floor}G",
+        'value_type' => 0,
+        'trigger_cond' => ">#{(size * 0.90).round(2)}G",
         'trigger_name' => "#{host}_#{disk}_SpaceUsed",
         'enable' => true,
-        'trigger_desc' => "More than 80% of disk space used",
+        'trigger_desc' => "More than 90% of disk space used",
         'severity' => 3,
         'route_to' => "tenant"
       }
@@ -90,13 +124,15 @@ monitored_nodes_objs.each do |node_obj|
   end # End of "disk_size_hash.each do |disk,size|"
 
   # Copy service specific queries
-  if not node_obj["bcpc"]["hadoop"]["graphite"].nil? and not node_obj["bcpc"]["hadoop"]["graphite"]["service_queries"].nil? and not node_obj["bcpc"]["hadoop"]["graphite"]["service_queries"].empty?
+  if not node_obj["bcpc"]["hadoop"]["graphite"].nil? and
+    not node_obj["bcpc"]["hadoop"]["graphite"]["service_queries"].nil? and
+    not node_obj["bcpc"]["hadoop"]["graphite"]["service_queries"].empty?
     node_obj["bcpc"]["hadoop"]["graphite"]["service_queries"].each do |s_host, s_query|
       triggers[s_host] = node_obj["bcpc"]["hadoop"]["graphite"]["service_queries"][s_host]
     end    
   end
 end # End of "monitored_nodes_objs.each do |node_obj|"
 
-# Save the trigger information in node's run_state so it is available for the recipe which
-# creates objects in Zabbix
+# Save the trigger information in node's run_state so it is available for
+# the recipe which creates objects in Zabbix
 node.run_state["zabbix_triggers"] = triggers

--- a/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
+++ b/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
@@ -7,12 +7,13 @@ end
 
 directory ::File.dirname(node['bcpc']['zabbix']['scripts']['mail']) do
   recursive true
-  owner 'root' 
+  owner 'root'
 end
 
 template node['bcpc']['zabbix']['scripts']['mail'] do
   source node["bcpc"]["hadoop"]["zabbix"]["mail_source"]
-  cookbook node["bcpc"]["hadoop"]["zabbix"]["cookbook"] if node["bcpc"]["hadoop"]["zabbix"]["cookbook"]
+  cookbook node["bcpc"]["hadoop"]["zabbix"]["cookbook"] if
+    node["bcpc"]["hadoop"]["zabbix"]["cookbook"]
   mode 0755
 end
 
@@ -33,18 +34,24 @@ end
 ruby_block "zabbix_monitor" do
   block do
     require 'zabbixapi'
-    
+
     # Make connection to zabbix api url
-    zbx=ZabbixApi.connect(:url => "https://#{node['bcpc']['management']['vip']}:#{node['bcpc']['zabbix']['web_port']}/api_jsonrpc.php", 
-                          :user => 'admin', 
-                          :password => "#{get_config!('password','zabbix-admin','os')}")
+    zbx = ZabbixApi.connect(
+      :url => "https://#{node['bcpc']['management']['vip']}" +
+        ":#{node['bcpc']['zabbix']['web_port']}/api_jsonrpc.php",
+      :user => 'admin',
+      :password => "#{get_config!('password','zabbix-admin','os')}"
+    )
     if zbx.nil?
       Chef::Log.error("Could not connect to Zabbix server")
       raise "Could not connect to Zabbix server"
     end
 
     # Fetch graphite hosts
-    graphite_hosts = (get_node_attributes(MGMT_IP_ATTR_SRCH_KEYS,"graphite","bcpc").map {|v| v['mgmt_ip']}).join(",")
+    graphite_hosts = get_node_attributes(
+      MGMT_IP_ATTR_SRCH_KEYS, "graphite", "bcpc"
+    ).map { |v| v['mgmt_ip'] }.join(",")
+
     if graphite_hosts.empty?
       Chef::Log.error("No graphite hosts found")
       raise "No graphite hosts found"
@@ -53,138 +60,246 @@ ruby_block "zabbix_monitor" do
     #cron_check_cond = Array.new
 
     # Create zabbix host group same as the chef environment name
-    if zbx.hostgroups.get_id(:name => "#{node.chef_environment}").nil?
-      zbx.hostgroups.create(:name => "#{node.chef_environment}")
+    hostgroup_id = zbx.hostgroups.get_id(:name => "#{node.chef_environment}")
+    if hostgroup_id.nil?
+      hostgroup_id = zbx.hostgroups.create(:name => "#{node.chef_environment}")
     end
+
+    # Get existing actions
+    actions = zbx.query(
+      method: 'action.get',
+      params: { "output" => ["actionid", "name"] }
+    )
+    existing_actions = actions.inject({}) {
+      |result, element| result.merge({element["name"] => element["actionid"]})
+    }
 
     zabbix_triggers = node.run_state["zabbix_triggers"] or {}
     zabbix_triggers.each do |trigger_host, queries|
-      # Create host entries in Zabbix. 
+      # Create host entries in Zabbix.
       # Note: these are dummy entries to define the required items and triggers
-      if zbx.hosts.get_id(:host => "#{trigger_host}").nil?
-        zbx.hosts.create(:host => "#{trigger_host}", 
-                         :interfaces => [ {:type => 1,:main => 1,:ip => '127.0.0.1', :dns => '127.0.0.1', :port => 10050, :useip => 0}], 
-                         :groups => [ :groupid => zbx.hostgroups.get_id(:name => "#{node.chef_environment}") ])
-      end
-      
-      # Define application which is used to group items
-      # FIXME: 
-      # Following zbx.applications.create only adds the first host to the application
-      # The items that are created latest are not added to the application. To add them one has to 
-      # specify "attributes => [ "<zabbix id for hadoop application>" ]" to the zbx.items.create_or_update call
-      # but when tried it failed complaining that application hadoop is not available on the host.
-      # This is for all the hosts other than the first one which was passed in while creating the application.
-      if zbx.applications.get_id(:name => "hadoop").nil?
-        zbx.applications.create(:name => "hadoop", 
-                                :hostid => zbx.hosts.get_id(:host => "#{trigger_host}"))
+      host_id = zbx.hosts.get_id(:host => "#{trigger_host}")
+      if host_id.nil?
+        host_id = zbx.hosts.create(
+          :host => "#{trigger_host}",
+          :interfaces => [{
+            :type => 1, :main => 1, :ip => '127.0.0.1', :dns => '127.0.0.1',
+            :port => 10050, :useip => 0
+          }],
+          :groups => [:groupid => "#{hostgroup_id}"]
+        )
       end
 
+      # Define application which is used to group items
+      # FIXME:
+      # Following zbx.applications.create only adds the first host to the
+      # application. The items that are created latest are not added to the
+      # application. To add them one has to specify "attributes =>
+      # [ "<zabbix id for hadoop application>" ]" to zbx.items.create_or_update
+      # call but when tried it failed complaining that application hadoop is not
+      # available on the host. This is for all the hosts other than the first
+      # one which was passed in while creating the application.
+      app_id = zbx.applications.get_id(:name => "hadoop")
+      if app_id.nil?
+        app_id = zbx.applications.create(
+          :name => "hadoop",
+          :hostid => "#{host_id}"
+        )
+      end
+
+      # Get existing items for the host
+      items = zbx.query(
+        method: 'item.get',
+        params: { "output" => ["itemid", "name"], "hostids" => host_id }
+      )
+      existing_items = items.inject({}) {
+        |result, element| result.merge(
+          { element["name"] => element["itemid"] }
+        )
+      }
+      createItemsArr = []
+      updateItemsArr = []
+
+      # Get existing triggers for the host
+      triggers = zbx.query(
+        method: 'trigger.get',
+        params: {
+          "output" => ["triggerid", "description"],
+          "hostids" => host_id
+        }
+      )
+      existing_triggers = triggers.inject({}) {
+        |result, element| result.merge(
+          { element["description"] => element["triggerid"] }
+        )
+      }
+      createTriggersArr = []
+      updateTriggersArr = []
+
+      createActionsArr = []
+      updateActionsArr = []
+
       queries.each do |trigger_key, attrs|
-        # Create zabbix items for each hosts which will accept data from zabbix sender processes
+        # Create zabbix items for each hosts which will accept data from
+        # zabbix sender processes.
         # For details about the parameter values refer to Zabbix documentaton
         # https://www.zabbix.com/documentation/2.2/manual/api/reference/item
         if attrs['history_days'].nil?
           history_days = node['bcpc']['hadoop']['zabbix']['history_days']
         else
           history_days = params['history_days']
-        end  
-        if attrs['trend_days'].nil?             
+        end
+        if attrs['trend_days'].nil?
           trend_days = node['bcpc']['hadoop']['zabbix']['trend_days']
         else
           trend_days = attrs['trend_days']
         end
         if attrs['value_type'].nil?
-          value_type = 3
+          value_type = 0 # default = numeric float
         else
           value_type = attrs['value_type']
         end
-        
-        # By default an item and its trigger & actions are disabled, which can be overwritten through attributes file
+
+        # By default an item and its trigger & actions are disabled, which can
+        # be overwritten through attributes file.
         # Per Zabbix API: status=1 => disable and status=0 => enable
         status = 1
         if attrs.key?('enable') and attrs['enable']
           status = 0
         end
-        
-        # type, value_type and data_type can be made configurable through attributes
-        zbx.items.create_or_update(:name => trigger_key, 
-                                   :description => trigger_key, 
-                                   :key_ => trigger_key, 
-                                   :type => 2, 
-                                   :value_type => value_type, 
-                                   :data_type => 0, 
-                                   :history => history_days, 
-                                   :trends => trend_days, 
-                                   :hostid => zbx.hosts.get_id(:host => "#{trigger_host}"), 
-                                   :trapper_hosts => graphite_hosts,
-                                   :status => status)
+
+        item_info = {
+          :name => trigger_key, :description => trigger_key,
+          :key_ => trigger_key, :type => 2, :value_type => value_type,
+          :data_type => 0, :history => history_days, :trends => trend_days,
+          :hostid => "#{host_id}", :trapper_hosts => graphite_hosts,
+          :status => status
+        }
+
+        if (item_id = existing_items[trigger_key]).nil?
+          createItemsArr.push(item_info)
+        else
+          item_info[:itemid] = item_id
+          updateItemsArr.push(item_info)
+        end
 
         if attrs['trigger_name'].nil?
           next
         end
 
-        # Create zabbix triggers on the items so that actions can be taken if a trigger even occurs
-        # For all triggers a companion trigger is created to check whether the zabbix sender cron job is active and sends data to zabbix
+        # Create zabbix triggers on the items so that actions can be taken if
+        # a trigger event occurs
         if attrs.key?('trigger_dep')
           dependencies = Array.new
           attrs['trigger_dep'].each do |dep|
-            dependency = Hash.new
-            dependency['triggerid'] = zbx.triggers.get_id(:description => dep)
-            dependencies.push(dependency)
+            dep_id = zbx.triggers.get_id(:description => dep)
+            if not dep_id.nil?
+              dependencies.push({'triggerid' => dep_id})
+            end
           end
         end
 
         trigger_name = attrs['trigger_name']
-        expr = "{"+"#{trigger_host}"+":"+trigger_key+"."+"#{attrs['trigger_val']}"+"}"+"#{attrs['trigger_cond']}"
-        if (trigger_id = zbx.triggers.get_id(:description => trigger_name)).nil?
-          zbx.triggers.create(:description => trigger_name,
-                              :expression => expr,
-                              :comments => attrs['trigger_desc'],
-                              :priority => attrs['severity'],
-                              :status => status,
-                              :dependencies => dependencies)
-          #cron_check_cond << "{"+"#{trigger_host}"+":"+trigger_key+".nodata(#{node["bcpc"]["hadoop"]["zabbix"]["cron_check_time"]})}=1"
-          #
-          # Create an action for each trigger which will inturn execute a shell script when the trigger status turns to PROBLEM state
-          #
-          zbx.query(method: 'action.create', 
-                    params: {"name" => "#{trigger_name}_action","eventsource" =>  0,"evaltype" => 1,"status" => status,"esc_period" => 120, 
-                    'conditions' => [{"conditiontype" => 3,"operator" => 2,"value" => trigger_name}, 
-                                     {"conditiontype" => 5,"operator" => 0,"value" => 1}, 
-                                     {"conditiontype" => 16,"operator" => 7}], 
-                    'operations' => [{"operationtype" => 1,"opcommand" => {"command" => "#{node['bcpc']['zabbix']['scripts']['mail']} {TRIGGER.NAME} #{node.chef_environment} #{attrs['severity']} '#{attrs['trigger_desc']}' #{trigger_host} #{attrs['route_to']}" ,"type" => "0","execute_on" => "1"},
-                    "opcommand_hst" => [ "hostid" => 0]}]})            
+        expr = "{" + "#{trigger_host}" + ":" + trigger_key + "." +
+          "#{attrs['trigger_val']}" + "}" + "#{attrs['trigger_cond']}"
+
+        if (trigger_id = existing_triggers[trigger_name]).nil?
+          createTriggersArr.push({
+            :description => trigger_name,
+            :expression => expr,
+            :comments => attrs['trigger_desc'],
+            :priority => attrs['severity'],
+            :status => status,
+            :dependencies => dependencies
+          })
+
+          # For all triggers, a companion trigger is created to check whether
+          # the zabbix sender cron job is active and sends data to Zabbix.
+          #cron_check_cond << "{" + "#{trigger_host}" + ":" + trigger_key +
+          #  ".nodata(#{node["bcpc"]["hadoop"]["zabbix"]["cron_check_time"]})}=1"
         else
-          zbx.triggers.update(:triggerid => trigger_id, :expression => expr, :comments => attrs['trigger_desc'], :priority => attrs['severity'], :status => status, :dependencies => dependencies)
-          action =  zbx.query(method: 'action.get', params: { "filter"=> { "name"=> "#{trigger_name}_action" } } )
-          if not action.empty? and action[0].has_key?('actionid')
-            zbx.query(method: 'action.update', 
-                      params: {"actionid" => "#{action[0]['actionid']}", "status" => status, 
-                               'operations' => [
-                                { "operationtype" => 1,
-                                  "opcommand" => {"command" => "#{node['bcpc']['zabbix']['scripts']['mail']} {TRIGGER.NAME} #{node.chef_environment} #{attrs['severity']} '#{attrs['trigger_desc']}' #{trigger_host} #{attrs['route_to']}" ,"type" => "0","execute_on" => "1"},
-                                  "opcommand_hst" => [ "hostid" => 0]           
-                                }
-                               ]
-                              }
-                      )            
-          end # if not action.empty? and action[0].has_key?('actionid')
-        end
+          updateTriggersArr.push({
+            :triggerid => trigger_id,
+            :expression => expr,
+            :comments => attrs['trigger_desc'],
+            :priority => attrs['severity'],
+            :status => status,
+            :dependencies => dependencies
+          })
+        end # End of "if (trigger_id = existing_triggers[trigger_name]).nil?"
 
+        # Create/Update Actions
+        if (action_id = existing_actions["#{trigger_name}_action"]).nil?
+          createActionsArr.push({
+            "name" => "#{trigger_name}_action", "eventsource" => 0,
+            "evaltype" => 1, "status" => status, "esc_period" => 120,
+            'conditions' => [
+              {"conditiontype" => 3,"operator" => 2,"value" => trigger_name},
+              {"conditiontype" => 5,"operator" => 0,"value" => 1},
+              {"conditiontype" => 16,"operator" => 7}
+            ],
+            'operations' => [{
+              "operationtype" => 1,
+              "opcommand" => {
+                "command" => "#{node['bcpc']['zabbix']['scripts']['mail']}" +
+                  " {TRIGGER.NAME} #{node.chef_environment}" +
+                  " #{attrs['severity']} '#{attrs['trigger_desc']}'" +
+                  " #{trigger_host} #{attrs['route_to']}",
+                "type" => "0", "execute_on" => "1"
+              },
+              "opcommand_hst" => ["hostid" => 0]
+            }]
+          })
+        else
+          updateActionsArr.push({
+            "actionid" => action_id, "evaltype" => 1, "status" => status,
+            "esc_period" => 120,
+            'conditions' => [
+              {"conditiontype" => 3, "operator" => 2, "value" => trigger_name},
+              {"conditiontype" => 5, "operator" => 0, "value" => 1},
+              {"conditiontype" => 16, "operator" => 7}
+            ],
+            'operations' => [{
+              "operationtype" => 1,
+              "opcommand" => {
+                "command" => "#{node['bcpc']['zabbix']['scripts']['mail']}" +
+                  " {TRIGGER.NAME} #{node.chef_environment}" +
+                  " #{attrs['severity']} '#{attrs['trigger_desc']}'" +
+                  " #{trigger_host} #{attrs['route_to']}",
+                 "type" => "0", "execute_on" => "1"
+              },
+              "opcommand_hst" => ["hostid" => 0]
+            }]
+          })
+        end # "if (action_id = existing_actions["#{trigger_name}_action"]).nil?"
       end #queries.each
-    end #node["bcpc"]["hadoop"]["graphite"]["queries"].each 
 
-    # Create a dummy trigger using all the items defined during the first run of this recipe to perform cron status check
-    # Change reverted back due to issue https://www.zabbix.com/forum/showthread.php?t=46276
+      zbx.query(method: 'item.create', params: createItemsArr) if not createItemsArr.empty?
+      zbx.query(method: 'item.update', params: updateItemsArr) if not updateItemsArr.empty?
+      zbx.query(method: 'trigger.create', params: createTriggersArr) if not createTriggersArr.empty?
+      zbx.query(method: 'trigger.update', params: updateTriggersArr) if not updateTriggersArr.empty?
+      zbx.query(method: 'action.create', params: createActionsArr) if not createActionsArr.empty?
+      zbx.query(method: 'action.update', params: updateActionsArr) if not updateActionsArr.empty?
+
+    end #node["bcpc"]["hadoop"]["graphite"]["queries"].each
+
+    # Create a dummy trigger using all the items defined during the first run
+    # of this recipe to perform cron status check
+    # Change reverted back due to issue
+    # https://www.zabbix.com/forum/showthread.php?t=46276
     #
     #if zbx.triggers.get_id(:description => "cron_check").nil?
     #  Chef::Log.debug "Trigger cron_check not defined"
     #  cron_check_expr = cron_check_cond.join("&")
-    #  zbx.triggers.create(:description => "cron_check", :expression => cron_check_expr, :comments => "Cron down", :priority => 4, :status => 0)
+    #  zbx.triggers.create(
+    #    :description => "cron_check", :expression => cron_check_expr,
+    #    :comments => "Cron down", :priority => 4, :status => 0
+    #  )
     #else
     #  Chef::Log.debug "Trigger cron_check already defined"
     #end
   end
+  only_if { has_vip? }
 end
 
 cron "Run script to query graphite and send data to zabbix" do

--- a/cookbooks/bcpc-hadoop/templates/default/zabbix.run_zabbix_sender.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/zabbix.run_zabbix_sender.sh.erb
@@ -1,5 +1,5 @@
 #!/bin/bash
-if ip addr | grep <%= node[:bcpc][:management][:vip] %> > /dev/null
+if ip addr show dev <%=node[:bcpc][:management][:interface]%> | grep "<%=node[:bcpc][:management][:vip]%>" > /dev/null
 then
   python /usr/local/bin/query_graphite.py | /usr/local/bin/zabbix_sender -z <%= node[:bcpc][:management][:vip] %> -p <%= node[:bcpc][:zabbix][:server_port] %> -T -i - > /dev/null
 fi


### PR DESCRIPTION
This PR improves the graphite-to-zabbix function:
- Fix formatting issue for metric value sent from graphite to zabbix
- **Create Zabbix objects only on the head node holding vip** (So only one head node will configure Zabbix)
- Increase disk space check limit
- Numerical formatting fixes for graphite metrics
- Set space used precision to 2 decimal places based on Zabbix latest data UI
- **Reduce Zabbix API calls for creation of Hosts, Items, Triggers and Actions** (This significantly reduces the time it took to configure all the objects in Zabbix)
- Add trigger for bootstrap chef-client runs