### PR TITLE
Add static group mappring for 'mapred' user

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/hdp_core-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_core-site.xml.erb
@@ -118,7 +118,7 @@
 
   <property>
     <name>hadoop.user.group.static.mapping.overrides</name>
-    <value>hdfs=hadoop,hdfs;yarn=mapred,hadoop;</value>
+    <value>hdfs=hadoop,hdfs;yarn=mapred,hadoop;mapred=mapred;</value>
   </property>
   <% if node[:bcpc][:hadoop][:hdfs][:ldap][:integration] == true %>
    <!-- HDFS LDAP Mapping configuration -->


### PR DESCRIPTION
This PR adds static group mapping for `mapred` user to reduce LDAP dependency on core components.