### PR TITLE
calling apt right before ubuntu is redundant

### DIFF
--- a/roles/Basic.json
+++ b/roles/Basic.json
@@ -6,7 +6,6 @@
     "run_list": [
       "recipe[bach_common::motd]",
       "recipe[bcpc::graphite_handler]",
-      "recipe[apt]",
       "recipe[ubuntu]",
       "recipe[ntp]",
       "recipe[chef-client::delete_validation]",


### PR DESCRIPTION
apt recipe is executed in ubuntu recipe anyway.

https://github.com/chef-cookbooks/ubuntu/blob/master/recipes/default.rb#L40 