### PR TITLE
Enable dynamic disk discovery

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -10,7 +10,6 @@ default["bcpc"]["hadoop"]["distribution"]["key"] = 'hortonworks.key'
 default["bcpc"]["hadoop"]["distribution"]["release"] = '2.3.4.0-3485'
 default["bcpc"]["hadoop"]["distribution"]["active_release"] = node["bcpc"]["hadoop"]["distribution"]["release"]
 # disks to use for Hadoop activities (expected to be an environment or role set variable)
-default["bcpc"]["hadoop"]["disks"] = []
 default["bcpc"]["hadoop"]["hadoop_home_warn_suppress"] = 1
 default["bcpc"]["hadoop"]["hadoop_log_dir"] = "/var/log/hadoop-hdfs"
 default["bcpc"]["hadoop"]["hadoop_mapred_ident_string"] = "mapred"

--- a/cookbooks/bcpc-hadoop/attributes/disks.rb
+++ b/cookbooks/bcpc-hadoop/attributes/disks.rb
@@ -1,6 +1,7 @@
 # enumerate available disks and how they will be used
+avail_disks = node[:block_device].keys.select{ |d| d =~ /sd[b-z]/ }
 default[:bcpc][:hadoop][:disks] = {
-  :available_disks => ["sdb" , "sdc", "sdd", "sde"],
+  :available_disks => avail_disks,
   # keep at least that many disks for the :disk_reserve_roles
   :role_min_disk => 2,
   # we are reserving disks for the following


### PR DESCRIPTION
This PR adds logic to read Ohai data and discover available disks on the system.