### PR TITLE
Spark package name include version and build spark metapackage

### DIFF
--- a/cookbooks/bach_spark/attributes/default.rb
+++ b/cookbooks/bach_spark/attributes/default.rb
@@ -2,6 +2,7 @@ default[:spark][:download][:url] = "http://d3kbcqa49mib13.cloudfront.net"
 default[:spark][:download][:file][:name] = "spark-1.4.1-bin-hadoop2.6"
 default[:spark][:download][:file][:type] = "tgz"
 default[:spark][:download][:dir] = "/home/vagrant/chef-bcpc/bins"
+default[:spark][:package][:install_meta] = false
 default[:spark][:package][:base] = "/usr/spark"
 default[:spark][:package][:prefix] = "spark"
 default[:spark][:package][:version] = "1.4.1"

--- a/cookbooks/bach_spark/recipes/default.rb
+++ b/cookbooks/bach_spark/recipes/default.rb
@@ -4,9 +4,14 @@ spark_pkg_version = node[:spark][:package][:version]
 spark_bin_dir = node[:spark][:bin][:dir]
 hdfs_url = node['spark']['hdfs_url']
 
-package "spark" do
-  action :install
-  version spark_pkg_version
+if node[:spark][:package][:install_meta] == true then
+  package "spark" do
+    action :upgrade
+  end
+else
+  package "spark-#{spark_pkg_version}" do
+    action :install
+  end
 end
 
 template "#{spark_bin_dir}/conf/spark-env.sh" do

--- a/cookbooks/bach_spark/templates/default/spark-metapackage.erb
+++ b/cookbooks/bach_spark/templates/default/spark-metapackage.erb
@@ -1,0 +1,25 @@
+### Commented entries have reasonable defaults.
+### Uncomment to edit them.
+# Source: <source package name; defaults to package name>
+Section: misc
+Priority: optional
+# Homepage: <enter URL here; no default>
+Standards-Version: 3.9.2
+
+Package: spark 
+Version: <%= @meta_version %> 
+# Maintainer: Your Name <yourname@example.com>
+# Pre-Depends: <comma-separated list of packages>
+Depends: <%= @package_name %>-<%= @package_version %>
+# Recommends: <comma-separated list of packages>
+# Suggests: <comma-separated list of packages>
+# Provides: <comma-separated list of packages>
+# Replaces: <comma-separated list of packages>
+Architecture: all
+# Copyright: <copyright file; defaults to GPL2>
+# Changelog: <changelog file; defaults to a generic changelog>
+# Readme: <README.Debian file; defaults to a generic one>
+# Extra-Files: <comma-separated list of additional files for the doc directory>
+# Files: <pair of space-separated paths; First is file to include, second is destination>
+#  <more pairs, if there's more than one file to include. Notice the starting space>
+Description: Spark meta package, this allows us to keep multiple versions of spark

--- a/environments/Test-Laptop.json
+++ b/environments/Test-Laptop.json
@@ -1,6 +1,11 @@
 {
   "name": "Test-Laptop",
   "override_attributes": {
+    "spark": {
+      "package": {
+        "install_meta": false
+      }
+    },
     "bcpc": {
       "graphite": {
         "graphite_disk": "sde"


### PR DESCRIPTION
Purpose of this pull request is to mitigate items mentioned in #310 
- Including spark version in spark package name will allow us to keep multiple versions of spark on the same host
- In addition we are also creating a spark meta package just **spark** which includes a specific spark version as a dependency
- meta package creation and installation is regulated by a Boolean flag so that we do not trample spark binary package on systems where it was already deployed

--Edit--
I kept the meta package option around, however having the version in the package name means that we do not need a metapackage

````text
total 4
drwxrwxr-x 11 root root 4096 Feb 14 06:35 1.4.1
lrwxrwxrwx  1 root root   16 Feb 14 06:35 current -> /usr/spark/1.4.1
````
after making changes to "cookbooks/bach_spark/attributes/default.rb"

...

default[:spark][:package][:version] = "1.6.0"
...

````text
drwxrwxr-x 11 root root 4096 Feb 14 06:35 1.4.1
drwxrwxr-x 11 root root 4096 Feb 14 17:26 1.6.0
lrwxrwxrwx  1 root root   16 Feb 14 17:26 current -> /usr/spark/1.6.0
````