### PR TITLE
Fix binidng precedence to install proper datanode package versions

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -13,11 +13,13 @@ hdp_select_pkgs = %w{
   hadoop-hdfs-datanode
   hadoop-client}
 
-(hdp_select_pkgs + %W{
+hdp_pkg_strs = (hdp_select_pkgs + %W{
   hadoop-mapreduce
   sqoop
   hadooplzo
-  hadooplzo-native}.map{|p| hwx_pkg_str(p, node[:bcpc][:hadoop][:distribution][:release])} + %W{
+  hadooplzo-native}).map{|p| hwx_pkg_str(p, node[:bcpc][:hadoop][:distribution][:release])}
+
+hdp_pkg_strs + %W{
   #{node['bcpc']['mysql']['connector']['package']['short_name']}
   cgroup-bin}).each do |pkg|
   package pkg do


### PR DESCRIPTION
This pull request fixes the issue identified in Issue #531 with bad binding precedence for the `datanode.rb` recipe.