### PR TITLE
Change to support version 0.3 of Oozie shell action

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-site.xml.erb
@@ -25,7 +25,21 @@
 
     <property>
       <name>oozie.service.SchemaService.wf.ext.schemas</name>
-      <value>shell-action-0.1.xsd,shell-action-0.2.xsd,email-action-0.1.xsd,hive-action-0.2.xsd,hive-action-0.3.xsd,hive-action-0.4.xsd,hive-action-0.5.xsd,sqoop-action-0.2.xsd,sqoop-action-0.3.xsd,ssh-action-0.1.xsd,ssh-action-0.2.xsd,distcp-action-0.1.xsd</value>
+      <value>
+        shell-action-0.1.xsd,
+        shell-action-0.2.xsd,
+        shell-action-0.3.xsd,
+        email-action-0.1.xsd,
+        hive-action-0.2.xsd,
+        hive-action-0.3.xsd,
+        hive-action-0.4.xsd,
+        hive-action-0.5.xsd,
+        sqoop-action-0.2.xsd,
+        sqoop-action-0.3.xsd,
+        ssh-action-0.1.xsd,
+        ssh-action-0.2.xsd,
+        distcp-action-0.1.xsd
+      </value>
     </property>
 
     <property>


### PR DESCRIPTION
Version 0.3 of Oozie shell action XSD supports ``global`` in workflow.xml. This in turn reduces complexity in the workflow xml definition and improves readability. 

Once we move to HDP 2.3, this override in site.xml can be removed since these will be available in the oozie-default.xml.