### PR TITLE
update hive config to prevent memory leaks

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/hv_hive-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hv_hive-site.xml.erb
@@ -198,4 +198,14 @@ characterEncoding=UTF-8&amp;user=<%=@template_vars[:stats_user]%>&amp;password=<
   <name>hive.server2.logging.operation.verbose</name>
   <value>true</value>
 </property>
+
+<property>
+  <name>fs.hdfs.impl.disable.cache</name>
+  <value>true</value>
+</property>
+
+<property>
+  <name>fs.file.impl.disable.cache</name>
+  <value>true</value>
+</property>
 </configuration>


### PR DESCRIPTION
This is a workaround to prevent memory leaks in hiveserver.
