### PR TITLE
Use an updated ubuntu iso which pxe boots faster

### DIFF
--- a/build_bins.sh
+++ b/build_bins.sh
@@ -157,7 +157,7 @@ if ! [[ -f $UBUNTU_IMAGE ]]; then
   # Download this ISO to get the latest kernel/X LTS stack installer
   #$CURL -o $UBUNTU_IMAGE http://archive.ubuntu.com/ubuntu/dists/precise-updates/main/installer-amd64/current/images/raring-netboot/mini.iso
   while ! $(file $UBUNTU_IMAGE | grep -qE '(x86 boot sector)|(ISO 9660 CD-ROM)'); do
-    $CURL -o $UBUNTU_IMAGE http://archive.ubuntu.com/ubuntu/dists/precise/main/installer-amd64/current/images/netboot/mini.iso
+    $CURL -o $UBUNTU_IMAGE http://archive.ubuntu.com/ubuntu/dists/precise-updates/main/installer-amd64/20101020ubuntu136.21/images/netboot/mini.iso
   done
 fi
 FILES="$UBUNTU_IMAGE $FILES"


### PR DESCRIPTION
This reduces the pxe boot time for a VM from 20-25 minutes to less than 10min.