### PR TITLE
numRegionServers should use maxSeries

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hbase_queries.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_queries.rb
@@ -13,7 +13,7 @@ node.set[:bcpc][:hadoop][:graphite][:service_queries][:hbase_master] = {
      'route_to' => "admin"
   },
   'hbase_master.numRegionServers' => {
-     'query' => "minSeries(jmx.hbase_master.*.hbm_server.Master.numRegionServers)",
+     'query' => "maxSeries(jmx.hbase_master.*.hbm_server.Master.numRegionServers)",
      'trigger_val' => "max(#{trigger_chk_period})",
      'trigger_cond' => "<#{node[:bcpc][:hadoop][:rs_hosts].length}",
      'trigger_name' => "HBaseRSAvailability",


### PR DESCRIPTION
In case of multiple hbase masters, only one will return the number of region servers, while others returning zero. The trigger should use maxSeries rather than minSeries.