### PR TITLE
Add missing ')' to haproxy template 'variables'

### DIFF
--- a/cookbooks/bcpc/recipes/haproxy.rb
+++ b/cookbooks/bcpc/recipes/haproxy.rb
@@ -55,7 +55,7 @@ end
 template "/etc/haproxy/haproxy.cfg" do
   source "haproxy.cfg.erb"
   mode 00644
-  variables(:mysql_servers => get_nodes_for("mysql","bcpc")
+  variables(:mysql_servers => get_nodes_for("mysql","bcpc"))
   notifies :restart, "service[haproxy]", :immediately
 end
 


### PR DESCRIPTION
This PR adds a missing ')' to variables section of `HAPROXY` template and resolves issue #335 .