### PR TITLE
Changes to enable Apache Phoenix tracing

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hbase.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hbase.rb
@@ -31,3 +31,5 @@ default["bcpc"]["hadoop"]["hbase"]["ipc"]["warn"]["responsetime"] = 250
 default["bcpc"]["hadoop"]["hbase_master"]["hfilecleaner"]["ttl"] = 3600000
 default["bcpc"]["hadoop"]["hbase_master"]["jmx"]["port"] = 10101
 default["bcpc"]["hadoop"]["hbase_rs"]["jmx"]["port"] = 10102
+#Apache Phoenix related attributes 
+default["bcpc"]["hadoop"]["phoenix"]["tracing"]["enabled"] = false

--- a/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
@@ -23,7 +23,7 @@ else
  dns_server = node[:bcpc][:dns_servers][0]
 end
 
-%w{hadoop-metrics.properties
+%w{hadoop-metrics2-hbase.properties
    hbase-env.sh
    hbase-policy.xml
    hbase-site.xml

--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -57,6 +57,7 @@ end
 service "hbase-master" do
   action [:enable, :start]
   supports :status => true, :restart => true, :reload => false
+  subscribes :restart, "template[/etc/hbase/conf/hadoop-metrics2-hbase.properties]", :delayed
   subscribes :restart, "template[/etc/hbase/conf/hbase-site.xml]", :delayed
   subscribes :restart, "template[/etc/hbase/conf/hbase-policy.xml]", :delayed
   subscribes :restart, "template[/etc/hbase/conf/hbase-env.sh]", :delayed
@@ -64,4 +65,21 @@ service "hbase-master" do
   subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
   subscribes :restart, "user_ulimit[hbase]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
+end
+
+if node["bcpc"]["hadoop"]["phoenix"]["tracing"]["enabled"]
+
+  template "/tmp/trace_table.sql" do
+    source "phoenix_trace-table.sql.erb"
+    mode "0755"
+    action :create
+  end
+
+  bash "create_phoenix_trace_table" do
+    code <<-EOH
+    HBASE_CONF_PATH=/etc/hadoop/conf:/etc/hbase/conf /usr/hdp/current/phoenix-client/bin/sqlline.py "#{node[:bcpc][:hadoop][:zookeeper][:servers].map{ |s| float_host(s[:hostname])}.join(",")}:#{node[:bcpc][:hadoop][:zookeeper][:port]}:/hbase" /tmp/trace_table.sql
+    EOH
+    user "hbase"
+  end
+
 end

--- a/cookbooks/bcpc-hadoop/recipes/region_server.rb
+++ b/cookbooks/bcpc-hadoop/recipes/region_server.rb
@@ -43,6 +43,7 @@ end
 service "hbase-regionserver" do
   supports :status => true, :restart => true, :reload => false
   action [:enable, :start]
+  subscribes :restart, "template[/etc/hbase/conf/hadoop-metrics2-hbase.properties]", :delayed
   subscribes :restart, "template[/etc/hbase/conf/hbase-site.xml]", :delayed
   subscribes :restart, "template[/etc/hbase/conf/hbase-policy.xml]", :delayed
   subscribes :restart, "template[/etc/hbase/conf/hbase-env.sh]", :delayed

--- a/cookbooks/bcpc-hadoop/templates/default/hb_hadoop-metrics2-hbase.properties.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hb_hadoop-metrics2-hbase.properties.erb
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# syntax: [prefix].[source|sink].[instance].[options]
+# See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
+
+*.sink.file*.class=org.apache.hadoop.metrics2.sink.FileSink
+# default sampling period
+*.period=10
+
+# Below are some examples of sinks that could be used
+# to monitor different hbase daemons.
+
+# hbase.sink.file-all.class=org.apache.hadoop.metrics2.sink.FileSink
+# hbase.sink.file-all.filename=all.metrics
+
+# hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
+# hbase.sink.file0.context=hmaster
+# hbase.sink.file0.filename=master.metrics
+
+# hbase.sink.file1.class=org.apache.hadoop.metrics2.sink.FileSink
+# hbase.sink.file1.context=thrift-one
+# hbase.sink.file1.filename=thrift-one.metrics
+
+# hbase.sink.file2.class=org.apache.hadoop.metrics2.sink.FileSink
+# hbase.sink.file2.context=thrift-two
+# hbase.sink.file2.filename=thrift-one.metrics
+
+# hbase.sink.file3.class=org.apache.hadoop.metrics2.sink.FileSink
+# hbase.sink.file3.context=rest
+# hbase.sink.file3.filename=rest.metrics
+
+<% if node["bcpc"]["hadoop"]["phoenix"]["tracing"]["enabled"] == true then %>
+# ensure that we receive traces on the server
+hbase.sink.tracing.class=org.apache.phoenix.trace.PhoenixMetricsSink
+# Tell the sink where to write the metrics
+hbase.sink.tracing.writer-class=org.apache.phoenix.trace.PhoenixTableMetricsWriter
+# Only handle traces with a context of "tracing"
+hbase.sink.tracing.context=tracing
+<% end %>

--- a/cookbooks/bcpc-hadoop/templates/default/phoenix_trace-table.sql.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/phoenix_trace-table.sql.erb
@@ -1,0 +1,1 @@
+CREATE TABLE SYSTEM.TRACING_STATS (trace_id BIGINT NOT NULL, parent_id BIGINT NOT NULL, span_id BIGINT NOT NULL, description VARCHAR, start_time BIGINT, end_time BIGINT, hostname VARCHAR, tags.count SMALLINT, annotations.count SMALLINT, CONSTRAINT pk PRIMARY KEY (trace_id, parent_id, span_id));


### PR DESCRIPTION
The changes in this PR will help users trace [Phoenix](https://phoenix.apache.org/) queries from clients and collect statistics. This is based on Apache Phoenix documentation on [tracing](https://phoenix.apache.org/tracing.html).