### PR TITLE
Set correct staging directory for HBase secure bulk load

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hbase.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hbase.rb
@@ -1,5 +1,5 @@
 default['bcpc']['hadoop']['hbase']['root_dir'] = "#{node['bcpc']['hadoop']['hdfs_url']}/hbase"
-default['bcpc']['hadoop']['hbase']['bulkload_staging_dir'] = "#{node['bcpc']['hadoop']['hdfs_url']}/tmp"
+default['bcpc']['hadoop']['hbase']['bulkload_staging_dir'] = "/tmp/hbase"
 default["bcpc"]["hadoop"]["hbase"]["repl"]["enabled"] = false
 default["bcpc"]["hadoop"]["hbase"]["repl"]["peer_id"] =  node.chef_environment.gsub("-","_")
 default["bcpc"]["hadoop"]["hbase"]["repl"]["target"] = ""


### PR DESCRIPTION
This PR sets correct directory location for `HBase` secure bulk load and fixes issue #457 