### PR TITLE
Move apt after ubuntu recipe in role::Basic

### DIFF
--- a/roles/Basic.json
+++ b/roles/Basic.json
@@ -6,8 +6,8 @@
     "run_list": [
       "recipe[bach_common::motd]",
       "recipe[bcpc::graphite_handler]",
-      "recipe[apt]",
       "recipe[ubuntu]",
+      "recipe[apt]",
       "recipe[ntp]",
       "recipe[chef-client::delete_validation]",
       "recipe[chef-client::config]"


### PR DESCRIPTION
This issue happens when try to kerberize chef-bach cluster. 
re-chefing bootstrap node after adding
"recipe[bach_krb5::krb5_server]", "recipe[bach_krb5::keytabs]"
 to BCPC-Bootstrap.json
failed on
sudo apt-get -q -y  install libkrb5-dev=1.10+dfsg~beta1-2ubuntu0.7

It seems there was problem with apt-get package authentication because apt recipe ran before ubuntu recipe, but really apt depends on ubuntu recipe, and hence ubuntu should run first

the proposed change is to run ubuntu recipe before apt recipe. 

