### PR TITLE
Zabbix leader election

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/monitoring.rb
+++ b/cookbooks/bcpc-hadoop/attributes/monitoring.rb
@@ -19,7 +19,7 @@ default["bcpc"]["hadoop"]["zabbix"]["escalation_period"] = 600
 
 # Interval within which chef-client is expected to run
 default["bcpc"]["hadoop"]["zabbix"]["chef_client_check_interval"] =
-  "#{((node['chef_client']['interval'].to_i + node['chef_client']['splay'].to_i) * 2 / 60).ceil}m"
+  "#{(node['bcpc']['zabbix']['chef_client_check_interval'] / 60).ceil}m"
 
 # Enable/Disable Zabbix alarming (Metrics will be collected and Triggers will change to
 # problem state but no alarms will be generated. One can still see the System State on Zabbix UI)

--- a/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
+++ b/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
@@ -304,7 +304,7 @@ ruby_block "zabbix_monitor" do
     #  Chef::Log.debug "Trigger cron_check already defined"
     #end
   end
-  only_if { has_vip? }
+  only_if { is_zabbix_leader?(node[:hostname]) }
 end
 
 cron "Run script to query graphite and send data to zabbix" do
@@ -312,4 +312,5 @@ cron "Run script to query graphite and send data to zabbix" do
   hour   "*"
   user   "nobody"
   command  "pgrep -u nobody 'zabbix_sender' > /dev/null || /usr/local/bin/run_zabbix_sender.sh"
+  action is_zabbix_leader?(node[:hostname]) ? :create : :delete
 end

--- a/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
+++ b/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
@@ -2,7 +2,8 @@ include_recipe "bcpc-hadoop::graphite_queries"
 
 template node['bcpc']['zabbix']['scripts']['sender'] do
   source "zabbix.run_zabbix_sender.sh.erb"
-  mode 0755
+  owner 'zabbix'
+  mode 0550
 end
 
 directory ::File.dirname(node['bcpc']['zabbix']['scripts']['mail']) do
@@ -308,9 +309,8 @@ ruby_block "zabbix_monitor" do
 end
 
 cron "Run script to query graphite and send data to zabbix" do
-  minute "*"
-  hour   "*"
-  user   "nobody"
-  command  "pgrep -u nobody 'zabbix_sender' > /dev/null || /usr/local/bin/run_zabbix_sender.sh"
-  action is_zabbix_leader?(node[:hostname]) ? :create : :delete
+  minute '*'
+  hour   '*'
+  user   'zabbix'
+  command  "pgrep -u zabbix 'zabbix_sender' > /dev/null || /usr/local/bin/run_zabbix_sender.sh"
 end

--- a/cookbooks/bcpc-hadoop/templates/default/zabbix.run_zabbix_sender.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/zabbix.run_zabbix_sender.sh.erb
@@ -1,5 +1,2 @@
 #!/bin/bash
-if ip addr show | grep "<%=node[:bcpc][:management][:vip]%>" > /dev/null
-then
-  python /usr/local/bin/query_graphite.py | /usr/local/bin/zabbix_sender -z <%= node[:bcpc][:management][:vip] %> -p <%= node[:bcpc][:zabbix][:server_port] %> -T -i - > /dev/null
-fi
+python /usr/local/bin/query_graphite.py | /usr/local/bin/zabbix_sender -z <%= node[:bcpc][:management][:vip] %> -p <%= node[:bcpc][:zabbix][:server_port] %> -T -i - > /dev/null

--- a/cookbooks/bcpc-hadoop/templates/default/zabbix.run_zabbix_sender.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/zabbix.run_zabbix_sender.sh.erb
@@ -1,2 +1,5 @@
 #!/bin/bash
-python /usr/local/bin/query_graphite.py | /usr/local/bin/zabbix_sender -z <%= node[:bcpc][:management][:vip] %> -p <%= node[:bcpc][:zabbix][:server_port] %> -T -i - > /dev/null
+if mysql -u<%="#{get_config('mysql-zabbix-user')}"%> -p<%="#{get_config!('password','mysql-zabbix','os')} #{node['bcpc']['zabbix_dbname']}"%> --raw --batch -e 'select host_id from leader_election where id=1' | grep "<%=node[:hostname]%>" > /dev/null
+then
+  python /usr/local/bin/query_graphite.py | /usr/local/bin/zabbix_sender -z <%= node[:bcpc][:management][:vip] %> -p <%= node[:bcpc][:zabbix][:server_port] %> -T -i - > /dev/null
+fi

--- a/cookbooks/bcpc/NOTICE.txt
+++ b/cookbooks/bcpc/NOTICE.txt
@@ -1,0 +1,21 @@
+Cookbook Name: bcpc
+Copyright 2015, Bloomberg L.P.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this cookbook except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Leader Election using MySQL:
+- Although leader election logic is simple and has fairly similar implementaions
+  in other tools for eg: Zookeeper
+  http://zookeeper.apache.org/doc/trunk/recipes.html#sc_leaderElection, the 
+  implementation using MySQL was inspired by and follows closely the following
+  article: http://code.openark.org/blog/mysql/leader-election-using-mysql

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -140,6 +140,8 @@ default['bcpc']['zabbix']['web_port'] = 7777
 default['bcpc']['zabbix']['scripts']['sender'] = "/usr/local/bin/run_zabbix_sender.sh"
 default['bcpc']['zabbix']['scripts']['mail'] = "/usr/local/bin/zbx_mail.sh"
 default['bcpc']['zabbix']['scripts']['query_graphite'] = "/usr/local/bin/query_graphite.py"
+# Interval (in seconds) during which we expect chef-client to have run at least once
+default['bcpc']['zabbix']['chef_client_check_interval'] = (node['chef_client']['interval'].to_i + node['chef_client']['splay'].to_i) * 2
 
 default['bcpc']['keepalived']['config_template'] = "keepalived.conf_openstack"
 

--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -297,3 +297,21 @@ def calc_reverse_dns_zone(cidr)
 
 end
 
+# Internal: Check if the given host is the Zabbix leader 
+#
+# host - host id (eg: hostname) 
+#
+# Examples
+#
+#   is_zabbix_leader?("bcpc-vm1")
+#   # => true
+#
+# Returns true if given host is the Zabbix leader, false otherwise 
+def is_zabbix_leader?(host)
+  leader_check = "mysql -u#{get_config('mysql-zabbix-user')} -p#{get_config!('password','mysql-zabbix','os')} #{node['bcpc']['zabbix_dbname']} --raw --batch -e 'select host_id from leader_election where id=1' "
+  cmd = Mixlib::ShellOut.new(
+    leader_check, :timeout => 10
+  ).run_command
+  Chef::Log.debug("is_zabbix_leader: #{cmd.stdout}")
+  cmd.exitstatus == 0 && cmd.stdout.include?(host)
+end

--- a/cookbooks/bcpc/recipes/zabbix-head.rb
+++ b/cookbooks/bcpc/recipes/zabbix-head.rb
@@ -20,7 +20,8 @@
 include_recipe "bcpc::mysql"
 include_recipe "bcpc::apache2"
 
-make_config('mysql-zabbix-user', "zabbix")
+mysql_zabbix_user = 'zabbix'
+make_config('mysql-zabbix-user', mysql_zabbix_user)
 
 # backward compatibility
 mysql_zabbix_password = get_config("mysql-zabbix-password")
@@ -71,113 +72,139 @@ chef_vault_secret "zabbix-guest" do
 end.run_action(:create_if_missing)
 
 remote_file "/tmp/zabbix-server.tar.gz" do
-    source "#{get_binary_server_url}/zabbix-server.tar.gz"
-    owner "root"
-    mode 00444
-    not_if { File.exists?("/usr/local/sbin/zabbix_server") }
+  source "#{get_binary_server_url}/zabbix-server.tar.gz"
+  owner "root"
+  mode 00444
+  not_if { File.exists?("/usr/local/sbin/zabbix_server") }
 end
 
 bash "install-zabbix-server" do
-    code "tar zxf /tmp/zabbix-server.tar.gz -C /usr/local/ && rm /tmp/zabbix-server.tar.gz"
-    not_if { File.exists?("/usr/local/sbin/zabbix_server") }
+  code "tar zxf /tmp/zabbix-server.tar.gz -C /usr/local/ && rm /tmp/zabbix-server.tar.gz"
+  not_if { File.exists?("/usr/local/sbin/zabbix_server") }
 end
 
 user node[:bcpc][:zabbix][:user] do
-    shell "/bin/false"
-    home "/var/log"
-    gid node[:bcpc][:zabbix][:group]
-    system true
+  shell "/bin/false"
+  home "/var/log"
+  gid node[:bcpc][:zabbix][:group]
+  system true
 end
 
 directory "/var/log/zabbix" do
-    user node[:bcpc][:zabbix][:user]
-    group node[:bcpc][:zabbix][:group]
-    mode 00755
+  user node[:bcpc][:zabbix][:user]
+  group node[:bcpc][:zabbix][:group]
+  mode 00755
 end
 
 template "/etc/init/zabbix-server.conf" do
-    source "upstart-zabbix-server.conf.erb"
-    owner "root"
-    group "root"
-    mode 00644
-    notifies :restart, "service[zabbix-server]", :delayed
+  source "upstart-zabbix-server.conf.erb"
+  owner "root"
+  group "root"
+  mode 00644
+  notifies :restart, "service[zabbix-server]", :delayed
 end
 
 template "/usr/local/etc/zabbix_server.conf" do
-    source "zabbix_server.conf.erb"
-    owner node[:bcpc][:zabbix][:user]
-    group "root"
-    mode 00600
-    notifies :restart, "service[zabbix-server]", :delayed
+  source "zabbix_server.conf.erb"
+  owner node[:bcpc][:zabbix][:user]
+  group "root"
+  mode 00600
+  notifies :restart, "service[zabbix-server]", :delayed
 end
 
 ruby_block "zabbix-database-creation" do
-    block do
-        mysql_root_password = get_config!('password','mysql-root','os')
-        if not system "mysql -uroot -p#{ mysql_root_password } -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['zabbix_dbname']}\"'|grep \"#{node['bcpc']['zabbix_dbname']}\"" then
-            puts %x[ mysql -uroot -p#{ mysql_root_password } -e "CREATE DATABASE #{node['bcpc']['zabbix_dbname']} CHARACTER SET UTF8;"
-                mysql -uroot -p#{ mysql_root_password } -e "GRANT ALL ON #{node['bcpc']['zabbix_dbname']}.* TO '#{get_config('mysql-zabbix-user')}'@'%' IDENTIFIED BY '#{get_config!('password','mysql-zabbix','os')}';"
-                mysql -uroot -p#{ mysql_root_password } -e "GRANT ALL ON #{node['bcpc']['zabbix_dbname']}.* TO '#{get_config('mysql-zabbix-user')}'@'localhost' IDENTIFIED BY '#{get_config!('password','mysql-zabbix','os')}';"
-                mysql -uroot -p#{ mysql_root_password } -e "FLUSH PRIVILEGES;"
-                mysql -uroot -p#{ mysql_root_password } #{node['bcpc']['zabbix_dbname']} < /usr/local/share/zabbix/schema.sql
-                mysql -uroot -p#{ mysql_root_password } #{node['bcpc']['zabbix_dbname']} < /usr/local/share/zabbix/images.sql
-                mysql -uroot -p#{ mysql_root_password } #{node['bcpc']['zabbix_dbname']} < /usr/local/share/zabbix/data.sql
-                HASH=`echo -n "#{get_config!('password','zabbix-admin','os')}" | md5sum | awk '{print $1}'`
-                mysql -uroot -p#{ mysql_root_password } #{node['bcpc']['zabbix_dbname']} -e "UPDATE users SET passwd=\\"$HASH\\" WHERE alias=\\"#{get_config('zabbix-admin-user')}\\";"
-                HASH=`echo -n "#{get_config!('password','zabbix-guest','os')}" | md5sum | awk '{print $1}'`
-                mysql -uroot -p#{ mysql_root_password } #{node['bcpc']['zabbix_dbname']} -e "UPDATE users SET passwd=\\"$HASH\\" WHERE alias=\\"#{get_config('zabbix-guest-user')}\\";"
-            ]
-        end
+  block do
+    mysql_root_password = get_config!('password','mysql-root','os')
+    if not system "mysql -uroot -p#{ mysql_root_password } -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['zabbix_dbname']}\"'|grep \"#{node['bcpc']['zabbix_dbname']}\"" then
+      puts %x[ mysql -uroot -p#{ mysql_root_password } -e "CREATE DATABASE #{node['bcpc']['zabbix_dbname']} CHARACTER SET UTF8;"
+        mysql -uroot -p#{ mysql_root_password } -e "GRANT ALL ON #{node['bcpc']['zabbix_dbname']}.* TO '#{get_config('mysql-zabbix-user')}'@'%' IDENTIFIED BY '#{get_config!('password','mysql-zabbix','os')}';"
+        mysql -uroot -p#{ mysql_root_password } -e "GRANT ALL ON #{node['bcpc']['zabbix_dbname']}.* TO '#{get_config('mysql-zabbix-user')}'@'localhost' IDENTIFIED BY '#{get_config!('password','mysql-zabbix','os')}';"
+        mysql -uroot -p#{ mysql_root_password } -e "FLUSH PRIVILEGES;"
+        mysql -uroot -p#{ mysql_root_password } #{node['bcpc']['zabbix_dbname']} < /usr/local/share/zabbix/schema.sql
+        mysql -uroot -p#{ mysql_root_password } #{node['bcpc']['zabbix_dbname']} < /usr/local/share/zabbix/images.sql
+        mysql -uroot -p#{ mysql_root_password } #{node['bcpc']['zabbix_dbname']} < /usr/local/share/zabbix/data.sql
+        HASH=`echo -n "#{get_config!('password','zabbix-admin','os')}" | md5sum | awk '{print $1}'`
+        mysql -uroot -p#{ mysql_root_password } #{node['bcpc']['zabbix_dbname']} -e "UPDATE users SET passwd=\\"$HASH\\" WHERE alias=\\"#{get_config('zabbix-admin-user')}\\";"
+        HASH=`echo -n "#{get_config!('password','zabbix-guest','os')}" | md5sum | awk '{print $1}'`
+        mysql -uroot -p#{ mysql_root_password } #{node['bcpc']['zabbix_dbname']} -e "UPDATE users SET passwd=\\"$HASH\\" WHERE alias=\\"#{get_config('zabbix-guest-user')}\\";"
+      ]
     end
+  end
+end
+
+template "/usr/local/share/zabbix/leader_election.sql" do
+  source "zabbix.leader_election.sql.erb"
+  owner "root"
+  group "root"
+  mode 00644
+  notifies :run, "ruby_block[setup-leader-election]", :immediately
+end
+
+mysql_zabbix_password = get_config!('password','mysql-zabbix','os')
+
+# Keeping this query out of 'ruby_block "zabbix-database-creation"' so that the
+# table can be created on an existing cluster which already has zabbix db
+ruby_block "setup-leader-election" do
+  block do
+    puts %x[
+      mysql -u#{mysql_zabbix_user} -p#{mysql_zabbix_password} #{node['bcpc']['zabbix_dbname']} < /usr/local/share/zabbix/leader_election.sql 
+    ]  
+  end
+  action :nothing
+end
+
+bash "elect_leader" do
+  code %Q{ mysql -u#{mysql_zabbix_user} -p#{mysql_zabbix_password} #{node['bcpc']['zabbix_dbname']} -e 'call elect_leader(\"#{node[:hostname]}\")' }
+  returns [0]
 end
 
 service "zabbix-server" do
-    provider Chef::Provider::Service::Upstart
-    action [ :enable, :start ]
+  provider Chef::Provider::Service::Upstart
+  action [ :enable, :start ]
 end
 
 %w{traceroute php5-mysql php5-gd}.each do |pkg|
-    package pkg do
-        action :upgrade
-    end
+  package pkg do
+    action :upgrade
+  end
 end
 
 file "/etc/php5/apache2/conf.d/zabbix.ini" do
-    user "root"
-    group "root"
-    mode 00644
-    content <<-EOH
-        post_max_size = 16M
-        max_execution_time = 300
-        max_input_time = 300
-        date.timezone = America/New_York
-    EOH
-    notifies :restart, "service[apache2]", :delayed
+  user "root"
+  group "root"
+  mode 00644
+  content <<-EOH
+    post_max_size = 16M
+    max_execution_time = 300
+    max_input_time = 300
+    date.timezone = America/New_York
+  EOH
+  notifies :restart, "service[apache2]", :delayed
 end
 
 template "/usr/local/share/zabbix/php/conf/zabbix.conf.php" do
-    source "zabbix.conf.php.erb"
-    user node[:bcpc][:zabbix][:user]
-    group "www-data"
-    mode 00640
-    notifies :restart, "service[apache2]", :delayed
+  source "zabbix.conf.php.erb"
+  user node[:bcpc][:zabbix][:user]
+  group "www-data"
+  mode 00640
+  notifies :restart, "service[apache2]", :delayed
 end
 
 template "/etc/apache2/sites-available/zabbix-web" do
-    source "apache-zabbix-web.conf.erb"
-    owner "root"
-    group "root"
-    mode 00644
-    notifies :restart, "service[apache2]", :delayed
+  source "apache-zabbix-web.conf.erb"
+  owner "root"
+  group "root"
+  mode 00644
+  notifies :restart, "service[apache2]", :delayed
 end
 
 bash "apache-enable-zabbix-web" do
-    user "root"
-    code <<-EOH
-         a2ensite zabbix-web
-    EOH
-    not_if "test -r /etc/apache2/sites-enabled/zabbix-web"
-    notifies :restart, "service[apache2]", :delayed
+  user "root"
+  code <<-EOH
+    a2ensite zabbix-web
+  EOH
+  not_if "test -r /etc/apache2/sites-enabled/zabbix-web"
+  notifies :restart, "service[apache2]", :delayed
 end
 
 include_recipe "bcpc::zabbix-work"
@@ -201,54 +228,3 @@ cookbook_file "/usr/local/bin/check" do
   owner "root"
   mode "00755"
 end
-
-if get_nodes_for("nova-head").length > 0
-  template  "/usr/local/etc/checks/default.yml" do
-    source "checks/default_openstack.yml.erb"
-    owner node[:bcpc][:zabbix][:user]
-      group "root"
-    mode 00640
-  end
-
-  template "/usr/local/etc/zabbix_agentd.conf.d/zabbix-openstack.conf" do
-      source "zabbix_openstack.conf.erb"
-      owner node[:bcpc][:zabbix][:user]
-      group "root"
-      mode 00600
-      notifies :restart, "service[zabbix-agent]", :immediately
-  end
-
-  %w{ nova rgw }.each do |cc| 
-    template  "/usr/local/etc/checks/#{cc}.yml" do
-      source "checks/#{cc}.yml.erb"
-      owner node[:bcpc][:zabbix][:user]
-      group "root"
-      mode 00640
-    end
-    
-    cookbook_file "/usr/local/bin/checks/#{cc}" do
-      source "checks/#{cc}"
-      owner "root"
-      mode "00755"
-    end
-   
-    cron "check-#{cc}" do
-      home "/var/lib/zabbix"
-      user "zabbix"
-      minute "0"
-      path "/usr/local/bin:/usr/bin:/bin"
-      command "zabbix_sender -c /usr/local/etc/zabbix_agentd.conf --key 'check.#{cc}' --value `check -f timeonly #{cc}`"
-    end
-  end
-
-  package "python-requests-aws" do
-  end
-
-  template "/usr/local/bin/zabbix_bucket_stats" do
-    source "zabbix_bucket_stats.erb"
-    owner "root"
-    group "root"
-    mode "00755"
-  end
-end
-

--- a/cookbooks/bcpc/templates/default/zabbix.leader_election.sql.erb
+++ b/cookbooks/bcpc/templates/default/zabbix.leader_election.sql.erb
@@ -1,0 +1,21 @@
+drop table if exists leader_election;
+create table leader_election (
+  id tinyint unsigned not null,
+  host_id varchar(128) not null,
+  heartbeat timestamp not null default current_timestamp,
+  primary key (id)
+) engine=innodb;
+
+drop procedure if exists elect_leader;
+delimiter //
+create procedure elect_leader(in host varchar(128))
+begin
+  insert ignore into leader_election (
+    id, host_id, heartbeat
+  ) values (
+      1, host, now()
+  ) on duplicate key update
+      host_id = if(heartbeat < current_timestamp - interval <%= node['chef_client']['interval'].to_i + node['chef_client']['splay'].to_i %> second,values(host_id),host_id),
+      heartbeat = if(host_id = values(host_id),values(heartbeat),heartbeat);
+end//
+delimiter ;

--- a/cookbooks/bcpc/templates/default/zabbix.leader_election.sql.erb
+++ b/cookbooks/bcpc/templates/default/zabbix.leader_election.sql.erb
@@ -15,7 +15,7 @@ begin
   ) values (
       1, host, now()
   ) on duplicate key update
-      host_id = if(heartbeat < current_timestamp - interval <%= node['chef_client']['interval'].to_i + node['chef_client']['splay'].to_i %> second,values(host_id),host_id),
+      host_id = if(heartbeat < current_timestamp - interval <%= (node['bcpc']['zabbix']['chef_client_check_interval'] / 60).ceil %> minute,values(host_id),host_id),
       heartbeat = if(host_id = values(host_id),values(heartbeat),heartbeat);
 end//
 delimiter ;


### PR DESCRIPTION
This PR provides Zabbix leader election using the shared MySQL database already being deployed on the cluster. Zabbix server processes will continue running on all the head nodes, but only one Head node will act as a Zabbix master at a given time. Here, Zabbix master refers to the node which assumes [responsibility of configuring Zabbix items/triggers/actions](https://github.com/bloomberg/chef-bach/blob/2d8720f76141f5562b6f0ef58560b7e1ba52599d/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb#L34-L308) and running the [cron job for zabbix_sender](https://github.com/bloomberg/chef-bach/blob/2d8720f76141f5562b6f0ef58560b7e1ba52599d/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb#L310-L315) which pushes graphite metric data to Zabbix server. On the non-zabbix-master, the cron job will be deleted and the `bcpc-hadoop::zabbix_monitor` chef resource won't run. 