### PR TITLE
Add a link in chef-client to use knife.rb as client.rb

### DIFF
--- a/cookbooks/bcpc/recipes/bootstrap.rb
+++ b/cookbooks/bcpc/recipes/bootstrap.rb
@@ -64,3 +64,7 @@ cron 'synchronize chef' do
 end
 
 package 'sshpass'
+
+link '/etc/chef/client.d/knife.rb' do
+  to '/home/vagrant/chef-bcpc/.chef/knife.rb'
+end

--- a/setup_chef_bootstrap_node.sh
+++ b/setup_chef_bootstrap_node.sh
@@ -30,8 +30,3 @@ fi
 
 knife node run_list add $(hostname -f) 'role[BCPC-Bootstrap]' -c .chef/knife.rb
 sudo chef-client -c .chef/knife.rb
-
-# Create a symlink in /etc/chef/client.d/ to knife.rb so that one can run chef-client
-# on the bootstrap node without having to specify -c .chef/knife.rb later. This will
-# make sure that the chef-client service runs without issues.
-sudo ln -s $(pwd)/.chef/knife.rb /etc/chef/client.d/knife.rb


### PR DESCRIPTION
We use a [custom client.rb](https://github.com/bloomberg/chef-bach/blob/master/setup_chef_cookbooks.sh#L26-L55) for [running chef-client](https://github.com/bloomberg/chef-bach/blob/master/setup_chef_bootstrap_node.sh#L32) on the bootstrap node. Since the location of that file is non-standard, chef-client daemon fails to find the file and the validation_key. This PR adds a link to knife.rb in `/etc/chef/client.d/knife.rb` which is included in chef-client's search path. The link was [added](https://github.com/bloomberg/chef-bach/commit/9ae14a46e1dc0073e188d1f291af22f8333bf313) in `setup_chef_bootstrap_node.sh` before but when building hardware clusters, if that script is not run, the symlink isn't created and thus chef-client fails to run.