### PR TITLE
Add hbase property hbase.coprocessor.abortonerror

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hbase.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hbase.rb
@@ -5,6 +5,7 @@ default["bcpc"]["hadoop"]["hbase"]["superusers"] = ["hbase"]
 # Interval in milli seconds when HBase major compaction need to be run. Disabled by default
 default["bcpc"]["hadoop"]["hbase"]["major_compact"]["time"] = 0
 default["bcpc"]["hadoop"]["hbase"]["bucketcache"]["enabled"] = false
+default["bcpc"]["hadoop"]["hbase_rs"]["coprocessor"]["abortonerror"] = true
 default["bcpc"]["hadoop"]["hbase_rs"]["xmn"]["size"] = 256
 default["bcpc"]["hadoop"]["hbase_rs"]["xms"]["size"] = 1024
 default["bcpc"]["hadoop"]["hbase_rs"]["xmx"]["size"] = 1024

--- a/cookbooks/bcpc-hadoop/templates/default/hb_hbase-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hb_hbase-site.xml.erb
@@ -295,4 +295,9 @@
     <name>hbase.replication</name>
     <value>true</value>
   </property>
+
+  <property>
+    <name>hbase.coprocessor.abortonerror</name>
+    <value><%= node["bcpc"]["hadoop"]["hbase_rs"]["coprocessor"]["abortonerror"] %></value>
+  </property>
 </configuration>


### PR DESCRIPTION
The property ``hbase.coprocessor.abortonerror`` will help recover HBase cluster gracefully if there was an issue with a co-processor that got deployed to the cluster. The default value is ``true`` and to recover it can be set to ``false`` so that the HBase master and RS will come-up so that the issue can be fixed.