### PR TITLE
Disable yarn's nodemanager virtual memory check

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/yarn.rb
+++ b/cookbooks/bcpc-hadoop/attributes/yarn.rb
@@ -16,3 +16,4 @@ default['bcpc']['hadoop']['yarn']['opts']['jute_buffer'] = 6291456
 default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["yarn.client.failover-sleep-base-ms"] = 150
 default['bcpc']['hadoop']['nodemanager']['jmx']['port'] = 3131
 default['bcpc']['hadoop']['resourcemanager']['jmx']['port'] = 3131
+default['bcpc']['hadoop']['yarn']['nodemanager']['vmem-check-enabled'] = false

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
@@ -304,4 +304,10 @@
     <name>yarn.scheduler.fair.preemption</name>
     <value><%= node["bcpc"]["hadoop"]["yarn"]["scheduler"]["fair"]["preemption"] %></value>
   </property>
+
+  <property>
+    <name>yarn.nodemanager.vmem-check-enabled</name>
+    <value><%= node['bcpc']['hadoop']['yarn']['nodemanager']['vmem-check-enabled'] %></value>
+  </property>
+
 </configuration>


### PR DESCRIPTION
This PR disables `Yarn NodeManager` virtual memory check.