### PR TITLE
Specify a version for ZabbixAPI to allow upgrades of ZabbixAPI GEM

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/default.rb
+++ b/cookbooks/bcpc-hadoop/recipes/default.rb
@@ -60,7 +60,7 @@ end.run_action(:install)
 
 gem_package "zabbixapi" do
     gem_binary gem_path
-    version ">=0.0.0"
+    version ">=2.4"
     action :nothing
 end.run_action(:install)
 


### PR DESCRIPTION
Upgrading Zabbix right now sucks. Unlike the rest of our stack it does not do any sort of upgrade really. This at least pins a version of ZabbixAPI so if one's upgrading a 2.2 cluster the new GEM is installed. One still has to do the following to scorch earth on the actual Zabbix install:

````
for n in $(grep -i head cluster.txt |cut -f 1 -d ' '); do
  for cmd in 'stop zabbix-server' 'stop zabbix-agent' 'rm -rf /usr/local/*/*zabbix* /etc/init/zabbix-*  /etc/php5/apache2/conf.d/zabbix.ini /etc/apache2/sites-available/zabbix-web /usr/local/etc/checks /var/log/zabbix'; do
    ./nodessh.sh <environment> $n $cmd sudo
  done &
done
````

And then login to MySQL as the root user and `DROP DATABASE zabbix;`