### PR TITLE
Do not install openjdk

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hadoop_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hadoop_config.rb
@@ -81,8 +81,3 @@ template "/etc/hadoop/conf/yarn-env.sh" do
    :rm_jmx_port => node[:bcpc][:hadoop][:resourcemanager][:jmx][:port]
   )
 end  
-
-
-package "openjdk-7-jdk" do
-    action :upgrade
-end


### PR DESCRIPTION
This PR removes chef resource that installs `openjdk`. This code was removed as part of PR #422 but for some reason during merge of `HDP 2.3.4` it came back.