### PR TITLE
enable oozie to get credentials for hcatalog and hbase

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/oozie_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/oozie_config.rb
@@ -41,7 +41,15 @@ end
   end
 end
 
-link "/etc/oozie/conf.#{node.chef_environment}/hive-site.xml" do
+directory "/etc/oozie/conf.#{node.chef_environment}/action-conf" do
+  mode '0755'
+end
+
+directory "/etc/oozie/conf.#{node.chef_environment}/action-conf/hive" do
+  mode '0755'
+end
+
+link "/etc/oozie/conf.#{node.chef_environment}/action-conf/hive/hive-site.xml" do
   to "/etc/hive/conf.#{node.chef_environment}/hive-site.xml"
 end
 

--- a/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-site.xml.erb
@@ -278,6 +278,15 @@
     <!-- Default proxyuser configuration for Hue -->
 
   <% if node[:bcpc][:hadoop][:kerberos][:enable] == true then %> 
+
+  <property>
+    <name>oozie.credentials.credentialclasses</name>
+    <value>
+      hcat=org.apache.oozie.action.hadoop.HCatCredentials,
+      hive2=org.apache.oozie.action.hadoop.Hive2Credentials
+    </value>
+  </property>
+
   <property>
     <name>oozie.authentication.kerberos.principal</name>
     <value><%=node[:bcpc][:hadoop][:kerberos][:data][:spnego][:principal]%>/<%=node[:bcpc][:hadoop][:kerberos][:data][:spnego][:princhost]=="_HOST" ? float_host(node[:fqdn]) : node[:bcpc][:hadoop][:kerberos][:data][:spnego][:princhost]%>@<%=node[:bcpc][:hadoop][:kerberos][:realm]%></value>


### PR DESCRIPTION
Oozie hive jobs are currently failing because only default database is being exposed by hive.  In order to see other databases oozie launched hive needs to be able to connect to the metastore.

**Verification Procedure**
- Database creation
create database sasl_meta_test;
use sasl_meta_test;
create table sasl_test_data (id int, data string);
insert into table sasl_test_data values(1, "aaa111");
insert into table sasl_test_data values(2, "bbb222");
insert into table sasl_test_data values(3, "ccc333");

- Ooozie job configuration
- job.properties
```text
nameNode=hdfs://f-bcpc-vm1.bcpc.example.com:8020
jobTracker=f-bcpc-vm2.bcpc.example.com:8032
fs.defaultFS=hdfs://f-bcpc-vm1.bcpc.example.com:8020
mapreduce.jobtracker.address=f-bcpc-vm2.bcpc.example.com:8032
oozie.libpath=hdfs://f-bcpc-vm1.bcpc.example.com:8020/user/oozie/share/lib/lib_20150422122443
oozie.use.system.libpath=true
queueName=default
examplesRoot=oozie-tests
oozie.wf.application.path=${nameNode}/user/${user.name}/${examplesRoot}/hive
outputDir=hive_output
````

- workflow.xml
````xml
<workflow-app xmlns="uri:oozie:workflow:0.3" name="map-reduce-wf">
  <credentials>
    <credential name="hcat_creds" type="hcat">
      <property>
        <name>hcat.metastore.uri</name>
        <value>thrift://f-bcpc-vm2.bcpc.example.com:9083</value>
      </property>
      <property>
        <name>hive.metastore.kerberos.principal</name>
        <value>hive/_HOST@BCPC.EXAMPLE.COM</value>
      </property>
      <property>
        <name>hcat.metastore.principal</name>
        <value>hive/_HOST@BCPC.EXAMPLE.COM</value>
      </property>
    </credential>
  </credentials>
  <start to="hive-query"/>
  <action name="hive-query" cred="hcat_creds">
    <hive xmlns="uri:oozie:hive-action:0.2">
     <job-tracker>${jobTracker}</job-tracker>
     <name-node>${nameNode}</name-node>
     <configuration>
          <property>
              <name>oozie.launcher.mapreduce.map.memory.mb</name>
              <value>256</value>
          </property>
          <property>
              <name>oozie.launcher.mapreduce.map.java.opts</name>
              <value>"-Xmx205m"</value>
          </property>
          <property>
              <name>oozie.launcher.mapreduce.reduce.memory.mb</name>
              <value>256</value>
          </property>
          <property>
              <name>oozie.launcher.mapreduce.reduce.java.opts</name>
              <value>"-Xmx205m"</value>
          </property>
          <property>
              <name>oozie.launcher.yarn.app.mapreduce.am.resource.mb</name>
              <value>256</value>
          </property>
     </configuration>
     <script>hivescript.hql</script>
     <param>OUTPUT=hive_output</param>
    </hive>
   <ok to="end"/>
   <error to="fail"/>
  </action>
  <kill name="fail">
    <message>Oozie hive action failed, error message[${wf:errorMessage(wf:lastErrorNode())}]</message>
  </kill>
  <end name="end"/>
</workflow-app>
````

- hivescript.hql
````text
use sasl_meta_test;
insert overwrite directory '${OUTPUT}' select * from sasl_test_data;
````

**OUTPUT**
````text
ubuntu@bcpc-vm3:~$ hdfs dfs -cat hive_output/000000_0
1aaa111
2bbb222
3ccc333
````


**TESTING CAVEATS**
- manually assign the hive principal name to hive/f-bcpc-vm2.bcpc.example.com@BCPC.EXAMPLE.COM otherwise hive thinks it should be hive/bcpc-
vm2.bcpc.example.com@BCPC.EXAMPLE.COM and that does not match the keytab.
This is described in #361 and only affects the VM environment

- oozie workflow configuration needed adjustments for smaller memory size on VM cluster (as I was unable to get it to read mapred-site.xml)
````xml
<configuration>
  <property>
      <name>oozie.launcher.mapreduce.map.memory.mb</name>
      <value>256</value>
  </property>

  <property>
      <name>oozie.launcher.mapreduce.map.java.opts</name>
      <value>"-Xmx205m"</value>
  </property>

  <property>
      <name>oozie.launcher.mapreduce.reduce.memory.mb</name>
      <value>256</value>
  </property>

  <property>
      <name>oozie.launcher.mapreduce.reduce.java.opts</name>
      <value>"-Xmx205m"</value>
  </property>

  <property>
      <name>oozie.launcher.yarn.app.mapreduce.am.resource.mb</name>
      <value>256</value>
  </property>
</configuration>

````

- Two worker VMs with 8GB each with two vcores exposed in node manager.  Probbaly could have just used one and assigned 16 and 4-6 cores