### PR TITLE
chef-bach-493 conditionally create Phoenix SYSTEM.TRACING_STATS table

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -99,6 +99,8 @@ if node["bcpc"]["hadoop"]["phoenix"]["tracing"]["enabled"]
     HBASE_CONF_PATH=/etc/hadoop/conf:/etc/hbase/conf /usr/hdp/current/phoenix-client/bin/sqlline.py "#{node[:bcpc][:hadoop][:zookeeper][:servers].map{ |s| float_host(s[:hostname])}.join(",")}:#{node[:bcpc][:hadoop][:zookeeper][:port]}:/hbase" /tmp/trace_table.sql
     EOH
     user "hbase"
+    not_if <<-EOH
+    echo "select count(1) from SYSTEM.TRACING_STATS" | HBASE_CONF_PATH=/etc/hadoop/conf:/etc/hbase/conf /usr/hdp/current/phoenix-client/bin/sqlline.py "#{node[:bcpc][:hadoop][:zookeeper][:servers].map{ |s| float_host(s[:hostname])}.join(",")}:#{node[:bcpc][:hadoop][:zookeeper][:port]}:/hbase"
+    EOH
   end
-
 end


### PR DESCRIPTION
This PR is to resolve issue #493 . This change will conditionally create the Phoenix tracing table which was not the case earlier. This is required due to the change in the behavior of ``sqlline.py`` Phoenix program in HDP 2.3.x compared to earlier HDP version. 