### PR TITLE
Use a restricted plugin set with ohai on bootstrap

### DIFF
--- a/cookbooks/bcpc/templates/default/knife.rb.erb
+++ b/cookbooks/bcpc/templates/default/knife.rb.erb
@@ -1,7 +1,10 @@
+# -*- mode: ruby -*-
 require 'rubygems'
 require 'ohai'
+
+# Restrict Ohai plugin list so that we don't run out of memory on bootstrap.
 o = Ohai::System.new
-o.all_plugins
+o.all_plugins(['fqdn','hostname','ipaddress'])
 
 log_level                :info
 log_location             STDOUT


### PR DESCRIPTION
By only loading the plugins needed in the configuration file, we can avoid having ohai run out of memory while parsing knife.rb on low-memory bootstrap nodes.