### PR TITLE
Add a rspec test for the datanode recipe to verify fix for issue #531

### DIFF
--- a/cookbooks/bcpc-hadoop/Gemfile
+++ b/cookbooks/bcpc-hadoop/Gemfile
@@ -1,6 +1,7 @@
-source 'https://rubygems.org'
+source 'http://rubygems.org'
 
 gem 'rspec', :require => false, :group => :test
 gem 'simplecov', :require => false, :group => :test
 gem 'simplecov-json', :require => false, :group => :test
 gem 'simplecov-rcov', :require => false, :group => :test
+gem 'zookeeper', :require => false, :group => :test

--- a/cookbooks/bcpc-hadoop/libraries/helpers.rb
+++ b/cookbooks/bcpc-hadoop/libraries/helpers.rb
@@ -34,7 +34,9 @@ module Bcpc_Hadoop
       bash "hdp-select #{package}" do
         code "hdp-select set #{package} #{version}"
         subscribes :run, "package[#{hwx_pkg_str(package, version)}]", :immediate
-        not_if { ::File.readlink("/usr/hdp/current/#{package}").start_with?("/usr/hdp/#{version}/") }
+        not_if { ::File.exist?("/usr/hdp/current/#{package}") &&
+                 ::File.readlink("/usr/hdp/current/#{package}")\
+                   .start_with?("/usr/hdp/#{version}/") }
       end
     end
 

--- a/cookbooks/bcpc-hadoop/spec/unit/recipes/datanode_spec.rb
+++ b/cookbooks/bcpc-hadoop/spec/unit/recipes/datanode_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'bcpc-hadoop::datanode' do
+  let(:dummy_class) do
+    Class.new do
+      include Bcpc_Hadoop::Helper
+    end
+  end
+
+  # load a bcpc-hadoop recipe to test cookbook attributes cover business rules
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new do |node|
+      Fauxhai.mock(platform: 'ubuntu', version: '12.04')
+      node.set['memory']['total'] = 1024
+      node.set['cpu']['total'] = 1
+      allow_any_instance_of(Chef::Recipe).to receive(:make_config).and_return(lambda { true })
+
+      node.set[:bcpc][:hadoop][:mounts] = [0, 1]
+      stub_search("node", "recipes:bcpc-hadoop\\:\\:zookeeper_server AND chef_environment:#{node.environment}").and_return([node])
+      $dbi = stub_data_bag_item('configs', node.environment).and_return({ 
+                           'id' => 'POB2-GEN',
+                           'mysql-hive-password' => 'sekret',
+                           'mysql-hive-table-stats-user' => 'name',
+                           'mysql-hive-table-stats-password' => 'sekret_too'
+                         }).block
+    end.converge("recipe[bcpc-hadoop::datanode]")
+
+#      node.set["bcpc"]["hadoop"]["distribution"]["version"] = 'HDP'
+#      node.set["bcpc"]["hadoop"]["distribution"]["release"] = '2.3.4.0-3485'
+#      node.set["bcpc"]["hadoop"]["distribution"]["active_release"] = node["bcpc"]["hadoop"]["distribution"]["release"]
+  end
+  let(:node) { chef_run.node }
+
+  %w{hadoop-2-3-4-0-3485-hdfs-datanode}.each do |pkg|
+    it { expect(chef_run).to install_package(pkg) }
+  end
+end


### PR DESCRIPTION
This is a ChefSpec test to verify the fix for Issue #531 after the three PR's (PR #532, PR #533, PR #534)  required to fix the issue. This ChefSpec test can be run via minimally (requiring chefdk being installed):

```
export PATH=/opt/chefdk/embedded/bin:$PATH
git clone https://github.com/bloomberg/chef-bach
cd chef-bach/cookbooks/bcpc-hadoop
bundle install
rspec spec/unit/recipes//datanode_spec.rb --color
```

One unhandled exception which was being swallowed was also addressed in this test.
