### PR TITLE
HBase 1.x related changes to configure bucket cache

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hbase.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hbase.rb
@@ -47,9 +47,7 @@ default["bcpc"]["hadoop"]["hbase_rs"]["PretenureSizeThreshold"] = "1m"
 default["bcpc"]["hadoop"]["phoenix"]["tracing"]["enabled"] = false
 
 
-bucketcache_size = (node["bcpc"]["hadoop"]["hbase_rs"]["xmx"]["size"] * node["bcpc"]["hadoop"]["hbase"]["blockcache"]["size"] + node["bcpc"]["hadoop"]["hbase_rs"]["mx_dir_mem"]["size"] -  node["bcpc"]["hadoop"]["hbase_rs"]["hdfs_dir_mem"]["size"]).floor 
-
-bucketcache_combinedcache_percent = bucketcache_size.to_f/(node["bcpc"]["hadoop"]["hbase_rs"]["xmx"]["size"] + node["bcpc"]["hadoop"]["hbase_rs"]["mx_dir_mem"]["size"] - node["bcpc"]["hadoop"]["hbase_rs"]["hdfs_dir_mem"]["size"])
+bucketcache_size = (node["bcpc"]["hadoop"]["hbase_rs"]["mx_dir_mem"]["size"] -  node["bcpc"]["hadoop"]["hbase_rs"]["hdfs_dir_mem"]["size"]).floor 
 
 # These will become key/value pairs in 'hbase_site.xml'
 default[:bcpc][:hadoop][:hbase][:site_xml].tap do |site_xml|
@@ -105,7 +103,7 @@ default[:bcpc][:hadoop][:hbase][:site_xml].tap do |site_xml|
     site_xml['hfile.block.cache.size'] = node["bcpc"]["hadoop"]["hbase"]["blockcache"]["size"].to_s
     site_xml['hbase.bucketcache.size'] = bucketcache_size
     site_xml['hbase.bucketcache.ioengine '] = node["bcpc"]["hadoop"]["hbase"]["bucketcache"]["ioengine"]
-    site_xml['hbase.bucketcache.percentage.in.combinedcache'] = bucketcache_combinedcache_percent
+    site_xml['hbase.bucketcache.combinedcache.enabled'] = true
   end
   if node["bcpc"]["hadoop"]["hbase"]["region"]["replication"]["enabled"] == true then
     site_xml['hbase.regionserver.storefile.refresh.period'] = node["bcpc"]["hadoop"]["hbase_rs"]["storefile"]["refresh"]["period"]

--- a/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
@@ -140,7 +140,7 @@ env_sh[:HBASE_REGIONSERVER_OPTS] =
 
 if node["bcpc"]["hadoop"]["hbase"]["bucketcache"]["enabled"] == true then
  env_sh[:HBASE_REGIONSERVER_OPTS] += 
-   " -XX:MaxDirectMemorySize='{node['bcpc']['hadoop']['hbase_rs']['mx_dir_mem']['size']}m"
+   " -XX:MaxDirectMemorySize=#{node['bcpc']['hadoop']['hbase_rs']['mx_dir_mem']['size']}m"
 end
 
 if node[:bcpc][:hadoop].attribute?(:jmx_enabled) and node[:bcpc][:hadoop][:jmx_enabled] then


### PR DESCRIPTION
The changes in this PR is to handle the difference in how bucketcache is configured in HBase 1.x. 