### PR TITLE
Install spark with Hadoop jars

### DIFF
--- a/environments/Test-Laptop.json
+++ b/environments/Test-Laptop.json
@@ -1,17 +1,6 @@
 {
   "name": "Test-Laptop",
   "override_attributes": {
-    "spark": {
-      "download" : {
-        "url": "http://apache.arvixe.com/spark/spark-1.6.0/",
-        "file": {
-          "name": "spark-1.6.0-bin-without-hadoop"
-        }
-      },
-      "package": {
-        "version": "1.6.0"
-      }
-    },
     "bcpc": {
       "graphite": {
         "graphite_disk": "sde"


### PR DESCRIPTION
This PR makes sure that the `Spark` is installed with `Hadoop` jars bundled in `Spark assembly` jar. This is required for Spark to work with `Hive`. Without `Hadoop/Hive` jars `Spark` is not able to create a `HiveContext`.