### PR TITLE
This will make hbase run mapreduce jobs

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -319,6 +319,7 @@ service "hadoop-yarn-nodemanager" do
   subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/yarn-env.sh]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/yarn-site.xml]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/container-executor.cfg]", :delayed
   subscribes :restart, "bash[hdp-select hadoop-yarn-nodemanager]", :delayed
   subscribes :restart, "user_ulimit[yarn]", :delayed
 end

--- a/cookbooks/bcpc-hadoop/recipes/historyserver.rb
+++ b/cookbooks/bcpc-hadoop/recipes/historyserver.rb
@@ -42,4 +42,5 @@ service "hadoop-mapreduce-historyserver" do
   subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/mapred-site.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/yarn-site.xml]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/container-executor.cfg]", :delayed
 end

--- a/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
@@ -85,6 +85,7 @@ service "hadoop-yarn-resourcemanager" do
   subscribes :restart, "template[/etc/hadoop/conf/yarn-env.sh]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/yarn-site.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/mapred-site.xml]", :delayed
+  subscribes :restart, "template[/etc/hadoop/conf/container-executor.cfg]", :delayed
   subscribes :restart, "bash[hdp-select hadoop-yarn-resourcemanager]", :delayed
 end
 

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_container-executor.cfg.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_container-executor.cfg.erb
@@ -2,4 +2,4 @@ yarn.nodemanager.local-dirs=<%=@mounts.map{ |d| "file:///disk/#{d}/yarn/local" }
 yarn.nodemanager.linux-container-executor.group=yarn
 yarn.nodemanager.log-dirs=<%=@mounts.map{ |d| "file:///disk/#{d}/yarn/logs" }.join(",")%>
 banned.users=hdfs,yarn,mapred,bin      
-min.user.id=1000
+min.user.id=100


### PR DESCRIPTION
Hbase user currently can't run mapreduce jobs since its id < min.user.id incontainer-executor.config. This change lowers the user id constraint and restarts yarn/mapred services to take changes into effect.
