### PR TITLE
Make Yarn application logs visiable through RM UI after app completes

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
@@ -309,5 +309,11 @@
     <name>yarn.nodemanager.vmem-check-enabled</name>
     <value><%= node['bcpc']['hadoop']['yarn']['nodemanager']['vmem-check-enabled'] %></value>
   </property>
+  <% if @hs_hosts.count > 0 %>
+  <property>
+    <name>yarn.log.server.url</name>
+    <value>http://<%="#{float_host(@hs_hosts.map{|i| i[:hostname] }.sort.first)}:19888" if not @hs_hosts.empty?%>/jobhistory/logs</value>
+  </property>
+  <% end %>
 
 </configuration>


### PR DESCRIPTION
As of today, after a `Yarn` application is FINISHED successfully, the logs for completed application are not visible via RM UI. One would see error akin to
````
Failed while trying to construct the redirect URL to the log server. Log server url may not be configured
````
This PR adds the correct parameter to make `Yarn` application log visible