### PR TITLE
Remove 'file://' from yarn nodemanager local dirs

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
@@ -162,7 +162,7 @@
 
   <property>
     <name>yarn.nodemanager.local-dirs</name>
-    <value><%=@mounts.map{ |d| "file:///disk/#{d}/yarn/local" }.join(",")%></value>
+    <value><%=@mounts.map{ |d| "/disk/#{d}/yarn/local" }.join(",")%></value>
   </property>
 
   <property>


### PR DESCRIPTION
This PR fixes the issue where a `spark dataframe object` won't be able to show any data due to issue reported in [SPARK-13514](https://issues.apache.org/jira/browse/SPARK-13514).