### PR TITLE
Add HBase jars to Oozie server

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/oozie_pack.rb
+++ b/cookbooks/bcpc-hadoop/recipes/oozie_pack.rb
@@ -1,0 +1,96 @@
+#
+# Recipe to include hbase jar files into Oozie
+#
+package "hbase" do
+  action :upgrade
+end
+
+bash "/tmp/oozie.war" do
+  user "root"
+  group "root"
+  code <<-EOH
+    cp /usr/hdp/2.2.0.0-2041/oozie/oozie-server/webapps/oozie.war /tmp/oozie.war
+  EOH
+  action :run
+end
+
+directory '/tmp/oozie-hbase-prep' do
+  owner 'root'
+  group 'root'
+  mode '0755'
+  action :create
+end
+
+bash 'extract-oozie-war' do
+  user "root"
+  group "root"
+  cwd "/tmp/oozie-hbase-prep"
+  code <<-EOH
+    jar -xf ../oozie.war
+  EOH
+  action :run
+end
+
+bash 'copy-hbase-jars' do
+  user "root"
+  group "root"
+  code <<-EOH
+    cp /usr/hdp/2.2.0.0-2041/hbase/lib/hbase-common-0.98.4.2.2.0.0-2041-hadoop2.jar /tmp/oozie-hbase-prep/WEB-INF/lib/hbase-common-0.98.4.2.2.0.0-2041-hadoop2.jar
+    cp /usr/hdp/2.2.0.0-2041/hbase/lib/hbase-client-0.98.4.2.2.0.0-2041-hadoop2.jar /tmp/oozie-hbase-prep/WEB-INF/lib/hbase-client-0.98.4.2.2.0.0-2041-hadoop2.jar
+    cp /usr/hdp/2.2.0.0-2041/hbase/lib/hbase-server-0.98.4.2.2.0.0-2041-hadoop2.jar /tmp/oozie-hbase-prep/WEB-INF/lib/hbase-server-0.98.4.2.2.0.0-2041-hadoop2.jar
+    cp /usr/hdp/2.2.0.0-2041/hbase/lib/hbase-protocol-0.98.4.2.2.0.0-2041-hadoop2.jar /tmp/oozie-hbase-prep/WEB-INF/lib/hbase-protocol-0.98.4.2.2.0.0-2041-hadoop2.jar
+    cp /usr/hdp/2.2.0.0-2041/hbase/lib/hbase-hadoop2-compat-0.98.4.2.2.0.0-2041-hadoop2.jar /tmp/oozie-hbase-prep/WEB-INF/lib/hbase-hadoop2-compat-0.98.4.2.2.0.0-2041-hadoop2.jar
+    cp /usr/hdp/2.2.0.0-2041/hbase/lib/htrace-core-2.04.jar /tmp/oozie-hbase-prep/WEB-INF/lib/htrace-core-2.04.jar
+    cp /usr/hdp/2.2.0.0-2041/hbase/lib/htrace-core-3.0.4.jar /tmp/oozie-hbase-prep/WEB-INF/lib/htrace-core-3.0.4.jar
+    cp /usr/hdp/2.2.0.0-2041/hbase/lib/netty-3.6.6.Final.jar /tmp/oozie-hbase-prep/WEB-INF/lib/netty-3.6.6.Final.jar
+  EOH
+  action :run
+  not_if do ::File.exists?('/tmp/oozie-hbase-prep/WEB-INF/lib/htrace-core-2.04.jar') end
+  notifies :run,"bash[create-new-oozie-war]", :immediately
+end
+
+bash 'create-new-oozie-war' do
+  user "root"
+  group "root"
+  code <<-EOH
+    cd /tmp/oozie-hbase-prep
+    jar -cMf ../oozie.war *
+  EOH
+  action :nothing
+  notifies :stop,"service[stop-oozie]", :immediately
+end
+
+service "stop-oozie" do
+  action :nothing
+  service_name "oozie"
+  supports :status => true, :restart => true, :reload => false
+  notifies :run,"bash[copy-hbase-jars]", :immediately
+end
+
+bash 'copy-hbase-jars' do
+  user "root"
+  group "root"
+  code <<-EOH
+    cp /usr/hdp/2.2.0.0-2041/oozie/oozie-server/webapps/oozie.war /usr/hdp/2.2.0.0-2041/oozie/oozie-server/webapps/oozie.war.orig
+    rm -fr /usr/hdp/2.2.0.0-2041/oozie/oozie-server/webapps/oozie.war
+    cp /tmp/oozie.war /usr/hdp/2.2.0.0-2041/oozie/oozie-server/webapps/oozie.war
+    rm -rf /usr/hdp/2.2.0.0-2041/oozie/oozie-server/webapps/oozie
+  EOH
+  action :nothing
+  notifies :start,"service[start-oozie]", :immediately
+end
+
+service "start-oozie" do
+  action :nothing
+  service_name "oozie"
+  supports :status => true, :restart => true, :reload => false
+end
+
+directory '/tmp/oozie-hbase-prep' do
+  action :delete
+  recursive true
+end
+
+file '/tmp/oozie.war' do
+  action :delete
+end

--- a/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-site.xml.erb
@@ -282,6 +282,7 @@
   <property>
     <name>oozie.credentials.credentialclasses</name>
     <value>
+      hbase=org.apache.oozie.action.hadoop.HbaseCredentials,
       hcat=org.apache.oozie.action.hadoop.HCatCredentials,
       hive2=org.apache.oozie.action.hadoop.Hive2Credentials
     </value>

--- a/cookbooks/bcpc_jmxtrans/attributes/default.rb
+++ b/cookbooks/bcpc_jmxtrans/attributes/default.rb
@@ -12,6 +12,11 @@ default['jmxtrans']['default_queries']['zookeeper'] = [
      'obj' => "org.apache.ZooKeeperService:name0=ReplicatedServer_id*",
      'result_alias' => "zookeeper",
      'attr' => [ "QuorumSize" ]
+  },
+  {
+    'obj' => "org.apache.ZooKeeperService:name0=ReplicatedServer_id*,name1=replica.*,name2=Follower,name3=InMemoryDataTree",
+    'result_alias' => "zookeeper",
+    'attr' => [ "NodeCount" ]
   }
 ]
 default['jmxtrans']['default_queries']['kafka'] = [

--- a/cookbooks/bcpc_jmxtrans/attributes/default.rb
+++ b/cookbooks/bcpc_jmxtrans/attributes/default.rb
@@ -12,11 +12,6 @@ default['jmxtrans']['default_queries']['zookeeper'] = [
      'obj' => "org.apache.ZooKeeperService:name0=ReplicatedServer_id*",
      'result_alias' => "zookeeper",
      'attr' => [ "QuorumSize" ]
-  },
-  {
-    'obj' => "org.apache.ZooKeeperService:name0=ReplicatedServer_id*,name1=replica.*,name2=Follower,name3=InMemoryDataTree",
-    'result_alias' => "zookeeper",
-    'attr' => [ "NodeCount" ]
   }
 ]
 default['jmxtrans']['default_queries']['kafka'] = [

--- a/roles/BCPC-Hadoop-Head-MapReduce.json
+++ b/roles/BCPC-Hadoop-Head-MapReduce.json
@@ -8,7 +8,8 @@
     "role[BCPC-Hadoop-Head]",
     "recipe[bcpc-hadoop::resource_manager]",
     "recipe[bcpc-hadoop::historyserver]",
-    "recipe[bcpc-hadoop::oozie]"
+    "recipe[bcpc-hadoop::oozie]",
+    "recipe[bcpc-hadoop::oozie_pack]"
   ],
   "description": "A highly-available head node in a BCPC Hadoop cluster",
   "chef_type": "role",


### PR DESCRIPTION
This is for enhancement #354 . This will help users to make Hbase related requests through Oozie. These changes were earlier included in PR #369 . But VM cluster build failed with the latest master. This PR is with the latest master.