### PR TITLE
Add hive-site.xml to SPARK_DIST_CLASSPATH to enable Spark SQL with Hive

### DIFF
--- a/cookbooks/bach_spark/templates/default/spark-env.sh.erb
+++ b/cookbooks/bach_spark/templates/default/spark-env.sh.erb
@@ -2,8 +2,9 @@ export SPARK_LOCAL_IP=<%= node['bcpc']['floating']['ip'] %>
 export SPARK_PUBLIC_DNS=<%= float_host(node['fqdn']) %>
 
 export HADOOP_CONF_DIR="/etc/hadoop/conf"
+HIVE_CONF_DIR="/etc/hive/conf"
 
-export SPARK_DIST_CLASSPATH=${SPARK_LIBRARY_PATH}:$(for i in $(export IFS=":"; for i in $(hadoop classpath); do find $i -maxdepth 1 -name "*.jar"; done | egrep -v "jackson-databind-.*.jar|jackson-core.jar|jackson-core-.*.jar|jackson-annotations-.*.jar"); do echo -n "${i}:"; done | sed 's/:$//')
+export SPARK_DIST_CLASSPATH=${HIVE_CONF_DIR}:${SPARK_LIBRARY_PATH}:$(for i in $(export IFS=":"; for i in $(hadoop classpath); do find $i -maxdepth 1 -name "*.jar"; done | egrep -v "jackson-databind-.*.jar|jackson-core.jar|jackson-core-.*.jar|jackson-annotations-.*.jar"); do echo -n "${i}:"; done | sed 's/:$//')
 
 export SPARK_CLASSPATH="$SPARK_DIST_CLASSPATH:$SPARK_CLASSPATH"
 export SPARK_LOCAL_DIRS=/home/$(whoami)/.spark_logs


### PR DESCRIPTION
This PR adds `Hive-Site.xml` to `Spark's` environment variable `SPARK_DIST_CLASSPATH` which in turn enables `Spark` sql to be able to communicate with correct `Hive` meta store. A local derby database is created if `Spark` is not aware of `Hive` configuration. Below are my test results:

##### Without `Hive-Site.xml` in `SPARK` classpath
```
scala> val df = sqlContext.sql("SELECT * FROM test")
2016-03-29 08:46:36,636 INFO  [main] parse.ParseDriver (ParseDriver.java:parse(185)) - Parsing command: SELECT * FROM test
2016-03-29 08:46:37,349 INFO  [main] parse.ParseDriver (ParseDriver.java:parse(209)) - Parse Completed
2016-03-29 08:46:37,476 INFO  [main] metastore.HiveMetaStore (HiveMetaStore.java:logInfo(746)) - 0: get_table : db=default tbl=test
2016-03-29 08:46:37,477 INFO  [main] HiveMetaStore.audit (HiveMetaStore.java:logAuditEvent(371)) - ugi=ubuntu   ip=unknown-ip-addr      cmd=get_table : db=default tbl=test
org.apache.spark.sql.AnalysisException: Table not found: test; line 1 pos 14
        at org.apache.spark.sql.catalyst.analysis.package$AnalysisErrorAt.failAnalysis(package.scala:42)
```
##### With `Hive-Site.xml` in `SPARK` classpath
```
2016-03-29 08:13:10,628 INFO  [main] hive.metastore (HiveMetaStoreClient.java:open(376)) - Trying to connect to metastore with URI thrift://f-bcpc-vm2.bcpc.example.com:9083
2016-03-29 08:13:10,675 INFO  [main] hive.metastore (HiveMetaStoreClient.java:open(472)) - Connected to metastore.
2016-03-29 08:13:10,841 INFO  [main] session.SessionState (SessionState.java:createPath(641)) - Created local directory: /tmp/d11861b1-df0a-42b5-a5d9-21ef6b217d7f_resources
2016-03-29 08:13:10,849 INFO  [main] session.SessionState (SessionState.java:createPath(641)) - Created HDFS directory: /tmp/hive-ubuntu/ubuntu/d11861b1-df0a-42b5-a5d9-21ef6b217d7f
2016-03-29 08:13:10,851 INFO  [main] session.SessionState (SessionState.java:createPath(641)) - Created local directory: /tmp/ubuntu/d11861b1-df0a-42b5-a5d9-21ef6b217d7f
3:10,860 INFO  [main] session.SessionState (SessionState.java:createPath(641)) - Created HDFS directory: /tmp/hive-ubuntu/ubuntu/d11861b1-df0a-42b5-a5d9-21ef6b217d7f/_tmp_space.db
2016-03-29 08:13:10,890 INFO  [main] repl.SparkILoop (Logging.scala:logInfo(58)) - Created sql context (with Hive support)..
SQL context available as sqlContext.

scala> val df = sqlContext.sql("SELECT * FROM test")
2016-03-29 08:13:15,351 INFO  [main] parse.ParseDriver (ParseDriver.java:parse(185)) - Parsing command: SELECT * FROM test
2016-03-29 08:13:16,071 INFO  [main] parse.ParseDriver (ParseDriver.java:parse(209)) - Parse Completed
df: org.apache.spark.sql.DataFrame = [id: string, idval: string]

scala> df.show()
+------+---------+
|    id|    idval|
+------+---------+
|id0001|value0001|
|id0002|value0002|
|id0003|value0003|
|id0004|value0004|
|id0005|value0005|
|id0006|value0006|
|id0007|value0007|
|id0008|value0008|
|id0009|value0009|
|id0010|value0010|
|id0011|value0011|
|id0012|value0012|
|id0013|value0013|
|id0014|value0014|
|id0015|value0015|
|id0016|value0016|
|id0017|value0017|
|id0018|value0018|
|id0019|value0019|
|id0020|value0020|
+------+---------+
only showing top 20 rows
```
