### PR TITLE
Change to support version 0.2 distcp Oozie action

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-site.xml.erb
@@ -38,7 +38,8 @@
         sqoop-action-0.3.xsd,
         ssh-action-0.1.xsd,
         ssh-action-0.2.xsd,
-        distcp-action-0.1.xsd
+        distcp-action-0.1.xsd,
+        distcp-action-0.2.xsd
       </value>
     </property>
 


### PR DESCRIPTION
Version 0.2 of Oozie ``distcp`` action supports ``global`` in workflow definition. This in turn reduces complexity in the workflow xml definition and improves readability.