### PR TITLE
Enable HDFS LDAP integration

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -119,3 +119,11 @@ default['jmxtrans']['run_interval'] = "15"
 default[:bcpc][:hadoop][:os][:group][:hadoop][:members]=["hdfs","yarn"]
 default[:bcpc][:hadoop][:os][:group][:hdfs][:members]=["hdfs"]
 default[:bcpc][:hadoop][:os][:group][:mapred][:members]=["yarn"]
+
+default[:bcpc][:hadoop][:hdfs][:ldap][:integration] = false
+default[:bcpc][:hadoop][:hdfs][:ldap][:user] = "" #must be LDAP DN
+default[:bcpc][:hadoop][:hdfs][:ldap][:domain] = "BCPC.EXAMPLE.COM"
+default[:bcpc][:hadoop][:hdfs][:ldap][:port] = 389
+default[:bcpc][:hadoop][:hdfs][:ldap][:password] =  nil
+default[:bcpc][:hadoop][:hdfs][:ldap][:search][:filter][:user]="(&(objectclass=user)(sAMAccountName={0}))"
+default[:bcpc][:hadoop][:hdfs][:ldap][:search][:filter][:group]="(objectClass=group)"

--- a/cookbooks/bcpc-hadoop/recipes/hadoop_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hadoop_config.rb
@@ -12,6 +12,18 @@ bash "update-hadoop-conf-alternatives" do
     update-alternatives --set hadoop-conf /etc/hadoop/conf.#{node.chef_environment}
   }
 end
+if ( node[:bcpc][:hadoop][:hdfs][:ldap][:integration] == true )
+
+  ldap_pwd = ( node[:bcpc][:hadoop][:hdfs][:ldap][:password].nil? ? get_config('password', 'ldap', 'os') : node[:bcpc][:hadoop][:hdfs][:ldap][:password] )
+
+  file "/etc/hadoop/conf/ldap-conn-pass.txt" do
+    content "#{ldap_pwd}"
+    mode 0444
+    owner "hdfs"
+    group "hadoop"
+    sensitive true
+  end
+end
 
 hadoop_conf_files = %w{capacity-scheduler.xml
    core-site.xml

--- a/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
@@ -148,6 +148,7 @@ service "generally run hadoop-hdfs-namenode" do
   subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/hdfs-policy.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/hdfs-site_HA.xml]", :delayed
+  subscribes :restart, "file[/etc/hadoop/conf/ldap-conn-pass.txt]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/topology]", :delayed
   subscribes :restart, "user_ulimit[hdfs]", :delayed

--- a/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
@@ -105,6 +105,7 @@ service "hadoop-hdfs-namenode" do
   action [:enable, :start]
   subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
+  subscribes :restart, "file[/etc/hadoop/conf/ldap-conn-pass.txt]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/hdfs-policy.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/topology]", :delayed

--- a/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
@@ -121,6 +121,7 @@ if @node['bcpc']['hadoop']['hdfs']['HA'] == true then
     subscribes :restart, "template[/etc/hadoop/conf/topology]", :delayed
     subscribes :restart, "user_ulimit[hdfs]", :delayed
     subscribes :restart, "directory[/var/log/hadoop-hdfs/gc/]", :delayed
+    subscribes :restart, "file[/etc/hadoop/conf/ldap-conn-pass.txt]", :delayed
   end
 else
   Chef::Log.info "Not running standby namenode services yet -- HA disabled!"

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_core-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_core-site.xml.erb
@@ -120,4 +120,51 @@
     <name>hadoop.user.group.static.mapping.overrides</name>
     <value>hdfs=hadoop,hdfs;yarn=mapred,hadoop;</value>
   </property>
+  <% if node[:bcpc][:hadoop][:hdfs][:ldap][:integration] == true %>
+   <!-- HDFS LDAP Mapping configuration -->
+  <property>
+    <name>hadoop.security.group.mapping</name>
+    <value>org.apache.hadoop.security.LdapGroupsMapping</value>
+  </property>
+
+  <property>
+    <name>hadoop.security.group.mapping.ldap.bind.user</name>
+    <value><%= node[:bcpc][:hadoop][:hdfs][:ldap][:user] %></value>
+  </property>
+
+  <property>
+    <name>hadoop.security.group.mapping.ldap.bind.password.file</name>
+    <value>/etc/hadoop/conf/ldap-conn-pass.txt</value>
+  </property>
+
+  <property>
+    <name>hadoop.security.group.mapping.ldap.url</name>
+    <value>ldap://<%= node[:bcpc][:hadoop][:hdfs][:ldap][:domain] %>:<%= node[:bcpc][:hadoop][:hdfs][:ldap][:port] %></value>
+  </property>
+
+  <property>
+    <name>hadoop.security.group.mapping.ldap.base</name>
+    <value>DC=<%= node[:bcpc][:hadoop][:hdfs][:ldap][:domain].split('.')[0] %>,DC=<%= node[:bcpc][:hadoop][:hdfs][:ldap][:domain].split('.')[1] %>,DC=<%= node[:bcpc][:hadoop][:hdfs][:ldap][:domain].split('.')[2] %></value>
+  </property>
+
+  <property>
+    <name>hadoop.security.group.mapping.ldap.search.filter.user</name>
+    <value><%= node[:bcpc][:hadoop][:hdfs][:ldap][:search][:filter][:user].encode(:xml => :text) %></value>
+  </property>
+
+  <property>
+    <name>hadoop.security.group.mapping.ldap.search.filter.group</name>
+    <value><%= node[:bcpc][:hadoop][:hdfs][:ldap][:search][:filter][:group] %></value>
+  </property>
+
+  <property>
+    <name>hadoop.security.group.mapping.ldap.search.attr.member</name>
+    <value>member</value>
+  </property>
+
+  <property>
+    <name>hadoop.security.group.mapping.ldap.search.attr.group.name</name>
+    <value>cn</value>
+  </property>
+  <% end %>
 </configuration>


### PR DESCRIPTION
This PR enables `HDFS` integration with `LDAP`. Once enabled, groups for individual users can be fetched from `LDAP` and fine grained access control can be implemented.  PR #392 should be merged first. 