### PR TITLE
moved run_interval from bcpc-hadoop.rb to bcpc_jmxtrans.rb

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -109,9 +109,6 @@ default['bcpc']['hadoop']['copylog_enable'] = true
 # File rollup interval in secs for log data copied into HDFS through Flume
 default['bcpc']['hadoop']['copylog_rollup_interval'] = 86400
 
-# Override defaults for the jmxtrans cookbook
-default['jmxtrans']['run_interval'] = "15"
-
 # Ensure the following group mappings in the group database
 default[:bcpc][:hadoop][:os][:group][:hadoop][:members]=["hdfs","yarn"]
 default[:bcpc][:hadoop][:os][:group][:hdfs][:members]=["hdfs"]

--- a/cookbooks/bcpc_jmxtrans/attributes/default.rb
+++ b/cookbooks/bcpc_jmxtrans/attributes/default.rb
@@ -471,3 +471,7 @@ default['jmxtrans']['default_queries']['hbase_rs'] = [
     ]
   } 
 ]
+
+# Override defaults for the jmxtrans cookbook
+default['jmxtrans']['run_interval'] = "15"
+


### PR DESCRIPTION
This is to fix a bug that run_interval for jmxtrans is not set to 15 seconds as expected. The value is somehow overridden to 60. https://github.com/bloomberg/chef-bach/issues/449

The solution is to move the run_interval from cookbook bcpc-hadoop to bcpc_jmxtrans for it to actually take effect.

Have confirmed that after uploading the cookbook and running chef-client on vm1, the SECONDS_BETWEEN_RUNS in /etc/default/jmxtrans has changed from 60 to 15.