### PR TITLE
Updating hbase bulkload staging dir to /user/hbase

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hbase.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hbase.rb
@@ -1,5 +1,5 @@
 default['bcpc']['hadoop']['hbase']['root_dir'] = "#{node['bcpc']['hadoop']['hdfs_url']}/hbase"
-default['bcpc']['hadoop']['hbase']['bulkload_staging_dir'] = "/tmp/hbase"
+default['bcpc']['hadoop']['hbase']['bulkload_staging_dir'] = "/user/hbase"
 default["bcpc"]["hadoop"]["hbase"]["repl"]["enabled"] = false
 default["bcpc"]["hadoop"]["hbase"]["repl"]["peer_id"] =  node.chef_environment.gsub("-","_")
 default["bcpc"]["hadoop"]["hbase"]["repl"]["target"] = ""


### PR DESCRIPTION
Updating hbase bulkload staging directory to '/user/hbase' so it can also be shared for both hbase bulkloading and mapred jobs run by hbase user.
