### PR TITLE
Changes for Zabbix to work with Routed Rack

### DIFF
--- a/cookbooks/bcpc-hadoop/libraries/utils.rb
+++ b/cookbooks/bcpc-hadoop/libraries/utils.rb
@@ -391,7 +391,7 @@ end
 
 def has_vip?
   cmd = Mixlib::ShellOut.new(
-    "ip addr show dev #{node[:bcpc][:management][:interface]}", :timeout => 10
+    "ip addr show", :timeout => 10
   ).run_command
   cmd.stderr.empty? && cmd.stdout.include?(node[:bcpc][:management][:vip])
 end

--- a/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
+++ b/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
@@ -57,6 +57,8 @@ ruby_block "zabbix_monitor" do
       raise "No graphite hosts found"
     end
 
+    trapper_hosts = graphite_hosts + "," + node[:bcpc][:management][:vip]
+
     #cron_check_cond = Array.new
 
     # Create zabbix host group same as the chef environment name
@@ -172,7 +174,7 @@ ruby_block "zabbix_monitor" do
           :name => trigger_key, :description => trigger_key,
           :key_ => trigger_key, :type => 2, :value_type => value_type,
           :data_type => 0, :history => history_days, :trends => trend_days,
-          :hostid => "#{host_id}", :trapper_hosts => graphite_hosts,
+          :hostid => "#{host_id}", :trapper_hosts => trapper_hosts,
           :status => status
         }
 

--- a/cookbooks/bcpc-hadoop/templates/default/zabbix.run_zabbix_sender.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/zabbix.run_zabbix_sender.sh.erb
@@ -1,5 +1,5 @@
 #!/bin/bash
-if ip addr show dev <%=node[:bcpc][:management][:interface]%> | grep "<%=node[:bcpc][:management][:vip]%>" > /dev/null
+if ip addr show | grep "<%=node[:bcpc][:management][:vip]%>" > /dev/null
 then
   python /usr/local/bin/query_graphite.py | /usr/local/bin/zabbix_sender -z <%= node[:bcpc][:management][:vip] %> -p <%= node[:bcpc][:zabbix][:server_port] %> -T -i - > /dev/null
 fi


### PR DESCRIPTION
The network changes that are proposed as part of PR #222 mean Zabbix won't work as expected. This is because:

- VIP won't be attached to the `node[:bcpc][:management][:interface]` and so `has_vip?` check will fail (Thus none of the Zabbix servers will be active w.r.t configuring zabbix and sending metrics to zabbix server)
- In Routed Rack, zabbix_sender's traffic will appear to be coming from the Global VIP and not the host local IP. Thus Zabbix items will reject the metric information since they expect that info to come only from [list of head/graphite nodes' local IPs](https://github.com/bloomberg/chef-bach/blob/master/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb#L175)

This PR proposes changes which will enable Zabbix to work with Routed Racks too.