### PR TITLE
ZooKeeper configuration changes

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/zookeeper.rb
+++ b/cookbooks/bcpc-hadoop/attributes/zookeeper.rb
@@ -8,6 +8,9 @@ default[:bcpc][:hadoop][:zookeeper][:conf_dir] = '/etc/zookeeper/conf'
 # Data directory for Zookeeper state
 default[:bcpc][:hadoop][:zookeeper][:data_dir] = '/var/lib/zookeeper'
 
+# Data log directory for Zookeeper state
+default[:bcpc][:hadoop][:zookeeper][:data_log_dir] = '/var/lib/zookeeper'
+
 # Log directory for Zookeeper state
 default[:bcpc][:hadoop][:zookeeper][:log_dir] = '/var/log/zookeeper'
 

--- a/cookbooks/bcpc-hadoop/templates/default/zk_zoo.cfg.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/zk_zoo.cfg.erb
@@ -29,6 +29,9 @@ syncLimit=<%= node[:bcpc][:hadoop][:zookeeper][:sync_limit] %>
 # the directory where the snapshot is stored.
 dataDir=<%= node[:bcpc][:hadoop][:zookeeper][:data_dir] %>
 
+# the directory where the txn log is stored
+dataLogDir=<%= node[:bcpc][:hadoop][:zookeeper][:data_log_dir] %>
+
 # the port at which the clients will connect
 clientPort=<%= node[:bcpc][:hadoop][:zookeeper][:port] %>
 

--- a/cookbooks/bcpc-hadoop/templates/default/zk_zookeeper-env.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/zk_zookeeper-env.sh.erb
@@ -7,7 +7,7 @@
 ################################################
 
 export JAVA_HOME=<%= node["bcpc"]["hadoop"]["java"] %>
-export ZOO_LOG_DIR=/var/log/zookeeper
+export ZOO_LOG_DIR=<%= node[:bcpc][:hadoop][:zookeeper][:log_dir] %>
 export ZOO_PID_DIR=/var/run/zookeeper
 export ZOOPIDFILE=$ZOO_PID_DIR/zookeeper-server
 export ZOOCFGDIR=<%= node[:bcpc][:hadoop][:zookeeper][:conf_dir] %>


### PR DESCRIPTION
Changes  in this PR includes
- Change ``export ZOO_LOG_DIR`` to use node attribute so that it is configurable. Currently it is hardcoded.
- Add ``dataLogDir`` ZooKeeper config and ideally this need to point to a dedicated disk for performance.