### PR TITLE
Changes to enable HBase replication

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -46,6 +46,9 @@ default["bcpc"]["hadoop"]["namenode"]["jmx"]["port"] = 10111
 default["bcpc"]["hadoop"]["namenode"]["rpc"]["port"] = 8020
 default["bcpc"]["hadoop"]["namenode"]["http"]["port"] = 50070 
 default["bcpc"]["hadoop"]["namenode"]["https"]["port"] = 50470
+default["bcpc"]["hadoop"]["hbase"]["repl"]["enabled"] = false
+default["bcpc"]["hadoop"]["hbase"]["repl"]["peer_id"] =  node.chef_environment.gsub("-","_")
+default["bcpc"]["hadoop"]["hbase"]["repl"]["target"] = ""
 default["bcpc"]["hadoop"]["hbase"]["superusers"] = ["hbase"]
 # Interval in milli seconds when HBase major compaction need to be run. Disabled by default
 default["bcpc"]["hadoop"]["hbase"]["major_compact"]["time"] = 0

--- a/cookbooks/bcpc-hadoop/recipes/hbase_repl.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_repl.rb
@@ -1,0 +1,19 @@
+#
+# To enable/disable replication peers
+#
+if (node["bcpc"]["hadoop"]["hbase"]["repl"]["enabled"])
+  bash "create_hbase_repl_peer" do
+    code <<-EOH
+      echo "add_peer '#{node["bcpc"]["hadoop"]["hbase"]["repl"]["peer_id"]}','#{node["bcpc"]["hadoop"]["hbase"]["repl"]["target"]}'"|hbase shell
+      EOH
+    not_if "echo list_peers|hbase shell|grep #{node["bcpc"]["hadoop"]["hbase"]["repl"]["peer_id"]}"
+  end
+else
+  bash "stop_repl_remove_repl_peer" do
+    code <<-EOH
+      echo "disable_peer '#{node["bcpc"]["hadoop"]["hbase"]["repl"]["peer_id"]}'"|hbase shell
+      echo "remove_peer '#{node["bcpc"]["hadoop"]["hbase"]["repl"]["peer_id"]}'"|hbase shell
+      EOH
+    only_if "echo list_peers|hbase shell|grep #{node["bcpc"]["hadoop"]["hbase"]["repl"]["peer_id"]}"
+  end
+end

--- a/cookbooks/bcpc-hadoop/templates/default/hb_hbase-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hb_hbase-site.xml.erb
@@ -166,4 +166,9 @@
     <value>org.apache.hadoop.hbase.ipc.SecureRpcEngine</value>    
   </property>   
   <% end %>
+
+  <property>
+    <name>hbase.replication</name>
+    <value>true</value>
+  </property>
 </configuration>

--- a/cookbooks/bcpc_jmxtrans/attributes/default.rb
+++ b/cookbooks/bcpc_jmxtrans/attributes/default.rb
@@ -345,6 +345,11 @@ default['jmxtrans']['default_queries']['hbase_rs'] = [
     "obj" => "Hadoop:service=HBase,name=RegionServer,sub=Regions,*",
     "result_alias" => "hb_regions"
   },
+  {   
+    "attr" => [],
+    "obj" => "Hadoop:service=HBase,name=RegionServer,sub=Replication,*",
+    "result_alias" => "hb_replication"
+  },
   {
     'obj' => "Hadoop:name=RegionServer,service=HBase,sub=Server",
     'result_alias' => "hb_rs_server",

--- a/roles/BCPC-Hadoop-Head-HBase.json
+++ b/roles/BCPC-Hadoop-Head-HBase.json
@@ -4,6 +4,7 @@
   "run_list": [
     "role[Basic]",
     "role[BCPC-Hadoop-Head]",
+    "recipe[bcpc-hadoop::hbase_repl]",
     "recipe[bcpc-hadoop::hbase_master]",
     "recipe[bcpc_jmxtrans]",
     "recipe[bcpc::diamond]"


### PR DESCRIPTION
Changes in this PR will enable users to set-up HBase replication. 

In order to enable replication users need to 

- Set ``default["bcpc"]["hadoop"]["hbase"]["repl"]["enabled"]`` to ``true``
- Set ``default["bcpc"]["hadoop"]["hbase"]["repl"]["peer_id"]`` to a string which will be used to create the replication peer in HBase and the string should not include "-" (hyphens). By default the string will be set to the chef environment name.
- Set ``default["bcpc"]["hadoop"]["hbase"]["repl"]["target"]`` to a string value of "target hbase ZooKeeper quorum hosts:ZK port number:/hbase root directory". For e.g. ``zkhost1.example.com,zkhost2.example.com,zkhost3.example.com:2181:/hbase``.

For more details please refer to [HBase book](http://hbase.apache.org/book.html#_cluster_replication).