### PR TITLE
Improve graphite-to-zabbix flow

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/monitoring.rb
+++ b/cookbooks/bcpc-hadoop/attributes/monitoring.rb
@@ -31,3 +31,10 @@ default["bcpc"]["hadoop"]["graphite"]["metric_fetch_period"] = 2
 # Override Graphite/Zabbix queries/triggers here
 default["bcpc"]["hadoop"]["graphite"]["basic_queries"] = {} # Basic OS/Node Queries
 default["bcpc"]["hadoop"]["graphite"]["service_queries"] = {} # Service specific queries
+
+default["bcpc"]["hadoop"]["zabbix"]["query_graphite"] = {
+  'log_file' => '/var/log/zabbix/query_graphite.log',
+  'logging_level' => 'DEBUG',
+  'rolling_max_bytes' => 20971520, # 20mb
+  'rolling_backup_count' => 3 
+}

--- a/cookbooks/bcpc-hadoop/files/default/query_graphite.py
+++ b/cookbooks/bcpc-hadoop/files/default/query_graphite.py
@@ -43,10 +43,13 @@ def write_data(zbxhost, zbxkey, data):
       if key == 'datapoints':
         for v in value:
           if (v[0] is None):
-            val = 0.0
+            val = 0
           else:
-            val = v[0]
-          out = "%s %s %s %0.1f" % (zbxhost,zbxkey,str(v[1]),val)
+            try:
+              val = int(v[0])
+            except ValueError:
+              val = 0
+          out = "%s %s %s %d" % (zbxhost,zbxkey,str(v[1]),val)
           sys.stdout.write(out+'\n')
 
 if __name__ == "__main__":

--- a/cookbooks/bcpc-hadoop/recipes/graphite_queries.rb
+++ b/cookbooks/bcpc-hadoop/recipes/graphite_queries.rb
@@ -58,7 +58,6 @@ monitored_nodes_objs.each do |node_obj|
       'trigger_val' => "max(" +
         "#{node["bcpc"]["hadoop"]["zabbix"]["chef_client_check_interval"]}, 0" +
       ")",
-      'value_type' => 0,
       'trigger_cond' => "=0",
       'trigger_name' => "#{host}_ChefClientFailure",
       'trigger_dep' => ["#{host}_NodeAvailability"],
@@ -96,7 +95,6 @@ monitored_nodes_objs.each do |node_obj|
         'type' => "servers",
         'query' => "diskspace.#{disk}.byte_avail",
         'trigger_val' => "max(61,0)",
-        'value_type' => 0,
         'trigger_cond' => "=0",
         'trigger_name' => "#{host}_#{disk}_Availability",
         'trigger_dep' => ["#{host}_NodeAvailability"],
@@ -112,9 +110,9 @@ monitored_nodes_objs.each do |node_obj|
         'type' => "servers",
         'query' => "diskspace.#{disk}.byte_used",
         'trigger_val' => "max(61,0)",
-        'value_type' => 0,
-        'trigger_cond' => ">#{(size * 0.90).round(2)}G",
+        'trigger_cond' => ">#{(size * 0.90).ceil}G",
         'trigger_name' => "#{host}_#{disk}_SpaceUsed",
+        'trigger_dep' => ["#{host}_NodeAvailability"],
         'enable' => true,
         'trigger_desc' => "More than 90% of disk space used",
         'severity' => 3,

--- a/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
+++ b/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
@@ -18,8 +18,13 @@ template node['bcpc']['zabbix']['scripts']['mail'] do
   mode 0755
 end
 
-cookbook_file node['bcpc']['zabbix']['scripts']['query_graphite'] do
-  source "query_graphite.py"
+template node['bcpc']['zabbix']['scripts']['query_graphite'] do
+  source "graphite.query_graphite.py.erb"
+  variables(:log_file => node[:bcpc][:hadoop][:zabbix][:query_graphite][:log_file],
+            :log_level => node[:bcpc][:hadoop][:zabbix][:query_graphite][:logging_level],
+            :max_bytes => node[:bcpc][:hadoop][:zabbix][:query_graphite][:rolling_max_bytes],
+            :backup_count => node[:bcpc][:hadoop][:zabbix][:query_graphite][:rolling_backup_count]
+           )
   mode 0744
   owner "root"
   group "root"

--- a/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
+++ b/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
@@ -158,7 +158,7 @@ ruby_block "zabbix_monitor" do
           trend_days = attrs['trend_days']
         end
         if attrs['value_type'].nil?
-          value_type = 0 # default = numeric float
+          value_type = 3 # default = numeric unsigned
         else
           value_type = attrs['value_type']
         end

--- a/cookbooks/bcpc-hadoop/templates/default/graphite.query_graphite.py.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/graphite.query_graphite.py.erb
@@ -3,9 +3,26 @@ import urllib
 import urllib2
 import json
 import sys
+import logging
+from logging.handlers import RotatingFileHandler
+
+LOGGER = None
+
+def create_log(path):
+  """  
+  Creates a rotating log
+  """
+  global LOGGER
+  LOGGER = logging.getLogger('query_graphite')
+  LOGGER.setLevel(logging.<%= @log_level %>)
+  handler = RotatingFileHandler(path, maxBytes=<%= @max_bytes %>, backupCount=<%= @backup_count %>)
+  formatter = logging.Formatter('%(asctime)s %(levelname)s - %(message)s')
+  handler.setFormatter(formatter)
+  LOGGER.addHandler(handler)
 
 def query_graphite(url):
-  """Function to make query to graphite to retrive monitoring data
+  """
+  Function to make query to graphite to retrive monitoring data
   Returns data for the query in json format. Refer document
   http://graphite.readthedocs.org/en/1.0/url-api.html for details
   Accepts url formatted to make a query to graphite. Time out to get
@@ -13,6 +30,7 @@ def query_graphite(url):
   Keyword arguments:
   url: graphite jsp api url along with the query parameter
   """
+
   req = urllib2.Request(url)
   response = urllib2.urlopen(req,timeout=30)
   res = response.read()
@@ -20,7 +38,8 @@ def query_graphite(url):
   return data
 
 def write_data(zbxhost, zbxkey, data):
-  """Function to parse the json object retruned by graphite query
+  """
+  Function to parse the json object retruned by graphite query
   and generate data in the format zabbix_sender protocol needs
   Refer to zabbix sender man pages for details.
   https://www.zabbix.com/documentation/1.8/manpages/zabbix_sender
@@ -38,10 +57,12 @@ def write_data(zbxhost, zbxkey, data):
       ]
   }]
   """
+  
   for entry in data:
     for key,value in entry.iteritems():
       if key == 'datapoints':
         for v in value:
+          ts = str(v[1])
           if (v[0] is None):
             val = 0
           else:
@@ -49,12 +70,20 @@ def write_data(zbxhost, zbxkey, data):
               val = int(v[0])
             except ValueError:
               val = 0
-          out = "%s %s %s %d" % (zbxhost,zbxkey,str(v[1]),val)
-          sys.stdout.write(out+'\n')
+              LOGGER.warn("Cannot convert %s.%s(%s) to int" + \
+                          (zbxkey, ts, str(v[0])))
+          out = "%s %s %s %d" % (zbxhost,zbxkey,ts,val)
+          sys.stdout.write(out + '\n')
 
-if __name__ == "__main__":
-  with open("/usr/local/etc/query_graphite.config","r") as fin:
+def main():
+  create_log("<%= @log_file %>")
+  LOGGER.info('start')
+  with open('/usr/local/etc/query_graphite.config','r') as fin:
     config = json.load(fin)
-    for entry in config["queries"]:
-      graphite_data=query_graphite(entry["graphite_url"])
-      write_data(entry["zabbix_host"],entry["zabbix_key"],graphite_data)
+    for entry in config['queries']:
+      graphite_data=query_graphite(entry['graphite_url'])
+      write_data(entry['zabbix_host'],entry['zabbix_key'],graphite_data)
+  LOGGER.info('end')
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
This PR provides the following:

- Changes the default data type for a Zabbix item from numeric float to numeric unsigned. This was done because numeric float cannot hold values greater than [double(16,4)](https://www.zabbix.com/documentation/2.2/manual/config/items/item) and the size(in bytes) for disks could be in Tera Bytes which is incompatible for this data type. Metric values from graphite are of the form `[0-9]+.0` and so we don't loose anything while converting the value to an int (in python) and it should be compatible for the type and range of values we expect to see in the metrics we use.
- Add a trigger dependency between `"#{host}_#{disk}_SpaceUsed"` and `"#{host}_NodeAvailability"`
- Add logging to `query_graphite.py` so one has visibility into when the script ran, for how long and if there were any errors.