### PR TITLE
enable jmx for yarn

### DIFF
--- a/cluster.txt
+++ b/cluster.txt
@@ -1,3 +1,3 @@
 bcpc-vm1 08:00:27:56:A2:28 10.0.100.11 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Head-Namenode-NoHA],role[BCPC-Hadoop-Head-HBase],role[Copylog]
-bcpc-vm2 08:00:27:E5:3A:00 10.0.100.12 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Head-Namenode-Standby],role[BCPC-Hadoop-Head-MapReduce],role[BCPC-Hadoop-Head-Hive],role[Copylog]
+bcpc-vm2 08:00:27:E5:3A:00 10.0.100.12 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Head-Namenode-Standby],role[BCPC-Hadoop-Head-MapReduce],role[BCPC-Hadoop-Head-ResourceManager],role[BCPC-Hadoop-Head-Hive],role[Copylog]
 bcpc-vm3 08:00:27:AD:1D:EA 10.0.100.13 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Worker],role[Copylog]

--- a/cookbooks/bcpc-hadoop/attributes/yarn.rb
+++ b/cookbooks/bcpc-hadoop/attributes/yarn.rb
@@ -14,3 +14,5 @@ default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["port"] = 8032
 default['bcpc']['hadoop']['yarn']['aux_services']['mapreduce_shuffle']['class'] = 'org.apache.hadoop.mapred.ShuffleHandler'
 default['bcpc']['hadoop']['yarn']['opts']['jute_buffer'] = 6291456
 default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["yarn.client.failover-sleep-base-ms"] = 150
+default['bcpc']['hadoop']['nodemanager']['jmx']['port'] = 3131
+default['bcpc']['hadoop']['resourcemanager']['jmx']['port'] = 3131

--- a/cookbooks/bcpc-hadoop/recipes/hadoop_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hadoop_config.rb
@@ -63,17 +63,26 @@ template "/etc/hadoop/conf/topology" do
   mode 0655
 end
 
-%w{yarn-env.sh
-  hadoop-env.sh}.each do |t|
- template "/etc/hadoop/conf/#{t}" do
-   source "hdp_#{t}.erb"
-   mode 0555
-   variables(:nn_hosts => node[:bcpc][:hadoop][:nn_hosts],
-             :zk_hosts => node[:bcpc][:hadoop][:zookeeper][:servers],
-             :jn_hosts => node[:bcpc][:hadoop][:jn_hosts],
-             :mounts => node[:bcpc][:hadoop][:mounts],
-             :nn_jmx_port => node[:bcpc][:hadoop][:namenode][:jmx][:port],
-             :dn_jmx_port => node[:bcpc][:hadoop][:datanode][:jmx][:port]
-   )
- end
+template "/etc/hadoop/conf/hadoop-env.sh" do
+  source "hdp_hadoop-env.sh.erb"
+  mode 0555
+  variables(
+    :nn_jmx_port => node[:bcpc][:hadoop][:namenode][:jmx][:port],
+    :dn_jmx_port => node[:bcpc][:hadoop][:datanode][:jmx][:port]
+  )
+end
+
+template "/etc/hadoop/conf/yarn-env.sh" do
+  source "hdp_yarn-env.sh.erb"
+  mode 0555
+  variables(
+   :yarn_jute_maxbuffer => node['bcpc']['hadoop']['yarn']['opts']['jute_buffer'],
+   :nm_jmx_port => node[:bcpc][:hadoop][:nodemanager][:jmx][:port],
+   :rm_jmx_port => node[:bcpc][:hadoop][:resourcemanager][:jmx][:port]
+  )
+end  
+
+
+package "openjdk-7-jdk" do
+    action :upgrade
 end

--- a/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
@@ -1,3 +1,5 @@
+# vim: tabstop=2:shiftwidth=2:softtabstop=2 
+#
 include_recipe 'dpkg_autostart'
 include_recipe 'bcpc-hadoop::hadoop_config'
 node[:bcpc][:hadoop][:mounts].each do |i|

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-env.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-env.sh.erb
@@ -69,10 +69,20 @@ YARN_OPTS="$YARN_OPTS -Dyarn.id.str=$YARN_IDENT_STRING"
 YARN_OPTS="$YARN_OPTS -Dhadoop.root.logger=${YARN_ROOT_LOGGER:-INFO,console}"
 YARN_OPTS="$YARN_OPTS -Dyarn.root.logger=${YARN_ROOT_LOGGER:-INFO,console}"
 YARN_OPTS="$YARN_OPTS -Dyarn.policy.file=$YARN_POLICYFILE"
-YARN_OPTS="$YARN_OPTS -Djute.maxbuffer=<%= node['bcpc']['hadoop']['yarn']['opts']['jute_buffer'] %>"
+YARN_OPTS="$YARN_OPTS -Djute.maxbuffer=<%= @yarn_jute_maxbuffer %>"
 
 if [ "x$JAVA_LIBRARY_PATH" != "x" ]; then
   YARN_OPTS="$YARN_OPTS -Djava.library.path=$JAVA_LIBRARY_PATH"
 fi
 
 export YARN_OPTS
+
+YARN_NODEMANAGER_OPTS="-Dcom.sun.management.jmxremote.ssl=false"
+YARN_NODEMANAGER_OPTS="$YARN_NODEMANAGER_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
+YARN_NODEMANAGER_OPTS="$YARN_NODEMANAGER_OPTS -Dcom.sun.management.jmxremote.port=<%= @nm_jmx_port %>"
+export YARN_NODEMANAGER_OPTS
+
+YARN_RESOURCEMANAGER_OPTS="-Dcom.sun.management.jmxremote.ssl=false"
+YARN_RESOURCEMANAGER_OPTS="$YARN_RESOURCEMANAGER_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
+YARN_RESOURCEMANAGER_OPTS="$YARN_RESOURCEMANAGER_OPTS -Dcom.sun.management.jmxremote.port=<%= @rm_jmx_port %>"
+export YARN_RESOURCEMANAGER_OPTS 

--- a/cookbooks/bcpc_jmxtrans/attributes/default.rb
+++ b/cookbooks/bcpc_jmxtrans/attributes/default.rb
@@ -7,6 +7,40 @@ default['jmxtrans']['sw']="jmxtrans-20120525-210643-4e956b1144.zip"
 # Also refer to the jmxtrans community cookbook if queries of the category you are planning to add is
 # already existing in the defualt attributes file
 #
+default['jmxtrans']['default_queries']['nodemanager'] = [
+  {
+    'obj' => "Hadoop:service=NodeManager,name=NodeManagerMetrics",
+    'result_alias' => "NodeManager",
+    'attr' => []
+  }
+]
+default['jmxtrans']['default_queries']['resourcemanager'] = [
+  { 
+    'obj' => "Hadoop:service=ResourceManager,name=ClusterMetrics*",
+    'result_alias' => "ResourceManager",
+    'attr' => [ "NumActiveNMs" ]
+  }, 
+  {
+    'type_name' => ["name", "q0", "user"],
+    'obj' => "Hadoop:service=ResourceManager,name=QueueMetrics,q0=root,user=*",
+    'result_alias' => "ResourceManager",
+    'attr' => [ 
+                "AppsRunning",                                  
+                "AppsPending",                                  
+                "AllocatedMB",                                  
+                "AllocatedVCores",                              
+                "AllocatedContainers",                          
+                "PendingMB",                                    
+                "PendingVCores",                                
+                "PendingContainers",                            
+                "ReservedMB",                                   
+                "ReservedVCores",                               
+                "ReservedContainers",                           
+                "ActiveUsers",                                  
+                "ActiveApplications"                            
+    ]           
+  }     
+]
 default['jmxtrans']['default_queries']['zookeeper'] = [
   {
      'obj' => "org.apache.ZooKeeperService:name0=ReplicatedServer_id*",

--- a/roles/BCPC-Hadoop-Head-ResourceManager.json
+++ b/roles/BCPC-Hadoop-Head-ResourceManager.json
@@ -1,0 +1,24 @@
+{
+  "name": "BCPC-Hadoop-Head-ResourceManager",
+  "json_class": "Chef::Role",
+  "run_list": [
+    "role[Basic]",
+    "role[BCPC-Hadoop-Head]",
+    "recipe[bcpc-hadoop::resource_manager]"
+  ],
+  "description": "A highly-available head node in a BCPC Hadoop cluster",
+  "chef_type": "role",
+  "default_attributes" : {
+    "jmxtrans":  {
+      "servers":  [
+                 {
+                    "type": "resourcemanager",
+                    "service": "hadoop-yarn-resourcemanager",
+                    "service_cmd": "org.apache.hadoop.yarn.server.resourcemanager.ResourceManagerver.quorum.QuorumPeerMain"
+                 }
+        ]
+      }
+  },
+  "override_attributes": {
+  }
+}

--- a/roles/BCPC-Hadoop-Worker.json
+++ b/roles/BCPC-Hadoop-Worker.json
@@ -38,6 +38,11 @@
                     "type": "hbase_rs",
                     "service": "hbase-regionserver",
                     "service_cmd": "org.apache.hadoop.hbase.regionserver.HRegionServer"
+                 },
+                 {
+                   "type": "nodemanager",
+                   "service": "hadoop-yarn-nodemanager",
+                   "service_cmd": "org.apache.hadoop.yarn.server.nodemanager.NodeManager"
                  }
         ]
       }


### PR DESCRIPTION
**BREAKING**
- For the graphite display to be useful, latest version of jmxtrans cookbook
- Role **roles/BCPC-Hadoop-Head-ResourceManager.json** needs to be assigned to both resourcemanagers

**Improvements**

- Enable cluster stat collection for YARN resourcemanager, unfortunately for this to work properly **bcpc-hadoop[recipe::resourcemanager]** had to be assigned a separate role **BCPC-Hadoop-Head-ResourceManager**.  A lot of it has to do with how jmxtrans cook book discovers the data it needs to poll.
- ResourceManager QueMetrics in graphite will display per queue statistics.  This will work properly now that https://github.com/jmxtrans/jmxtrans-cookbook/pull/15 is merged

**Testing**
**Nodemanager**
![nodemanager_jmx](https://cloud.githubusercontent.com/assets/4019043/13716903/f58d52be-e7ab-11e5-9542-fdd888568cb0.jpg)



