### PR TITLE
Use cabin 0.7.2 instead of 0.8.0

### DIFF
--- a/build_bins.sh
+++ b/build_bins.sh
@@ -44,6 +44,11 @@ apt-get -y update
 
 # Install tools needed for packaging
 apt-get -y install git rubygems make pkg-config pbuilder python-mock python-configobj python-support cdbs python-all-dev python-stdeb libmysqlclient-dev libldap2-dev ruby-dev gcc patch rake ruby1.9.3 ruby1.9.1-dev python-pip python-setuptools dpkg-dev apt-utils haveged libtool autoconf automake autotools-dev unzip rsync autogen
+
+if [[ -z `gem list --local cabin | grep cabin | cut -f1 -d" "` ]]; then
+  gem install cabin --no-ri --no-rdoc -v 0.7.2
+fi
+
 if [[ -z `gem list --local fpm | grep fpm | cut -f1 -d" "` ]]; then
   gem install fpm --no-ri --no-rdoc -v 1.3.3
 fi


### PR DESCRIPTION
This appears to fix issue #362.

The symptom: Cabin-related stacktrace during fpm invocation.

Cabin 0.8.0 changes its API such that it is incompatible with the
version of fpm in use in chef-bach.  Downgrading to cabin 0.7.2
resolves the API incompatibility.

Since Cabin is a log library, I expected to find an underlying
problem, but none presented itself.