### PR TITLE
Add support for Hive LDAP integration

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hive.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hive.rb
@@ -2,3 +2,6 @@ default[:bach][:hive][:metastore][:port] = 9083
 default[:bach][:hive][:hiveserver2][:port] = 10000
 default[:bcpc][:hive][:heap][:size]=1024
 default[:bcpc][:hive][:gc_opts] = " -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:/var/log/hive/gc/gc.log-$$-$(hostname)-$(date +'%Y%m%d%H%M').log -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC"
+default[:bcpc][:hadoop][:hive][:hiveserver2][:authentication][:method] = "KERBEROS"
+default[:bcpc][:hadoop][:hive][:hiveserver2][:authentication][:ldap_url] = ""
+default[:bcpc][:hadoop][:hive][:hiveserver2][:authentication][:ldap_domain] = ""

--- a/cookbooks/bcpc-hadoop/templates/default/hv_hive-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hv_hive-site.xml.erb
@@ -101,6 +101,22 @@
   <name>hive.exec.scratchdir</name>
   <value>/tmp/hive-${user.name}</value>
 </property>
+<% if node[:bcpc][:hadoop][:hive][:hiveserver2][:authentication][:method].upcase == "LDAP" %>
+<property>
+  <name>hive.server2.authentication</name>
+  <value><%= node[:bcpc][:hadoop][:hive][:hiveserver2][:authentication][:method] %></value>
+</property>
+
+<property>
+  <name>hive.server2.authentication.ldap.url</name>
+  <value><%= node[:bcpc][:hadoop][:hive][:hiveserver2][:authentication][:ldap_url] %></value>
+</property>
+
+<property>
+  <name>hive.server2.authentication.ldap.Domain</name>
+  <value><%= node[:bcpc][:hadoop][:hive][:hiveserver2][:authentication][:ldap_domain] %></value>
+</property>
+<% end %>
 
 <% if @template_vars[:kerberos_enabled] == true then %>
 
@@ -122,10 +138,12 @@
 </property>
 
 <!-- HiveServer2 Security Configuration -->
+<% if node[:bcpc][:hadoop][:hive][:hiveserver2][:authentication][:method].upcase == "KERBEROS" %>
 <property>
   <name>hive.server2.authentication</name>
-  <value>KERBEROS</value>
+  <value><%= node[:bcpc][:hadoop][:hive][:hiveserver2][:authentication][:method] %></value>
 </property>
+<% end %>
 
 <property>
   <name>hive.server2.authentication.kerberos.keytab</name>


### PR DESCRIPTION
This PR adds support for integrating `HiveServer2` with `LDAP` for user authentication.