### PR TITLE
Correct typo for HS2 LDAP domain parameter

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hive_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hive_config.rb
@@ -126,7 +126,7 @@ elsif hive_site_vars[:hs2_auth] == 'LDAP'
     'hive.server2.authentication.ldap.url' =>
       hive_site_vars[:hs2_ldap_url],
 
-    'hive.server2.authentication.ldap.domain' =>
+    'hive.server2.authentication.ldap.Domain' =>
       hive_site_vars[:hs2_ldap_domain]
   }
 end


### PR DESCRIPTION
This PR uses correct capitalization for `Hive` LDAP domain parameter. 