### PR TITLE
This is to make flume work in a kerberised cluster and make syslogs and chef-logs world readable.

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/flume.rb
+++ b/cookbooks/bcpc-hadoop/attributes/flume.rb
@@ -1,0 +1,3 @@
+#log4j defaults
+default[:bcpc][:hadoop][:log4j][:max_file_size] = "100MB"
+default[:bcpc][:hadoop][:log4j][:max_backups] = 10

--- a/cookbooks/bcpc-hadoop/attributes/kerberos.rb
+++ b/cookbooks/bcpc-hadoop/attributes/kerberos.rb
@@ -13,6 +13,7 @@ default[:bcpc][:hadoop][:kerberos][:data] = {
         :hbase => {"principal" => "hbase", "keytab" => "hbase.service.keytab", "owner" => "hbase", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" =>  "hbase.service.keytab"},
         :httpfs => {"principal" => "httpfs", "keytab" => "httpfs.service.keytab", "owner" => "httpfs", "princhost"  => "_HOST", "perms" => "0600", "spnego_keytab" => "httpfs.service.keytab"},
         :hive => {"principal" => "hive", "keytab" => "hive.service.keytab", "owner" => "hive", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" => "hive.service.keytab"},
-        :oozie => {"principal" => "oozie", "keytab" => "oozie.service.keytab", "owner" => "oozie", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" => "oozie.service.keytab"}}
+        :oozie => {"principal" => "oozie", "keytab" => "oozie.service.keytab", "owner" => "oozie", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" => "oozie.service.keytab"},
+        :flume => {"principal" => "flume", "keytab" => "flume.service.keytab", "owner" => "flume", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" => "flume.service.keytab"}}
 default[:bcpc][:hadoop][:kerberos][:keytab][:dir] = "/etc/security/keytabs"
 default[:bcpc][:hadoop][:kerberos][:keytab][:recreate] = false

--- a/cookbooks/bcpc-hadoop/recipes/copylog.rb
+++ b/cookbooks/bcpc-hadoop/recipes/copylog.rb
@@ -53,6 +53,15 @@ if node['bcpc']['hadoop']['copylog_enable']
     action [:enable, :start]
     subscribes :restart, "template[/etc/flume/conf/flume-env.sh]", :delayed
   end
+
+  template '/etc/flume/conf/log4j.properties' do
+    source "flume_log4j.properties.erb"
+    mode '0644'
+    owner 'flume'
+    group 'flume'
+    action :create
+  end
+
   node['bcpc']['hadoop']['copylog'].each do |id,f|
     if f['docopy'] 
       template "/etc/flume/conf/flume-#{id}.conf" do

--- a/cookbooks/bcpc-hadoop/recipes/default.rb
+++ b/cookbooks/bcpc-hadoop/recipes/default.rb
@@ -23,12 +23,17 @@
 #
 node.default['bcpc']['hadoop']['copylog']['syslog'] = {
     'logfile' => "/var/log/syslog",
-    'docopy' => false
+    'docopy' => true
 }
 
 node.default['bcpc']['hadoop']['copylog']['authlog'] = {
     'logfile' => "/var/log/auth.log",
     'docopy' => false
+}
+
+node.default['bcpc']['hadoop']['copylog']['cheflog'] = {
+    'logfile' => "#{node['chef_client']['log_dir']}/#{node['chef_client']['log_file']}",
+    'docopy' => true
 }
 
 # ensure the Zookeeper Gem is available for use in later recipes

--- a/cookbooks/bcpc-hadoop/templates/default/flume_flume-conf.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/flume_flume-conf.erb
@@ -16,3 +16,7 @@
 <%= @agent_name %>.sinks.hdfsSink.hdfs.rollInterval = <%= node['bcpc']['hadoop']['copylog_rollup_interval'] %>
 <%= @agent_name %>.sinks.hdfsSink.hdfs.rollSize = 0
 <%= @agent_name %>.sinks.hdfsSink.hdfs.rollCount = 0
+<% if node[:bcpc][:hadoop][:kerberos][:enable] %>
+<%= @agent_name %>.sinks.hdfsSink.hdfs.kerberosPrincipal = <%= node['bcpc']['hadoop']['kerberos']['data']['flume']['principal'] %>/<%=node[:bcpc][:hadoop][:kerberos][:data][:namenode][:princhost] == "_HOST" ? "_HOST" : node[:bcpc][:hadoop][:kerberos][:data][:namenode][:princhost]%>@<%= node['bcpc']['hadoop']['kerberos']['realm'] %>
+<%= @agent_name %>.sinks.hdfsSink.hdfs.kerberosKeytab  = <%= node['bcpc']['hadoop']['kerberos']['keytab']['dir'] %>/<%= node['bcpc']['hadoop']['kerberos']['data']['flume']['keytab'] %>
+<% end %>

--- a/cookbooks/bcpc-hadoop/templates/default/flume_log4j.properties.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/flume_log4j.properties.erb
@@ -1,0 +1,2 @@
+log4j.appender.file.MaxFileSize = <%= node[:bcpc][:hadoop][:log4j][:max_file_size] %>
+log4j.appender.file.MaxBackupIndex= <%= node[:bcpc][:hadoop][:log4j][:max_backups] %>


### PR DESCRIPTION
Added new keytab for flume so it can authenticate to the kerberised cluster and aggregate logs from all nodes and put in hdfs with public permission. 

Also, make flume roll over flume logs so it doesn't fill up local diskspace.