### PR TITLE
adjusted yarn client fail over timers to fail over between RMs faster

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/yarn.rb
+++ b/cookbooks/bcpc-hadoop/attributes/yarn.rb
@@ -11,4 +11,4 @@ default['bcpc']['hadoop']['yarn']['historyserver']['heap']["ratio"] = 0
 default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["port"] = 8032
 default['bcpc']['hadoop']['yarn']['aux_services']['mapreduce_shuffle']['class'] = 'org.apache.hadoop.mapred.ShuffleHandler'
 default['bcpc']['hadoop']['yarn']['opts']['jute_buffer'] = 6291456
-
+default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["yarn.client.failover-sleep-base-ms"] = 150

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
@@ -21,6 +21,11 @@
   </property>
 
   <property>
+    <name>yarn.client.failover-sleep-base-ms</name>
+    <value><%=node["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["yarn.client.failover-sleep-base-ms"]%></value>
+  </property>
+
+  <property>
     <name>yarn.resourcemanager.ha.rm-ids</name>
     <value><%=@rm_hosts.map{ |s| "rm#{node.chef_environment}#{s[:node_number]}" }.join(",") %></value>
   </property>

--- a/environments/Test-Laptop.json
+++ b/environments/Test-Laptop.json
@@ -37,6 +37,11 @@
       },
       "dns_servers" : [ "8.8.8.8", "8.8.4.4" ],
       "hadoop" : {
+        "yarn" : {
+          "resourcemanager" : {
+            "yarn.client.failover-sleep-base-ms": 30000
+          }
+        },
         "hdfs" : {
           "dfs_replication_factor" : 1
         },


### PR DESCRIPTION
Currently in environments with two or more ResourceManagers a yarn client will attempt to connect to a list of hosts corresponding to a list of ResourceManager IDs in 
````xml
  <property>
    <name>yarn.resourcemanager.ha.rm-ids</name>
    <value>rmMyCluster1,rmMyCluster2</value>
  </property>
````
The client attempts a connection in port 8032 and if the ResourceManager is currently in standby will receive a ConnectionRefused as standby ResourceManagers do not listen on the RPC port.  The proposed request will limit the amount of time it takes for the yarn client to wait between retries and thus speed up the selection process. This does not affect the failover and leader election logic of the ResourceManagers.

Below is the explanation for this property
````
When HA is enabled, the sleep base (in milliseconds) to be used for calculating the exponential delay between failovers. When set, this overrides the yarn.resourcemanager.connect.* settings. When not set, yarn.resourcemanager.connect.retry-interval.ms is used instead.
````

The right behavior will eventually be introduced in https://issues.apache.org/jira/browse/YARN-4496