### PR TITLE
Enable GC Overhead limit

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hive.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hive.rb
@@ -1,4 +1,4 @@
 default[:bach][:hive][:metastore][:port] = 9083
 default[:bach][:hive][:hiveserver2][:port] = 10000
 default[:bcpc][:hive][:heap][:size]=1024
-default[:bcpc][:hive][:gc_opts] = " -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:/var/log/hive/gc/gc.log-$$-$(hostname)-$(date +'%Y%m%d%H%M').log -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-UseGCOverheadLimit"
+default[:bcpc][:hive][:gc_opts] = " -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:/var/log/hive/gc/gc.log-$$-$(hostname)-$(date +'%Y%m%d%H%M').log -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC"


### PR DESCRIPTION
This PR enables GC Overhead limit for Hive process. Originally it was disabled referring [this](http://hvivani.com.ar/2014/12/06/hive-dealing-with-out-of-memory-and-garbage-collector-errors/) article. Based on recommendation from Hadoop vendor we need to enable it back. 