### PR TITLE
Add support for Kafka 0.9.0.1 and remove 0.8.x

### DIFF
--- a/build_bins.sh
+++ b/build_bins.sh
@@ -62,16 +62,16 @@ fi
 FILES="jmxtrans-20120525-210643-4e956b1144.zip $FILES"
 
 # Fetch Kafka Tar
-for version in 0.8.1 0.8.1.1; do
+for version in 0.9.0.1; do
   mkdir -p kafka/${version}/
-  if ! [[ -f kafka/${version}/kafka_2.9.2-${version}.tgz ]]; then
+  if ! [[ -f kafka/${version}/kafka_2.11-${version}.tgz ]]; then
     pushd kafka/${version}/
-    while ! $(file kafka_2.9.2-${version}.tgz | grep -q 'gzip compressed data'); do
-      $CURL -O -L https://archive.apache.org/dist/kafka/${version}/kafka_2.9.2-${version}.tgz
+    while ! $(file kafka_2.11-${version}.tgz | grep -q 'gzip compressed data'); do
+      $CURL -O -L http://mirrors.ocf.berkeley.edu/apache/kafka/${version}/kafka_2.11-${version}.tgz
     done
     popd
   fi
-  FILES="kafka_2.9.2-${version}.tgz $FILES"
+  FILES="kafka_2.11-${version}.tgz $FILES"
 done
 
 # Fetch Java Tar


### PR DESCRIPTION
This PR fixes the URL for downloading `Kafka` packages. Also, support for downloading `Kafka 0.9.0.1` is added. Removing `0.8.x` from downloads as we don't need it anymore.