### PR TITLE
Setup hadoop yarn log directory with correct permissions

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
@@ -273,9 +273,3 @@ bash "create-hdfs-history" do
   user "hdfs"
   not_if "sudo -u hdfs #{hdfs_cmd} dfs -test -d /user/history"
 end
-
-bash "create-hdfs-yarn-log" do
-  code "#{hdfs_cmd} dfs -mkdir -p /var/log/hadoop-yarn; #{hdfs_cmd} dfs -chown yarn:mapred /var/log/hadoop-yarn"
-  user "hdfs"
-  not_if "sudo -u hdfs #{hdfs_cmd} dfs -test -d /var/log/hadoop-yarn"
-end

--- a/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
@@ -157,9 +157,3 @@ bash "create-hdfs-history" do
   user "hdfs"
   not_if "sudo -u hdfs #{hdfs_cmd} dfs -test -d /user/history"
 end
-
-bash "create-hdfs-yarn-log" do
-  code "#{hdfs_cmd} dfs -mkdir -p /var/log/hadoop-yarn; #{hdfs_cmd} dfs -chown yarn:mapred /var/log/hadoop-yarn"
-  user "hdfs"
-  not_if "sudo -u hdfs #{hdfs_cmd} dfs -test -d /var/log/hadoop-yarn"
-end

--- a/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
@@ -29,7 +29,7 @@ end
 end
 
 bash "create-hdfs-yarn-log" do
-  code "hdfs dfs -mkdir -p /var/log/hadoop-yarn && hdfs dfs -chmod 1777 /var/log/hadoop-yarn && hdfs dfs -chown yarn:mapred /var/log/hadoosp-yarn"
+  code "hdfs dfs -mkdir -p /var/log/hadoop-yarn && hdfs dfs -chmod 0777 /var/log/hadoop-yarn && hdfs dfs -chown yarn:mapred /var/log/hadoosp-yarn"
   user "hdfs"
   not_if "hdfs dfs -test -d /var/log/hadoop-yarn", :user => "hdfs"
 end


### PR DESCRIPTION
This PR removes creation of `yarn log` directory from `NameNode` recipe that was creating and setting the permissions incorrectly causing `oozie` `mapreduce` action to fail on job's completion while moving it to history server. Since `yarn log` is related to `Yarn/Mapreduce`, it should be handled in `resource_manager` recipe only. 