### PR TITLE
bcpc-bach::resource_manager recipe has its own role BCPC-Hadoop-Head-ResourceManager

### DIFF
--- a/roles/BCPC-Hadoop-Head-MapReduce.json
+++ b/roles/BCPC-Hadoop-Head-MapReduce.json
@@ -6,7 +6,6 @@
   "run_list": [
     "role[Basic]",
     "role[BCPC-Hadoop-Head]",
-    "recipe[bcpc-hadoop::resource_manager]",
     "recipe[bcpc-hadoop::historyserver]",
     "recipe[bcpc-hadoop::oozie]"
   ],


### PR DESCRIPTION
In #399 JMX was enabled for yarn, however as a result we needed a new roles created in order to provide hints to jmxtrans.  This is a follow up PR to remove bcpc-hadoop::resourcemanager from BCPC-Hadoop-Head-MapReduce role since it is redundant

# Changes
- removed bcpc-bach::resource_manager from BCPC-Hadoop-Head-MapReduce.json

# Breaking
Every resource manager node (previously node with BCPC-Hadoop-Head-MapReduce or bcpc-bach::resource_manager assigned) will need this roles assigned in cluster.txt.  Following that run cluster-assign-role.sh