### PR TITLE
Not importing metrics.search in graphite.wsgi

### DIFF
--- a/cookbooks/bcpc/templates/default/graphite.wsgi.erb
+++ b/cookbooks/bcpc/templates/default/graphite.wsgi.erb
@@ -22,4 +22,3 @@ application = django.core.handlers.wsgi.WSGIHandler()
 # to the process.
 from graphite.logger import log
 log.info("graphite.wsgi - pid %d - reloading search index" % os.getpid())
-import graphite.metrics.search


### PR DESCRIPTION
search module has been recently removed, fixes #358 