### PR TITLE
Enable hadoop high availability(HA) automatically

### DIFF
--- a/cluster.txt
+++ b/cluster.txt
@@ -1,3 +1,3 @@
-bcpc-vm1 08:00:27:56:A2:28 10.0.100.11 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Head-Namenode-NoHA],role[BCPC-Hadoop-Head-HBase],role[Copylog]
-bcpc-vm2 08:00:27:E5:3A:00 10.0.100.12 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Head-Namenode-Standby],role[BCPC-Hadoop-Head-MapReduce],role[BCPC-Hadoop-Head-ResourceManager],role[BCPC-Hadoop-Head-Hive],role[Copylog]
-bcpc-vm3 08:00:27:AD:1D:EA 10.0.100.13 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Worker],role[Copylog]
+bcpc-vm1 08:00:27:56:A2:28 10.0.100.11 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Head],role[BCPC-Hadoop-Head-Namenode],role[BCPC-Hadoop-Head-HBase]
+bcpc-vm2 08:00:27:E5:3A:00 10.0.100.12 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Head],role[BCPC-Hadoop-Head-ResourceManager],role[BCPC-Hadoop-Head-Namenode-Standby],role[BCPC-Hadoop-Head-MapReduce],role[BCPC-Hadoop-Head-Hive]
+bcpc-vm3 08:00:27:AD:1D:EA 10.0.100.13 - bcpc_host bcpc.example.com role[BCPC-Hadoop-Worker]

--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -29,7 +29,7 @@ default["bcpc"]["hadoop"]["core"]["hadoop"]["security"]["group"]["mapping"]["lda
 default["bcpc"]["hadoop"]["core"]["hadoop"]["security"]["group"]["mapping"]["ldap"]["search"]["attr"]["group"]["name"] = "cn"
 default["bcpc"]["hadoop"]["hadoop"]["bin"]["path"] = "/usr/bin/hadoop"
 default["bcpc"]["hadoop"]["hadoop"]["config"]["dir"] = "/etc/hadoop/conf"
-default["bcpc"]["hadoop"]["hdfs"]["HA"] = false
+default["bcpc"]["hadoop"]["hdfs"]["HA"] = true
 default["bcpc"]["hadoop"]["hdfs"]["failed_volumes_tolerated"] = 1
 default["bcpc"]["hadoop"]["hdfs"]["dfs_replication_factor"] = 3
 default["bcpc"]["hadoop"]["hdfs"]["dfs_blocksize"] = "128m"

--- a/cookbooks/bcpc-hadoop/libraries/utils.rb
+++ b/cookbooks/bcpc-hadoop/libraries/utils.rb
@@ -118,8 +118,12 @@ end
 def get_namenodes()
   # Logic to get all namenodes if running in HA
   # or to get only the master namenode if not running in HA
-  if node['bcpc']['hadoop']['hdfs']['HA'] then
-    nn_hosts = get_nodes_for("namenode*")
+  if node['bcpc']['hadoop']['hdfs']['HA']
+    nnrole = search(:node, "role:BCPC-Hadoop-Head-Namenode* AND chef_environment:#{node.chef_environment}")
+    nnroles = search(:node, "roles:BCPC-Hadoop-Head-Namenode* AND chef_environment:#{node.chef_environment}")
+    puts "nnrole: #{nnrole}"
+    puts "nnroles:#{nnroles}"
+    nn_hosts = nnrole | nnroles
   else
     nn_hosts = get_nodes_for("namenode_no_HA")
   end

--- a/roles/BCPC-Hadoop-Head-HBase.json
+++ b/roles/BCPC-Hadoop-Head-HBase.json
@@ -3,7 +3,6 @@
   "json_class": "Chef::Role",
   "run_list": [
     "role[Basic]",
-    "role[BCPC-Hadoop-Head]",
     "recipe[bcpc-hadoop::hbase_repl]",
     "recipe[bcpc-hadoop::hbase_master]",
     "recipe[bcpc_jmxtrans]",

--- a/roles/BCPC-Hadoop-Head-Hive.json
+++ b/roles/BCPC-Hadoop-Head-Hive.json
@@ -5,7 +5,6 @@
   "json_class": "Chef::Role",
   "run_list": [
     "role[Basic]",
-    "role[BCPC-Hadoop-Head]",
     "recipe[bcpc-hadoop::hive_hcatalog]"
   ],
   "description": "A highly-available head node in a BCPC Hadoop cluster",

--- a/roles/BCPC-Hadoop-Head-MapReduce.json
+++ b/roles/BCPC-Hadoop-Head-MapReduce.json
@@ -5,7 +5,6 @@
   "json_class": "Chef::Role",
   "run_list": [
     "role[Basic]",
-    "role[BCPC-Hadoop-Head]",
     "recipe[bcpc-hadoop::historyserver]",
     "recipe[bcpc-hadoop::oozie]"
   ],

--- a/roles/BCPC-Hadoop-Head-Namenode-NoHA.json
+++ b/roles/BCPC-Hadoop-Head-Namenode-NoHA.json
@@ -3,7 +3,6 @@
   "json_class": "Chef::Role",
   "run_list": [
     "role[Basic]",
-    "role[BCPC-Hadoop-Head]",
     "recipe[bcpc-hadoop::namenode_no_HA]",
     "recipe[bcpc_jmxtrans]"
   ],

--- a/roles/BCPC-Hadoop-Head-Namenode-Standby.json
+++ b/roles/BCPC-Hadoop-Head-Namenode-Standby.json
@@ -3,7 +3,7 @@
   "json_class": "Chef::Role",
   "run_list": [
     "role[Basic]",
-    "role[BCPC-Hadoop-Head]",
+    "recipe[bcpc-hadoop::configs]",
     "recipe[bcpc-hadoop::namenode_standby]",
     "recipe[bcpc_jmxtrans]"
   ],

--- a/roles/BCPC-Hadoop-Head-Namenode.json
+++ b/roles/BCPC-Hadoop-Head-Namenode.json
@@ -3,7 +3,6 @@
   "json_class": "Chef::Role",
   "run_list": [
     "role[Basic]",
-    "role[BCPC-Hadoop-Head]",
     "recipe[bcpc-hadoop::namenode_master]",
     "recipe[bcpc_jmxtrans]"
   ],

--- a/roles/BCPC-Hadoop-Head-ResourceManager.json
+++ b/roles/BCPC-Hadoop-Head-ResourceManager.json
@@ -3,7 +3,6 @@
   "json_class": "Chef::Role",
   "run_list": [
     "role[Basic]",
-    "role[BCPC-Hadoop-Head]",
     "recipe[bcpc-hadoop::resource_manager]"
   ],
   "description": "A highly-available head node in a BCPC Hadoop cluster",

--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -78,6 +78,7 @@ vagrant ssh -c "sudo apt-get install -y sshpass"
 
 printf "#### Chef machine bcpc-vms\n"
 vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT Basic"
+vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT Bootstrap"
 vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT Hadoop"
 
 printf "Snapshotting post-Cobbler\n"


### PR DESCRIPTION
This PR enables creation of cluster in `HDFS` HA mode automatically. No manual intervention is needed to enable HA on the cluster. 

The cluster now needs to be chef'd in three stages:
* Chef with `Basic` install type. This will create `node/client` objects in `chef-server`
* Chef with `Bootstrap` install type. This will configure head services like `Zookeeper`, `Journalnode` and `MySQL` that are required for other `Hadoop` components
* Chef with `Hadoop` install type. This will install Hadoop components like `NameNode`, `HBase`, `Hive`, `Yarn` etc.

Example:
```
./cluster-assign-roles.sh <Environment> Basic
./cluster-assign-roles.sh <Environment> Bootstrap
./cluster-assign-roles.sh <Environment> Hadoop
```

Once cluster is built one should see message similar to:
```
#### Install finished
Connection to 127.0.0.1 closed.
+ printf 'Snapshotting post-Cobbler\n'
Snapshotting post-Cobbler
+ VBoxManage snapshot bcpc-vm1 take Full-Shoes
0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
Snapshot taken. UUID: 7f15ec72-05ff-43ad-8d92-3ad42636776c
+ VBoxManage snapshot bcpc-vm2 take Full-Shoes
0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
Snapshot taken. UUID: c79ab183-f95f-4e12-9090-1b0825c3f69e
+ VBoxManage snapshot bcpc-vm3 take Full-Shoes
0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
Snapshot taken. UUID: 542cb8c2-f533-4b27-af9c-93c3227d3752
```

After this a final `chef-ing` of the cluster is required and that can be done by logging on to `Bootstrap` host and running `cluster-assign-roles.sh`. 

Example:
```
vagrant ssh

./cluster-assign-roles.sh <Environment> Bootstrap
```