### PR TITLE
Enable Hiveserver2 HA via zookeeper

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hive.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hive.rb
@@ -1,7 +1,14 @@
 default["bcpc"]["hadoop"]["hive"]["hive_table_stats_db"] =
-  "hive_table_stats"
+  'hive_table_stats'
 default["bcpc"]["hadoop"]["hive"]["hive_table_stats_db_user"] =
-  "hive_table_stats"
+  'hive_table_stats'
+default["bcpc"]["hadoop"]["hive"]["server2"]["authentication"] =
+  'KERBEROS'
+default["bcpc"]["hadoop"]["hive"]["server2"]["ldap_url"] =
+  'ldap://bcpc.example.com'
+default["bcpc"]["hadoop"]["hive"]["server2"]["ldap_domain"] =
+  'bcpc.example.com'
+default["bcpc"]["hadoop"]["hive"]["server2"]["port"] = '10000'
 
 # These will become key/value pairs in 'hive_site.xml'
 default[:bcpc][:hadoop][:hive][:site_xml].tap do |site_xml|


### PR DESCRIPTION
This PR enables `HiveServer2` HA via ``Zookeeper`.  The architecture for service discovery is given [here](https://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.3.2/bk_hadoop-ha/content/ha-hs2-service-discovery.html).

Once HA is enabled users will have to connect a url akin to given below:
```
ubuntu@bcpc-vm8:~$ beeline -u  "jdbc:hive2://f-bcpc-vm1.bcpc.example.com:2181,f-bcpc-vm2.bcpc.example.com:2181,f-bcpc-vm3.bcpc.example.com:2181,f-bcpc-vm4.
bcpc.example.com:2181,f-bcpc-vm5.bcpc.example.com:2181/default;serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=HS2-Test-Laptop-KERBEROS;principal=hive/f-
bcpc-vm3.bcpc.example.com@BCPC.EXAMPLE.COM"
Connecting to jdbc:hive2://f-bcpc-vm1.bcpc.example.com:2181,f-bcpc-vm2.bcpc.example.com:2181,f-bcpc-vm3.bcpc.example.com:2181,f-bcpc-vm4.bcpc.example.com:2
181,f-bcpc-vm5.bcpc.example.com:2181/default;serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=HS2-Test-Laptop-KERBEROS;principal=hive/f-bcpc-vm3.bcpc.exam
ple.com@BCPC.EXAMPLE.COM
Connected to: Apache Hive (version 1.2.1.2.3.4.0-3485)
Driver: Hive JDBC (version 1.2.1.2.3.4.0-3485)
Transaction isolation: TRANSACTION_REPEATABLE_READ
Beeline version 1.2.1.2.3.4.0-3485 by Apache Hive
0: jdbc:hive2://f-bcpc-vm1.bcpc.example.com:2> select * from test limit 10;
+----------+-------------+--+
| test.id  | test.idval  |
+----------+-------------+--+
| id0001   | value0001   |
| id0002   | value0002   |
| id0003   | value0003   |
| id0004   | value0004   |
| id0005   | value0005   |
| id0006   | value0006   |
| id0007   | value0007   |
| id0008   | value0008   |
| id0009   | value0009   |
| id0010   | value0010   |
+----------+-------------+--+
10 rows selected (2.102 seconds)
```