### PR TITLE
Fix spellings for 'hadoop-yarn' directory

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
@@ -29,7 +29,7 @@ end
 end
 
 bash "create-hdfs-yarn-log" do
-  code "hdfs dfs -mkdir -p /var/log/hadoop-yarn && hdfs dfs -chmod 0777 /var/log/hadoop-yarn && hdfs dfs -chown yarn:mapred /var/log/hadoosp-yarn"
+  code "hdfs dfs -mkdir -p /var/log/hadoop-yarn && hdfs dfs -chmod 0777 /var/log/hadoop-yarn && hdfs dfs -chown yarn:mapred /var/log/hadoop-yarn"
   user "hdfs"
   not_if "hdfs dfs -test -d /var/log/hadoop-yarn", :user => "hdfs"
 end


### PR DESCRIPTION
This PR fixes spelling for `yarn` log directory `hadoop-yarn`.