### PR TITLE
Fix for HBase staging dir

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hbase.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hbase.rb
@@ -1,3 +1,5 @@
+default['bcpc']['hadoop']['hbase']['root_dir'] = "#{node['bcpc']['hadoop']['hdfs_url']}/hbase"
+default['bcpc']['hadoop']['hbase']['bulkload_staging_dir'] = "#{node['bcpc']['hadoop']['hdfs_url']}/tmp"
 default["bcpc"]["hadoop"]["hbase"]["repl"]["enabled"] = false
 default["bcpc"]["hadoop"]["hbase"]["repl"]["peer_id"] =  node.chef_environment.gsub("-","_")
 default["bcpc"]["hadoop"]["hbase"]["repl"]["target"] = ""

--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -39,10 +39,23 @@ service "hbase-thrift" do
   action :disable
 end 
 
-bash "create-hbase-dir" do
-  code "hadoop fs -mkdir -p /hbase; hadoop fs -chown hbase:hadoop /hbase"
-  user "hdfs"
-  not_if "sudo -u hdfs hadoop fs -test -d /hbase"
+bash 'create-hbase-dir' do
+  code  <<-EOH
+    hdfs dfs -mkdir -p #{node['bcpc']['hadoop']['hbase']['root_dir']}
+    hdfs dfs -chown hbase:hadoop #{node['bcpc']['hadoop']['hbase']['root_dir']}
+  EOH
+  user 'hdfs'
+  not_if "hdfs dfs -test -d #{node['bcpc']['hadoop']['hbase']['root_dir']}", :user => 'hdfs'
+end
+
+bash 'create-hbase-staging-dir' do
+  code <<-EOH
+    hdfs dfs -mkdir -p #{node['bcpc']['hadoop']['hbase']['bulkload_staging_dir']}
+    hdfs dfs -chown hbase:hadoop #{node['bcpc']['hadoop']['hbase']['bulkload_staging_dir']}
+    hdfs dfs -chmod 711 #{node['bcpc']['hadoop']['hbase']['bulkload_staging_dir']}
+  EOH
+  user 'hdfs'
+  not_if "hdfs dfs -test -d #{node['bcpc']['hadoop']['hbase']['bulkload_staging_dir']}", :user => 'hdfs'
 end
 
 directory "/usr/hdp/#{node[:bcpc][:hadoop][:distribution][:active_release]}/hbase/lib/native/Linux-amd64-64" do

--- a/cookbooks/bcpc-hadoop/templates/default/hb_hbase-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hb_hbase-site.xml.erb
@@ -16,7 +16,12 @@
 <configuration>
   <property>
     <name>hbase.rootdir</name>
-    <value><%= node['bcpc']['hadoop']['hdfs_url'] %>/hbase</value>
+    <value><%= node['bcpc']['hadoop']['hbase']['root_dir'] %></value>
+  </property>
+
+  <property>
+    <name>hbase.bulkload.staging.dir</name>
+    <value><%= node['bcpc']['hadoop']['hbase']['bulkload_staging_dir'] %></value>
   </property>
 
   <property>


### PR DESCRIPTION
This is omitted code from the HDP2.3 (PR #327) which supports HBase bulk loads by setting an explicit staging directory and making it and the HBase root directory attributes.