### PR TITLE
Restart Yarn Resource Mananger when mapred-site.xml changes

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
@@ -74,6 +74,7 @@ service "hadoop-yarn-resourcemanager" do
   subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/yarn-env.sh]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/yarn-site.xml]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/mapred-site.xml]", :delayed
 end
 
 bash "reload mapreduce nodes" do


### PR DESCRIPTION
This PR enables restart of `Yarn RM` when `mapred-site.xml` changes. 