### PR TITLE
Increase jute.maxbuffer to handle large number of znodes by client

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/yarn.rb
+++ b/cookbooks/bcpc-hadoop/attributes/yarn.rb
@@ -10,3 +10,5 @@ default['bcpc']['hadoop']['yarn']['historyserver']['heap']["size"] = 128
 default['bcpc']['hadoop']['yarn']['historyserver']['heap']["ratio"] = 0
 default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["port"] = 8032
 default['bcpc']['hadoop']['yarn']['aux_services']['mapreduce_shuffle']['class'] = 'org.apache.hadoop.mapred.ShuffleHandler'
+default['bcpc']['hadoop']['yarn']['opts']['jute_buffer'] = 6291456
+

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-env.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-env.sh.erb
@@ -56,10 +56,10 @@ fi
 # restore ordinary behaviour
 unset IFS
 
-
 <% if node.run_list.expand(node.chef_environment).recipes.include?("bach_spark::default") %>
 export YARN_USER_CLASSPATH="/usr/spark/current/lib/spark-yarn-shuffle.jar"
 <% end %>
+
 YARN_OPTS="$YARN_OPTS -Dhadoop.log.dir=$YARN_LOG_DIR"
 YARN_OPTS="$YARN_OPTS -Dyarn.log.dir=$YARN_LOG_DIR"
 YARN_OPTS="$YARN_OPTS -Dhadoop.log.file=$YARN_LOGFILE"
@@ -68,9 +68,11 @@ YARN_OPTS="$YARN_OPTS -Dyarn.home.dir=$YARN_COMMON_HOME"
 YARN_OPTS="$YARN_OPTS -Dyarn.id.str=$YARN_IDENT_STRING"
 YARN_OPTS="$YARN_OPTS -Dhadoop.root.logger=${YARN_ROOT_LOGGER:-INFO,console}"
 YARN_OPTS="$YARN_OPTS -Dyarn.root.logger=${YARN_ROOT_LOGGER:-INFO,console}"
+YARN_OPTS="$YARN_OPTS -Dyarn.policy.file=$YARN_POLICYFILE"
+YARN_OPTS="$YARN_OPTS -Djute.maxbuffer=<%= node['bcpc']['hadoop']['yarn']['opts']['jute_buffer'] %>"
+
 if [ "x$JAVA_LIBRARY_PATH" != "x" ]; then
   YARN_OPTS="$YARN_OPTS -Djava.library.path=$JAVA_LIBRARY_PATH"
 fi
-YARN_OPTS="$YARN_OPTS -Dyarn.policy.file=$YARN_POLICYFILE"
 
-
+export YARN_OPTS

--- a/cookbooks/bcpc-hadoop/templates/default/zk_zookeeper-env.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/zk_zookeeper-env.sh.erb
@@ -12,11 +12,16 @@ export ZOO_PID_DIR=/var/run/zookeeper
 export ZOOPIDFILE=$ZOO_PID_DIR/zookeeper-server
 export ZOOCFGDIR=<%= node[:bcpc][:hadoop][:zookeeper][:conf_dir] %>
 export ZOO_DATADIR_AUTOCREATE_DISABLE=1
+SERVER_JVMFLAGS="$SERVER_JVMFLAGS -Djute.maxbuffer=<%= node['bcpc']['hadoop']['yarn']['opts']['jute_buffer'] %>"
+CLIENT_JVMFLAGS="$CLIENT_JVMFLAGS -Djute.maxbuffer=<%= node['bcpc']['hadoop']['yarn']['opts']['jute_buffer'] %>"
 <% if node[:bcpc][:hadoop].attribute?(:jmx_enabled) and node[:bcpc][:hadoop][:jmx_enabled] %>
 export JMXPORT=<%= @zk_jmx_port %>
 <% end %>
 
 <% if node[:bcpc][:hadoop][:kerberos][:enable] == true %>
-export SERVER_JVMFLAGS="-Djava.security.auth.login.config=/etc/zookeeper/conf/zookeeper-server.jaas"
-export CLIENT_JVMFLAGS="-Djava.security.auth.login.config=/etc/zookeeper/conf/zookeeper-client.jaas"
+SERVER_JVMFLAGS="$SERVER_JVMFLAGS -Djava.security.auth.login.config=/etc/zookeeper/conf/zookeeper-server.jaas"
+CLIENT_JVMFLAGS="$CLIENT_JVMFLAGS -Djava.security.auth.login.config=/etc/zookeeper/conf/zookeeper-client.jaas"
 <% end %>
+
+export SERVER_JVMFLAGS
+export CLIENT_JVMFLAGS


### PR DESCRIPTION
This PR enables `zookeeper` clients to handle large number of `znodes` to avoid seeing errors akin to
````
2011-08-29 13:26:47,298 - WARN [NIOServerCxn.Factory:0.0.0.0/0.0.0.0:2181:NIOServerCnxn@639] - Exception causing close of session 0x1319819fcd1000b due to java.io.IOException: Len error 1150247
````