### PR TITLE
Change to move the cluster profile attribute to BCPC

### DIFF
--- a/stub-environment/environments/Test-Laptop.json
+++ b/stub-environment/environments/Test-Laptop.json
@@ -37,10 +37,10 @@
         "hortonworks": "http://public-repo-1.hortonworks.com/HDP/ubuntu12/2.x/updates/2.3.4.0",
         "hdp_utils": "http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.20/repos/ubuntu12"
       },
-      "hadoop" : {
-        "environment" : {
+      "cluster" : {
           "profile" : ""
-        },
+      },
+      "hadoop" : {
         "yarn" : {
           "resourcemanager" : {
             "yarn.client.failover-sleep-base-ms": 30000


### PR DESCRIPTION
Currently ``profile`` attribute is in ``bcpc.hadoop.environment``. The change is to move it to ``bcpc.cluster`` so that the attribute is cluster specific.