### PR TITLE
Enable graphite-webapp to read local_settings.py to get its configuration

### DIFF
--- a/cookbooks/bcpc/recipes/graphite.rb
+++ b/cookbooks/bcpc/recipes/graphite.rb
@@ -158,9 +158,9 @@ end
 
 template "/opt/graphite/webapp/graphite/local_settings.py" do
     source "graphite.local_settings.py.erb"
-    owner "root"
+    owner "www-data"
     group "root"
-    mode 00640
+    mode 00440
     variables( :servers => mysql_servers )
     notifies :restart, "service[apache2]", :delayed
 end


### PR DESCRIPTION
In ['chef vault mysql graphite password'](https://github.com/bloomberg/chef-bach/commit/7ae4bfca6efc5d8363ffebcff0ce88a951dab27e), the permissions on `/opt/graphite/webapp/graphite/local_settings.py` were changed from `00644` to [`00640`](https://github.com/bloomberg/chef-bach/blob/master/cookbooks/bcpc/recipes/graphite.rb#L163). This was done so only the owner of the file can read the config and protect the graphite-mysql password from general browsing. The file was owned by `root:root`. Graphite webapp is run as user `www-data` which reads the local_settings.py file to get its configuration, which after this commit it couldn't do.

This PR makes `www-data` owner of `/opt/graphite/webapp/graphite/local_settings.py`; group is still `root` and changes permissions to `00440` so only root can change the file. This fixes issue #303 