### PR TITLE
Fix for pig in HDP2.3.4

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/yarn.rb
+++ b/cookbooks/bcpc-hadoop/attributes/yarn.rb
@@ -17,3 +17,4 @@ default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["yarn.client.failover-sleep
 default['bcpc']['hadoop']['nodemanager']['jmx']['port'] = 3131
 default['bcpc']['hadoop']['resourcemanager']['jmx']['port'] = 3131
 default['bcpc']['hadoop']['yarn']['nodemanager']['vmem-check-enabled'] = false
+default['bcpc']['hadoop']['yarn']['timeline-service']['client']['max-retries'] = 0

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_yarn-site.xml.erb
@@ -316,4 +316,10 @@
   </property>
   <% end %>
 
+  <property>
+    <name>yarn.timeline-service.client.max-retries</name>
+    <value><%= node['bcpc']['hadoop']['yarn']['timeline-service']['client']['max-retries'] %></value>
+  </property>
+
+
 </configuration>


### PR DESCRIPTION
 Fix for pig in HDP2.3.4 to set number of attempted connections to yan timeline service to 0.

To test:
run pig and see if the grunt shell comes up without 30 attempts to hit the timeline service, which is not installed by default on the cluster.