### PR TITLE
Return unique list of namenodes in the cluster

### DIFF
--- a/cookbooks/bcpc-hadoop/libraries/utils.rb
+++ b/cookbooks/bcpc-hadoop/libraries/utils.rb
@@ -123,13 +123,11 @@ def get_namenodes()
   if node['bcpc']['hadoop']['hdfs']['HA']
     nnrole = search(:node, "role:BCPC-Hadoop-Head-Namenode* AND chef_environment:#{node.chef_environment}")
     nnroles = search(:node, "roles:BCPC-Hadoop-Head-Namenode* AND chef_environment:#{node.chef_environment}")
-    puts "nnrole: #{nnrole}"
-    puts "nnroles:#{nnroles}"
-    nn_hosts = nnrole | nnroles
+    nn_hosts = nnrole.concat nnroles
   else
     nn_hosts = get_nodes_for("namenode_no_HA")
   end
-  return nn_hosts.sort
+  return nn_hosts.uniq{ |x| float_host(x[:hostname]) }.sort 
 end
 
 def get_nodes_for(recipe, cookbook=cookbook_name)


### PR DESCRIPTION
This PR fixes an issue where duplicate hosts are returned for `NameNode` that causes `hdfs-site.xml` to have four `NameNodes` instead of two.