### PR TITLE
control carbon-cache max updates and prevent it from over utilizing disk

### DIFF
--- a/cookbooks/bcpc/attributes/graphite.rb
+++ b/cookbooks/bcpc/attributes/graphite.rb
@@ -18,3 +18,4 @@ default['bcpc']['graphite']['carbon']['storage'] = {
 }
 default['bcpc']['graphite']['django']['version'] = "1.5.4" 
 default['bcpc']['graphite']['carbon']['relay']['idle_timeout'] = 1800 
+default['bcpc']['graphite']['carbon']['cache']['MAX_UPDATES_PER_SECOND'] = 170 

--- a/cookbooks/bcpc/templates/default/carbon.conf.erb
+++ b/cookbooks/bcpc/templates/default/carbon.conf.erb
@@ -9,7 +9,7 @@ LOCAL_DATA_DIR = <%= node['bcpc']['graphite']['local_data_dir'] %>
 LOG_DIR =  <%= node['bcpc']['graphite']['local_log_dir'] %>
 ENABLE_LOGROTATION = True
 MAX_CACHE_SIZE = inf
-MAX_UPDATES_PER_SECOND = 500
+MAX_UPDATES_PER_SECOND = <%= node['bcpc']['graphite']['carbon']['cache']['MAX_UPDATES_PER_SECOND'] %>
 MAX_CREATES_PER_MINUTE = inf
 LINE_RECEIVER_INTERFACE = <%="#{node[:bcpc][:management][:ip]}"%>
 LINE_RECEIVER_PORT = 2003


### PR DESCRIPTION
When MAX_UPDATES_PER_SECOND is too high carbon-cache can deny disk access to other processes such as ZooKeeper. When Zookeeper becomes unstable, so does the entire cluster, Name Node and Resource Manager and HBase and others all depend on being able to reach ZooKeeper. On many clusters we've noticed that carbon-cache is driving root disk utilization to 100%, we need to tell carbon cache to keep more in memory and trickle data to disk slower.