### PR TITLE
Update bcpc-hadoop::maven_config for maven cookbook v2.0.0

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/maven_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/maven_config.rb
@@ -2,14 +2,15 @@ require 'pathname'
 
 node.override['maven']['install_java'] = false
 
-internet_download_url = node['maven']['3']['url']
-maven_file = Pathname.new(node['maven']['3']['url']).basename
+internet_download_url = node['maven']['url']
+maven_file = Pathname.new(node['maven']['url']).basename
 
-node.override['maven']['3']['url'] = "#{get_binary_server_url}/#{maven_file}"
+node.override['maven']['url'] = "#{get_binary_server_url}/#{maven_file}"
 
 # download Maven only if not already stashed in the bins directory
 remote_file "/home/vagrant/chef-bcpc/bins/#{maven_file}" do
   source internet_download_url
-  action :create_if_missing
-  mode '0555'
+  action :create
+  mode 0555
+  checksum node['maven']['checksum']
 end


### PR DESCRIPTION
Maven cookbook v2.0.0 drops maven 2.x support, so all the `node[:maven][:3]` attributes are located at `node[:maven]` instead.

This patch updates bcpc-hadoop::maven_config for changes in v2.0.0