### PR TITLE
Restart services when core-site.xml changes

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -98,4 +98,6 @@ service "hbase-master" do
   subscribes :restart, "template[/etc/hbase/conf/hbase-env.sh]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
   subscribes :restart, "user_ulimit[hbase]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
 end

--- a/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
@@ -126,6 +126,8 @@ service "hive-metastore" do
   subscribes :restart, "template[/etc/hive/conf/hive-log4j.properties]", :delayed
   subscribes :restart, "bash[extract-mysql-connector]", :delayed
   subscribes :restart, "directory[/var/log/hive/gc]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
 end
 
 service "hive-server2" do
@@ -135,4 +137,6 @@ service "hive-server2" do
   subscribes :restart, "template[/etc/hive/conf/hive-log4j.properties]", :delayed
   subscribes :restart, "bash[extract-mysql-connector]", :delayed
   subscribes :restart, "directory[/var/log/hive/gc]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
 end

--- a/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
@@ -145,6 +145,7 @@ service "generally run hadoop-hdfs-namenode" do
   supports :status => true, :restart => true, :reload => false
   service_name "hadoop-hdfs-namenode"
   subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/hdfs-policy.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/hdfs-site_HA.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed

--- a/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
@@ -104,6 +104,7 @@ service "hadoop-hdfs-namenode" do
   supports :restart => true, :status => true, :reload => false
   action [:enable, :start]
   subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/hdfs-policy.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/topology]", :delayed

--- a/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
@@ -115,6 +115,7 @@ if @node['bcpc']['hadoop']['hdfs']['HA'] == true then
     action [:enable, :start]
     supports :status => true, :restart => true, :reload => false
     subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
+    subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
     subscribes :restart, "template[/etc/hadoop/conf/hdfs-policy.xml]", :delayed
     subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
     subscribes :restart, "template[/etc/hadoop/conf/topology]", :delayed

--- a/cookbooks/bcpc-hadoop/recipes/oozie.rb
+++ b/cookbooks/bcpc-hadoop/recipes/oozie.rb
@@ -164,6 +164,9 @@ service "generally run oozie" do
   supports :status => true, :restart => true, :reload => false
   subscribes :restart, "template[/etc/oozie/conf/oozie-site.xml]", :delayed
   subscribes :restart, "template[/etc/oozie/conf/oozie-env.sh]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
 end
 
 ruby_block "Oozie Down" do


### PR DESCRIPTION

This PR takes care of restarting services when `core-site.xml` and `hdfs-site.xml` changes. The impacted services are:
* `NameNode`
* `Oozie`
* `HBase`
* `Hive`