### PR TITLE
Enable logging/rotation for HiveServer2 and Hive Metastore

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/hdp_hive-metastore-initd.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_hive-metastore-initd.erb
@@ -84,13 +84,13 @@ start() {
 
     LOG_FILE=/var/log/hive/${DAEMON}.out
 
-    exec_env="HADOOP_OPTS=\"-Dhive.log.dir=`dirname $LOG_FILE` -Dhive.log.file=${DAEMON}.log -Dhive.log.threshold=INFO\""
-
     # Autodetect JDBC drivers for metastore
     exec_env="HADOOP_CLASSPATH=${HADOOP_CLASSPATH}:${BIGTOP_CLASSPATH} $exec_env"
 
+    HIVE_METASTORE_OPTS=" -hiveconf hive.log.file=${DAEMON}.log -hiveconf hive.log.dir=`dirname $LOG_FILE` "
+
     su -s /bin/bash $SVC_USER -c "$exec_env nohup nice -n 0 \
-        $EXEC_PATH --service metastore $PORT \
+        $EXEC_PATH --service metastore $HIVE_METASTORE_OPTS \
             > $LOG_FILE 2>&1 < /dev/null & "'echo $! '"> $PIDFILE"
     sleep 3
 

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_hive-server2-initd.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_hive-server2-initd.erb
@@ -77,10 +77,10 @@ start() {
 
     LOG_FILE=/var/log/hive/${DAEMON}.out
 
-    exec_env="HADOOP_OPTS=\"-Dhive.log.dir=`dirname $LOG_FILE` -Dhive.log.file=${DAEMON}.log -Dhive.log.threshold=INFO\""
+    HIVE_SERVER2_OPTS=" -hiveconf hive.log.file=${DAEMON}.log -hiveconf hive.log.dir=`dirname $LOG_FILE` "
 
-    su -s /bin/bash $SVC_USER -c "$exec_env nohup nice -n 0 \
-        $EXEC_PATH --service hiveserver2 -hiveconf hive.metastore.uris=' ' $PORT \
+    su -s /bin/bash $SVC_USER -c "nohup nice -n 0 \
+        $EXEC_PATH --service hiveserver2 -hiveconf hive.metastore.uris=' ' $HIVE_SERVER2_OPTS \
             > $LOG_FILE 2>&1 < /dev/null & "'echo $! '"> $PIDFILE"
     sleep 3
 

--- a/cookbooks/bcpc-hadoop/templates/default/hv_hive-log4j.properties.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hv_hive-log4j.properties.erb
@@ -16,7 +16,7 @@
 
 # Define some default values that can be overridden by system properties
 hive.log.threshold=ALL
-hive.root.logger=WARN,DRFA
+hive.root.logger=INFO,DRFA
 hive.log.dir=/tmp/${user.name}
 hive.log.file=hive.log
 

--- a/cookbooks/bcpc-hadoop/templates/default/hv_hive-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hv_hive-site.xml.erb
@@ -180,4 +180,18 @@ characterEncoding=UTF-8&amp;user=<%=get_config("mysql-hive-table-stats-user")%>&
   <description>A flag to gather statistics automatically during the INSERT OVERWRITE command.</description>
 </property>
 
+<property>
+  <name>hive.server2.logging.operation.enabled</name>
+  <value>true</value>
+</property>
+
+<property>
+  <name>hive.server2.logging.operation.log.location</name>
+  <value>/tmp/${user.name}/operation_logs</value>
+</property>
+
+<property>
+  <name>hive.server2.logging.operation.verbose</name>
+  <value>true</value>
+</property>
 </configuration>


### PR DESCRIPTION
This PR fixes `Hive init` scripts and `Hive log4j.properties` file to generate/roate `HiveServer2` and `Hive MetaStore` logs. This PR resolves issue #307 
Also, this PR adds operation logging for `HiveServer2`.