### PR TITLE
Correc the Yarn site property resource.percentage-physical-cpu-limit 

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
@@ -238,7 +238,7 @@
   </property>
 
   <property>
-    <name>resource.percentage-physical-cpu-limit</name>
+    <name>yarn.nodemanager.resource.percentage-physical-cpu-limit</name>
     <value><%= (node['bcpc']['hadoop']['yarn']['nodemanager']['avail_vcpu']['count'] ? \
                  node['bcpc']['hadoop']['yarn']['nodemanager']['avail_vcpu']['count']/node['cpu']['total'] :
                  node['bcpc']['hadoop']['yarn']['nodemanager']['avail_vcpu']['ratio'] * 100).floor %></value>


### PR DESCRIPTION
The supported yarn-site property name in is yarn.nodemanager.resource.percentage-physical-cpu-limit.