### PR TITLE
Change cluster's default mode to be secure (Kerberized)

### DIFF
--- a/cookbooks/bach_krb5/recipes/gems.rb
+++ b/cookbooks/bach_krb5/recipes/gems.rb
@@ -20,14 +20,9 @@ gem_package "rkerberos" do
   action :nothing
 end.run_action(:install)
 
-file "correct-permissions-for-rkerberos" do
-  path "/opt/chef/embedded/lib/ruby/gems/1.9.1/specifications/rkerberos-0.1.3.gemspec"
-  mode 0644
+execute "correct-gem-permissions" do
+  command 'find /opt/chef/embedded/lib/ruby/gems -type f -exec chmod a+r {} \; && ' +
+          'find /opt/chef/embedded/lib/ruby/gems -type d -exec chmod a+rx {} \;'
+  user "root"
   action :nothing
-end.run_action(:touch)
-
-file "correct-permissions-for-rake-compiler" do
-  path "/opt/chef/embedded/lib/ruby/gems/1.9.1/specifications/rake-compiler-0.9.5.gemspec"
-  mode 0644 
-  action :nothing
-end.run_action(:touch)
+end.run_action(:run)

--- a/cookbooks/bach_krb5/recipes/keytabs.rb
+++ b/cookbooks/bach_krb5/recipes/keytabs.rb
@@ -1,9 +1,9 @@
 keytab_dir = node[:bcpc][:hadoop][:kerberos][:keytab][:dir]
 realm = node[:bcpc][:hadoop][:kerberos][:realm]
 
-get_all_nodes().each do |h|
+get_cluster_nodes().each do |h|
   # Create directory for the the host to store keytabs
-  directory "#{keytab_dir}/#{float_host(h[:fqdn])}" do
+  directory "#{keytab_dir}/#{float_host(h)}" do
     action :create
     owner "root"
     group "root"
@@ -15,7 +15,7 @@ get_all_nodes().each do |h|
   node[:bcpc][:hadoop][:kerberos][:data].each do |ke, va|
   
     service_principal = va['principal']
-    host_fqdn = float_host(h[:fqdn])
+    host_fqdn = float_host(h)
     keytab_file = va['keytab']
   
     # Delete the existing kerberos principal if principal is being recreated
@@ -44,10 +44,10 @@ get_all_nodes().each do |h|
 end
 
 
-get_all_nodes().each do |h|
+get_cluster_nodes().each do |h|
   node[:bcpc][:hadoop][:kerberos][:data].each do |ke, va|
     service_principal = va['principal']
-    host_fqdn = float_host(h[:fqdn])
+    host_fqdn = float_host(h)
     keytab_file = va['keytab']
 
     # Create the keytab file

--- a/cookbooks/bach_krb5/recipes/upload_keytabs.rb
+++ b/cookbooks/bach_krb5/recipes/upload_keytabs.rb
@@ -1,10 +1,10 @@
 require 'base64'
 # Upload keytabs to chef-server
-get_all_nodes().each do |h|
+get_cluster_nodes().each do |h|
   node[:bcpc][:hadoop][:kerberos][:data].each do |srvc, srvdat|
     # Set host based on configuration
-    config_host=srvdat['princhost'] == "_HOST" ? float_host(h[:hostname]) : srvdat['princhost'].split('.')[0]
-    keytab_host=srvdat['princhost'] == "_HOST" ? float_host(h[:fqdn]) : srvdat['princhost']
+    config_host=srvdat['princhost'] == "_HOST" ? float_host(h.split('.')[0]) : srvdat['princhost'].split('.')[0]
+    keytab_host=srvdat['princhost'] == "_HOST" ? float_host(h) : srvdat['princhost']
 
     # Delete existing configuration item (if requested)
     config_key = "#{config_host}-#{srvc}"

--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -135,3 +135,6 @@ default['java']['oracle']['jce']['8']['url'] = get_binary_server_url + "jce_poli
 
 # Set the JAVA_HOME for Hadoop components
 default['bcpc']['hadoop']['java'] = '/usr/lib/jvm/java-7-oracle-amd64'
+
+
+default['bcpc']['cluster']['file_path'] = "/home/vagrant/chef-bcpc/cluster.txt"

--- a/cookbooks/bcpc-hadoop/attributes/kerberos.rb
+++ b/cookbooks/bcpc-hadoop/attributes/kerberos.rb
@@ -1,5 +1,5 @@
 # Kerberos settings 
-default[:bcpc][:hadoop][:kerberos][:enable] = false
+default[:bcpc][:hadoop][:kerberos][:enable] = true
 default[:bcpc][:hadoop][:kerberos][:realm] = "BCPC.EXAMPLE.COM"
 default[:bcpc][:hadoop][:kerberos][:data] = {
         :namenode => {"principal" => "nn", "keytab" => "nn.service.keytab", "owner" => "hdfs", "princhost" => "_HOST", "perms"=> "0600", "spnego_keytab" => "nn.service.keytab"},
@@ -13,6 +13,7 @@ default[:bcpc][:hadoop][:kerberos][:data] = {
         :hbase => {"principal" => "hbase", "keytab" => "hbase.service.keytab", "owner" => "hbase", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" =>  "hbase.service.keytab"},
         :httpfs => {"principal" => "httpfs", "keytab" => "httpfs.service.keytab", "owner" => "httpfs", "princhost"  => "_HOST", "perms" => "0600", "spnego_keytab" => "httpfs.service.keytab"},
         :hive => {"principal" => "hive", "keytab" => "hive.service.keytab", "owner" => "hive", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" => "hive.service.keytab"},
+        :flume=> {"principal" => "flume", "keytab" => "flume.service.keytab", "owner" => "flume", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" => "flume.service.keytab"},
         :oozie => {"principal" => "oozie", "keytab" => "oozie.service.keytab", "owner" => "oozie", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" => "oozie.service.keytab"}}
 default[:bcpc][:hadoop][:kerberos][:keytab][:dir] = "/etc/security/keytabs"
 default[:bcpc][:hadoop][:kerberos][:keytab][:recreate] = false

--- a/cookbooks/bcpc-hadoop/definitions/configure_kerberos.rb
+++ b/cookbooks/bcpc-hadoop/definitions/configure_kerberos.rb
@@ -1,0 +1,44 @@
+define :configure_kerberos do
+  if node[:bcpc][:hadoop][:kerberos][:enable]
+    service_name = params[:service_name]
+    keytab_dir = node[:bcpc][:hadoop][:kerberos][:keytab][:dir]
+    srvdat = node[:bcpc][:hadoop][:kerberos][:data][service_name]
+    srvc=service_name
+    keytab_file = srvdat['keytab']
+    config_host = srvdat['princhost'] == "_HOST" ?  float_host(node[:hostname]) : srvdat['princhost'].split('.')[0]
+    # Delete existing keytab if keytab is being re-created
+    file "#{keytab_dir}/#{keytab_file}" do
+      action :delete
+      only_if {
+        File.exists?("#{keytab_dir}/#{keytab_file}") &&
+        node[:bcpc][:hadoop][:kerberos][:keytab][:recreate] == true
+      }
+    end
+
+    # Create the keytab file
+    file "#{keytab_dir}/#{keytab_file}" do
+      owner "#{srvdat['owner']}"
+      group "root"
+      mode "#{srvdat['perms']}"
+      action :create_if_missing
+      content Base64.decode64(get_config!("#{config_host}-#{srvc}"))
+      only_if { user_exists?("#{srvdat['owner']}")  }
+    end
+
+    princ_host = srvdat['princhost'] == "_HOST" ? float_host(node[:fqdn]) : srvdat['princhost']
+
+    execute "kdestroy-for-#{srvdat['owner']}" do
+      command "kdestroy"
+      user "#{srvdat['owner']}"
+      action :run
+      only_if { user_exists?("#{srvdat['owner']}") }
+    end
+
+    execute "kinit-for-#{srvdat['owner']}" do
+      command "kinit -kt #{keytab_dir}/#{keytab_file} #{srvdat['principal']}/#{princ_host}"
+      action :run
+      user "#{srvdat['owner']}"
+      only_if { user_exists?("#{srvdat['owner']}") }
+    end
+  end
+end

--- a/cookbooks/bcpc-hadoop/libraries/utils.rb
+++ b/cookbooks/bcpc-hadoop/libraries/utils.rb
@@ -439,3 +439,22 @@ def update_oozie_sharelib(host)
     Chef::Log.info("Sharelibupdate: Oozie server not running on #{host}")
   end
 end
+
+def get_cluster_nodes()
+
+  cluster_file = node['bcpc']['cluster']['file_path']
+
+  if !File::file?(cluster_file)
+    Chef::Log.fatal("File #{cluster_file} does not exist.")
+    raise
+  end
+
+  fileList = Array.new
+
+  File::open(cluster_file,"r").each_line do |line|
+    lines = line.split()
+    fileList.push("#{lines[0]}.#{lines[5]}")
+  end
+
+  fileList  
+end

--- a/cookbooks/bcpc-hadoop/recipes/configs.rb
+++ b/cookbooks/bcpc-hadoop/recipes/configs.rb
@@ -72,61 +72,11 @@ include_recipe "java::oracle_jce"
   end
 end
 
-# Create Keytabs (if kerberos is eanbled)
-if node[:bcpc][:hadoop][:kerberos][:enable] == true then
-
-  keytab_dir = node[:bcpc][:hadoop][:kerberos][:keytab][:dir]
-  
-  # Create directory to store keytab files
-  directory "#{keytab_dir}" do
-    owner "root"
-    group "root"
-    recursive true
-    mode 0755  
-  end
-
-  # Download and create keytab file
-  node[:bcpc][:hadoop][:kerberos][:data].each do |srvc, srvdat|
-  
-    keytab_file = srvdat['keytab']
-
-    config_host = srvdat['princhost'] == "_HOST" ?  float_host(node[:hostname]) : srvdat['princhost'].split('.')[0]
-    
-    # Delete existing keytab if keytab is being re-created
-    file "#{keytab_dir}/#{keytab_file}" do
-      action :delete
-      only_if { 
-        File.exists?("#{keytab_dir}/#{keytab_file}") && 
-        node[:bcpc][:hadoop][:kerberos][:keytab][:recreate] == true
-      }
-    end 
-
-    # Create the keytab file
-    file "#{keytab_dir}/#{keytab_file}" do
-      owner "#{srvdat['owner']}"
-      group "root"
-      mode "#{srvdat['perms']}"
-      action :create_if_missing
-      content Base64.decode64(get_config!("#{config_host}-#{srvc}"))
-      only_if { user_exists?("#{srvdat['owner']}")  }
-    end
-
-    princ_host = srvdat['princhost'] == "_HOST" ? float_host(node[:fqdn]) : srvdat['princhost']
-
-    next if srvdat['principal'] == "HTTP"
-
-    execute "kdestroy-for-#{srvdat['owner']}" do
-      command "kdestroy"
-      user "#{srvdat['owner']}"
-      action :run
-      only_if { user_exists?("#{srvdat['owner']}") }
-    end
-
-    execute "kinit-for-#{srvdat['owner']}" do
-    command "kinit -kt #{keytab_dir}/#{keytab_file} #{srvdat['principal']}/#{princ_host}"
-      action :run
-      user "#{srvdat['owner']}"
-      only_if { user_exists?("#{srvdat['owner']}") }
-    end
-  end
+# Create directory to store keytab files
+directory node[:bcpc][:hadoop][:kerberos][:keytab][:dir] do
+  owner "root"
+  group "root"
+  recursive true
+  mode 0755
+  only_if { node[:bcpc][:hadoop][:kerberos][:enable] }
 end

--- a/cookbooks/bcpc-hadoop/recipes/copylog.rb
+++ b/cookbooks/bcpc-hadoop/recipes/copylog.rb
@@ -25,6 +25,10 @@ link "/etc/init.d/flume-agent-multi" do
   notifies :run, "bash[kill flume-java]", :immediate
 end
 
+configure_kerberos 'flume_kerb' do
+  service_name 'flume'
+end
+
 bash "kill flume-java" do
   code "pkill -u flume -f java"
   action :nothing

--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -49,6 +49,17 @@ user_ulimit "yarn" do
   process_limit 65536
 end
 
+configure_kerberos 'datanode_kerb' do
+  service_name 'datanode'
+end
+
+configure_kerberos 'nodemanager_kerb' do
+  service_name 'nodemanager'
+end
+
+configure_kerberos 'mapred_kerb' do
+  service_name 'historyserver'
+end
 # need to ensure hdfs user is in hadoop and hdfs
 # groups. Packages will not add hdfs if it
 # is already created at install time (e.g. if

--- a/cookbooks/bcpc-hadoop/recipes/default.rb
+++ b/cookbooks/bcpc-hadoop/recipes/default.rb
@@ -66,3 +66,11 @@ end.run_action(:install)
 
 Gem.clear_paths
 require 'zookeeper'
+
+execute "correct-gem-permissions" do
+  command 'find /opt/chef/embedded/lib/ruby/gems -type f -exec chmod a+r {} \; && ' +
+          'find /opt/chef/embedded/lib/ruby/gems -type d -exec chmod a+rx {} \;'
+  user "root"
+   action :nothing
+end.run_action(:run)
+

--- a/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
@@ -45,14 +45,13 @@ end
   end
 end
 
-if node[:bcpc][:hadoop][:kerberos][:enable] == true then 
-  %w{
-    hbase-client.jaas
-    hbase-server.jaas
-    regionserver.jaas}.each do |t|
-    template "/etc/hbase/conf/#{t}" do
-      source "hb_#{t}.erb"
-      mode 0644
-    end
+%w{
+  hbase-client.jaas
+  hbase-server.jaas
+  regionserver.jaas}.each do |t|
+  template "/etc/hbase/conf/#{t}" do
+    source "hb_#{t}.erb"
+    mode 0644
+    only_if { node[:bcpc][:hadoop][:kerberos][:enable] }
   end
-end 
+end

--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -31,6 +31,10 @@ phoenix-client
   hdp_select(p, node[:bcpc][:hadoop][:distribution][:active_release])
 end
 
+configure_kerberos 'hbase_kerb' do
+  service_name 'hbase'
+end
+
 user_ulimit "hbase" do
   filehandle_limit 32769
 end

--- a/cookbooks/bcpc-hadoop/recipes/historyserver.rb
+++ b/cookbooks/bcpc-hadoop/recipes/historyserver.rb
@@ -10,6 +10,10 @@ include_recipe 'bcpc-hadoop::hadoop_config'
   hdp_select(pkg, node[:bcpc][:hadoop][:distribution][:active_release])
 end
 
+configure_kerberos 'historyserver_kerb' do
+  service_name 'historyserver'
+end
+
 template "/etc/hadoop/conf/mapred-env.sh" do
   source "hdp_mapred-env.sh.erb"
   mode 0655

--- a/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
@@ -26,6 +26,10 @@ user_ulimit "hive" do
   process_limit 65536
 end
 
+configure_kerberos 'hive_kerb' do
+  service_name 'hive'
+end
+
 bash "create-hive-user-home" do
   code <<-EOH
   hdfs dfs -mkdir -p /user/hive

--- a/cookbooks/bcpc-hadoop/recipes/httpfs.rb
+++ b/cookbooks/bcpc-hadoop/recipes/httpfs.rb
@@ -24,6 +24,10 @@ bash "kill hdfs-httpfs" do
   returns [0, 1]
 end
 
+configure_kerberos 'httpfs_kerb' do
+  service_name 'httpfs'
+end
+
 service "hadoop-httpfs" do
   action [:enable, :start]
   supports :status => true, :restart => true, :reload => false

--- a/cookbooks/bcpc-hadoop/recipes/journalnode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/journalnode.rb
@@ -10,6 +10,10 @@ include_recipe 'bcpc-hadoop::hadoop_config'
   hdp_select(pkg, node[:bcpc][:hadoop][:distribution][:active_release])
 end
 
+configure_kerberos 'journalnode_kerb' do
+  service_name 'journalnode'
+end
+
 if get_config("namenode_txn_fmt") then
   file "#{Chef::Config[:file_cache_path]}/nn_fmt.tgz" do
     user "hdfs"

--- a/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
@@ -92,6 +92,10 @@ node[:bcpc][:hadoop][:mounts].each do |d|
   end
 end
 
+configure_kerberos 'namenode_kerb' do
+  service_name 'namenode'
+end
+
 bash "format namenode" do
   code "#{hdfs_cmd} namenode -format -nonInteractive -force"
   user "hdfs"

--- a/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
@@ -90,6 +90,10 @@ node[:bcpc][:hadoop][:mounts].each do |d|
   end
 end
 
+configure_kerberos 'namenode_kerb' do
+  service_name 'namenode'
+end
+
 bash "format namenode" do
   code "#{hdfs_cmd} namenode -format -nonInteractive -force"
   user "hdfs"

--- a/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
@@ -86,6 +86,10 @@ node[:bcpc][:hadoop][:mounts].each do |d|
   end
 end
 
+configure_kerberos 'namenode_kerb' do
+  service_name 'namenode'
+end
+
 if @node['bcpc']['hadoop']['hdfs']['HA'] == true then
   bash "#{hdfs_cmd} namenode -bootstrapStandby -force -nonInteractive" do
     code "#{hdfs_cmd} namenode -bootstrapStandby -force -nonInteractive"

--- a/cookbooks/bcpc-hadoop/recipes/oozie.rb
+++ b/cookbooks/bcpc-hadoop/recipes/oozie.rb
@@ -12,6 +12,10 @@ end
   hdp_select(pkg, node[:bcpc][:hadoop][:distribution][:active_release])
 end
 
+configure_kerberos 'oozie_kerb' do
+  service_name 'oozie'
+end
+
 OOZIE_LIB_PATH="/usr/hdp/#{node[:bcpc][:hadoop][:distribution][:active_release]}/oozie"
 OOZIE_CLIENT_PATH='/usr/hdp/current/oozie-client'
 OOZIE_SERVER_PATH="/usr/hdp/#{node[:bcpc][:hadoop][:distribution][:active_release]}/oozie/oozie-server"

--- a/cookbooks/bcpc-hadoop/recipes/region_server.rb
+++ b/cookbooks/bcpc-hadoop/recipes/region_server.rb
@@ -42,16 +42,9 @@ template "/etc/default/hbase" do
   variables(:hbrs_jmx_port => node[:bcpc][:hadoop][:hbase_rs][:jmx][:port])
 end
 
-#link "/etc/init.d/hbase-regionserver" do
-#  to "/usr/hdp/#{node[:bcpc][:hadoop][:distribution][:release]}/hbase/etc/init.d/hbase-regionserver"
-#  notifies :run, 'bash[kill hbase-regionserver]', :immediate
-#end
-#
-#bash "kill hbase-regionserver" do
-#  code "pkill -u hbase -f regionserver"
-#  action :nothing
-#  returns [0, 1]
-#end
+configure_kerberos 'hbasers_kerb' do
+  service_name 'hbase'
+end
 
 template "/etc/init.d/hbase-regionserver" do
   source "hdp_hbase-regionserver-initd.erb"

--- a/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
@@ -54,6 +54,10 @@ bash "kill yarn-resourcemanager" do
   returns [0, 1]
 end
 
+configure_kerberos 'rm_kerb' do
+  service_name 'resourcemanager'
+end
+
 hdfs_write = "echo 'test' | hdfs dfs -copyFromLocal - /user/hdfs/chef-mapred-test"
 hdfs_remove = "hdfs dfs -rm -skipTrash /user/hdfs/chef-mapred-test"
 

--- a/cookbooks/bcpc-hadoop/recipes/zookeeper_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/zookeeper_config.rb
@@ -28,11 +28,10 @@ end
   end
 end
 
-if node[:bcpc][:hadoop][:kerberos][:enable] == true then
-  %w{zookeeper-client.jaas zookeeper-server.jaas}.each do |t|
-    template "/etc/zookeeper/conf/#{t}" do
-      source "zk_#{t}.erb"
-      mode 0644
-    end
+%w{zookeeper-client.jaas zookeeper-server.jaas}.each do |t|
+  template "/etc/zookeeper/conf/#{t}" do
+    source "zk_#{t}.erb"
+    mode 0644
+    only_if { node[:bcpc][:hadoop][:kerberos][:enable] }
   end
 end

--- a/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
+++ b/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
@@ -13,6 +13,10 @@ user_ulimit "zookeeper" do
   filehandle_limit 32769
 end
 
+configure_kerberos 'zookeeper_kerb' do
+  service_name 'zookeeper'
+end
+   
 directory "/var/run/zookeeper" do 
   owner "zookeeper"
   group "zookeeper"

--- a/roles/BCPC-Bootstrap.json
+++ b/roles/BCPC-Bootstrap.json
@@ -14,6 +14,8 @@
       "role[Hannibal-Build]",
       "recipe[bach_spark::spark_package]",
       "recipe[bcpc::mysql_connector]",
+      "recipe[bach_krb5::krb5_server]",
+      "recipe[bach_krb5::keytabs]",
       "recipe[bcpc::rotate_chef_nginx_access_log]"
     ],
     "description": "A bootstrap node in a BCPC cluster",

--- a/roles/BCPC-Hadoop-Head.json
+++ b/roles/BCPC-Hadoop-Head.json
@@ -18,6 +18,7 @@
     "recipe[bcpc::diamond]",
     "recipe[bcpc::zabbix-head]",
     "recipe[bcpc-hadoop::hdp_repo]",
+    "recipe[bach_krb5::krb5_client]",
     "recipe[bcpc-hadoop::configs]",
     "recipe[pam::default]",
     "recipe[bcpc-hadoop::zookeeper_server]",

--- a/roles/BCPC-Hadoop-Worker.json
+++ b/roles/BCPC-Hadoop-Worker.json
@@ -10,6 +10,7 @@
     "recipe[bcpc::networking]",
     "recipe[bcpc-hadoop::disks]",
     "recipe[bcpc-hadoop::hdp_repo]",
+    "recipe[bach_krb5::krb5_client]",
     "recipe[bcpc-hadoop::configs]",
     "recipe[pam::default]",
     "recipe[bach_spark::default]",

--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -77,6 +77,7 @@ printf "#### Chef all the nodes\n"
 vagrant ssh -c "sudo apt-get install -y sshpass"
 
 printf "#### Chef machine bcpc-vms\n"
+vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT Basic"
 vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT Hadoop"
 
 printf "Snapshotting post-Cobbler\n"


### PR DESCRIPTION
This PR changes default cluster mode to be secure(Kerberos).  This reduces the number of steps that are required to `kerberized` a cluster. In the past we used to build the cluster first and then manually manipulate `roles/environment` to enable `Kerberos` and with this PR `Kerberos` is enabled by default. 

Also, this PR fixes gem permission issues that have bothered us for some time. 