### PR TITLE
sample oozie test job

### DIFF
--- a/tools/oozie/oozie_simple_test/README.md
+++ b/tools/oozie/oozie_simple_test/README.md
@@ -1,0 +1,27 @@
+# Oozie Simple Tester
+
+Use these files for a simple oozie test case that runs a simple oozie shell action.
+
+In order to run the test, simple update coordinator.properties with:
+ - The yarn task tracker url
+ - The HDFS name node url
+ - An HDFS directory to store the files
+ - A start and end time set to today
+
+Then, create your test HDFS directory, and create 2 subdirectories underneath - lib and output.
+
+Finally, put the following files into that HDFS directory.
+ - coordinator.xml  
+ - logoozieid.sh  
+ - test.sh  
+ - workflow.xml
+
+To run your test, run:
+` oozie job -oozie <oozie url> -config coordinator.properties  -run`
+
+This will output your oozie coordinator job id.
+
+To check on your job status:
+`oozie job -oozie <oozie url>  -info <jobid>`
+
+To check the job output from HDFS, retrieve the oozieId.log file from the HDFS output directory you created above.

--- a/tools/oozie/oozie_simple_test/job.properties
+++ b/tools/oozie/oozie_simple_test/job.properties
@@ -1,0 +1,6 @@
+nameNode=hdfs://Test-Laptop
+jobTracker=hdfs://Test-Laptop
+queueName=default
+oozie.wf.application.path=${nameNode}/tmp/oozie/shell-hadoopsh/workflow.xml
+script=script.sh
+oozie.use.system.libpath=true

--- a/tools/oozie/oozie_simple_test/run.sh
+++ b/tools/oozie/oozie_simple_test/run.sh
@@ -1,0 +1,1 @@
+/usr/hdp/current/oozie-client/bin/oozie job -oozie http://f-bcpc-vm2.bcpc.example.com:11000/oozie  -config job.properties -run

--- a/tools/oozie/oozie_simple_test/script.sh
+++ b/tools/oozie/oozie_simple_test/script.sh
@@ -1,0 +1,1 @@
+hdfs dfs -copyFromLocal /etc/passwd /tmp/passwd`date +%Y%m%d`

--- a/tools/oozie/oozie_simple_test/setup.sh
+++ b/tools/oozie/oozie_simple_test/setup.sh
@@ -1,0 +1,3 @@
+sudo hdfs dfs -mkdir -p /tmp/oozie/shell-hadoopsh/
+sudo hdfs dfs -copyFromLocal job.properties /tmp/oozie/shell-hadoopsh/
+sudo hdfs dfs -copyFromLocal workflow.xml /tmp/oozie/shell-hadoopsh/

--- a/tools/oozie/oozie_simple_test/workflow.xml
+++ b/tools/oozie/oozie_simple_test/workflow.xml
@@ -1,0 +1,24 @@
+<workflow-app name="WorkFlowForShellAction" xmlns="uri:oozie:workflow:0.4">
+    <start to="shellAction"/>
+    <action name="shellAction">
+        <shell xmlns="uri:oozie:shell-action:0.2">
+	    <job-tracker>${jobTracker}</job-tracker>
+            <name-node>${nameNode}</name-node>
+            <configuration>
+                <property>
+                    <name>oozie.launcher.mapred.job.queue.name</name>
+                    <value>default</value>
+                </property>
+            </configuration>
+	    <exec>script.sh</exec>
+            <file>/tmp/oozie/shell-hadoopsh/script.sh#script.sh</file>    
+    	<capture-output/>
+        </shell>
+    <ok to="end"/>
+    <error to="killAction"/>
+    </action>
+    <kill name="killAction">
+        <message>"Killed job due to error"</message>
+    </kill>
+    <end name="end"/>
+</workflow-app>


### PR DESCRIPTION
Added a tools directory where we can use small smoke-test tools.

Added a sample oozie test case that tests an oozie shell action and pushes the resulting job id to hdfs for verification.

I envision more simple tools being added as time goes on.