### PR TITLE
Changes to use Chef cache in the Phoenix trace code path

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -69,7 +69,7 @@ end
 
 if node["bcpc"]["hadoop"]["phoenix"]["tracing"]["enabled"]
 
-  template "/tmp/trace_table.sql" do
+  template "#{Chef::Config[:file_cache_path]}/trace_table.sql" do
     source "phoenix_trace-table.sql.erb"
     mode "0755"
     action :create
@@ -77,7 +77,7 @@ if node["bcpc"]["hadoop"]["phoenix"]["tracing"]["enabled"]
 
   bash "create_phoenix_trace_table" do
     code <<-EOH
-    HBASE_CONF_PATH=/etc/hadoop/conf:/etc/hbase/conf /usr/hdp/current/phoenix-client/bin/sqlline.py "#{node[:bcpc][:hadoop][:zookeeper][:servers].map{ |s| float_host(s[:hostname])}.join(",")}:#{node[:bcpc][:hadoop][:zookeeper][:port]}:/hbase" /tmp/trace_table.sql
+    HBASE_CONF_PATH=/etc/hadoop/conf:/etc/hbase/conf /usr/hdp/current/phoenix-client/bin/sqlline.py "#{node[:bcpc][:hadoop][:zookeeper][:servers].map{ |s| float_host(s[:hostname])}.join(",")}:#{node[:bcpc][:hadoop][:zookeeper][:port]}:/hbase" "#{Chef::Config[:file_cache_path]}/trace_table.sql"
     EOH
     user "hbase"
   end


### PR DESCRIPTION
Changes to use Chef cache instead of /tmp in the Phoenix trace code path. This is to cater to the comments in PR #424 .