### PR TITLE
Restart Hadoop-Httpfs service when hdfs config changes

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/httpfs.rb
+++ b/cookbooks/bcpc-hadoop/recipes/httpfs.rb
@@ -17,6 +17,8 @@ end
 service "hadoop-httpfs" do
   action [:enable, :start]
   supports :status => true, :restart => true, :reload => false
+  subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop-httpfs/conf/httpfs-site.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
 end


### PR DESCRIPTION
This PR makes sure that `hadoop-httpfs` is restarted when `Hadoop` configuration files change.