### PR TITLE
fortan lib support for https://github.com/fommil/netlib-java

### DIFF
--- a/cookbooks/bach_spark/recipes/default.rb
+++ b/cookbooks/bach_spark/recipes/default.rb
@@ -1,11 +1,11 @@
-node.default[:bcpc][:hadoop][:yarn][:aux_services][:spark_shuffle][:class] = "org.apache.spark.network.yarn.YarnShuffleService"
+node.default[:bcpc][:hadoop][:yarn][:aux_services][:spark_shuffle][:class] =
+  'org.apache.spark.network.yarn.YarnShuffleService'
 
 spark_pkg_version = node[:spark][:package][:version]
 spark_bin_dir = node[:spark][:bin][:dir]
-hdfs_url = node['spark']['hdfs_url']
 
-if node[:spark][:package][:install_meta] == true then
-  package "spark" do
+if node[:spark][:package][:install_meta] == true
+  package 'spark' do
     action :upgrade
   end
 else
@@ -15,19 +15,28 @@ else
 end
 
 template "#{spark_bin_dir}/conf/spark-env.sh" do
-  source "spark-env.sh.erb"
+  source 'spark-env.sh.erb'
   mode 0755
 end
 
 template "#{spark_bin_dir}/conf/spark-defaults.conf" do
-  source "spark-defaults.conf.erb"
+  source 'spark-defaults.conf.erb'
   mode 0755
 end
 
 link "/#{spark_bin_dir}/lib/spark-yarn-shuffle.jar" do
- to "#{spark_bin_dir}/lib/spark-#{spark_pkg_version}-yarn-shuffle.jar"
+  to "#{spark_bin_dir}/lib/spark-#{spark_pkg_version}-yarn-shuffle.jar"
 end
 
-link "/usr/spark/current" do
- to "#{spark_bin_dir}"
+link '/usr/spark/current' do
+  to "#{spark_bin_dir}"
+end
+
+# install fortran libs needed by some jobs
+package 'libatlas3gf-base' do
+  action :install
+end
+
+package 'libopenblas-base' do
+  action :install
 end


### PR DESCRIPTION
Added a new recipe to bcpc-hadoop cookbook that installs the two necessary packages.  This will allow worker nodes to have libblas and liblapack installed on them.  This is for support of https://github.com/fommil/netlib-java.

Testing:
```
ubuntu@bcpc-vm3:~$ ls /etc/alternatives/libbla*
/etc/alternatives/libblas.so.3gf
ubuntu@bcpc-vm3:~$ ls /etc/alternatives/liblapack*
/etc/alternatives/liblapack.so.3gf
```
