### PR TITLE
Fix up bcpc-hadoop metadata for new maven cookbook

### DIFF
--- a/cookbooks/bcpc-hadoop/metadata.rb
+++ b/cookbooks/bcpc-hadoop/metadata.rb
@@ -1,14 +1,15 @@
-name             "bcpc-hadoop"
-maintainer       "Bloomberg Finance L.P."
-maintainer_email "rrichardson6@bloomberg.net"
-license          "Apache License 2.0"
-description      "Installs/Configures Bloomberg Clustered Private Hadoop Cloud (BCPHC)"
+name             'bcpc-hadoop'
+maintainer       'Bloomberg Finance L.P.'
+maintainer_email 'compute@bloomberg.net'
+license          'Apache License 2.0'
+description      'Installs/Configures Bloomberg Clustered Private Hadoop Cloud (BCPHC)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
+version          '0.1.0'
 
-depends "bcpc", ">= 0.5.0"
-depends "dpkg_autostart"
-depends "sysctl"
-depends "pam"
+depends 'bcpc', '>= 0.5.0'
+depends 'dpkg_autostart'
 depends 'java', '>= 1.28.0'
+depends 'maven', '>= 2.0.0'
+depends 'pam'
+depends 'sysctl'
 depends 'ulimit'

--- a/cookbooks/bcpc-hadoop/recipes/maven_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/maven_config.rb
@@ -2,14 +2,15 @@ require 'pathname'
 
 node.override['maven']['install_java'] = false
 
-internet_download_url = node['maven']['3']['url']
-maven_file = Pathname.new(node['maven']['3']['url']).basename
+internet_download_url = node['maven']['url']
+maven_file = Pathname.new(node['maven']['url']).basename
 
-node.override['maven']['3']['url'] = "#{get_binary_server_url}/#{maven_file}"
+node.override['maven']['url'] = "#{get_binary_server_url}/#{maven_file}"
 
 # download Maven only if not already stashed in the bins directory
 remote_file "/home/vagrant/chef-bcpc/bins/#{maven_file}" do
   source internet_download_url
-  action :create_if_missing
-  mode '0555'
+  action :create
+  mode 0555
+  checksum node['maven']['checksum']
 end


### PR DESCRIPTION
I updated bcpc-hadoop with fixes for v2.0.0 of the Maven cookbook in a previous PR.  This PR fixes the metadata.rb to reflect the new requirements.