### PR TITLE
use spark 2.0 preview

### DIFF
--- a/cookbooks/bach_spark/attributes/default.rb
+++ b/cookbooks/bach_spark/attributes/default.rb
@@ -1,11 +1,11 @@
 default[:spark][:download][:url] = 'http://d3kbcqa49mib13.cloudfront.net'
-default[:spark][:download][:file][:name] = 'spark-1.6.0-bin-hadoop2.6'
+default[:spark][:download][:file][:name] = 'spark-2.0.0-preview-bin-hadoop2.7'
 default[:spark][:download][:file][:type] = 'tgz'
 default[:spark][:download][:dir] = '/home/vagrant/chef-bcpc/bins'
 default[:spark][:package][:install_meta] = false
 default[:spark][:package][:base] = '/usr/spark'
 default[:spark][:package][:prefix] = 'spark'
-default[:spark][:package][:version] = '1.6.0'
+default[:spark][:package][:version] = '2.0.0-preview'
 default[:spark][:hdfs_url] = node['bcpc']['hadoop']['hdfs_url']
 default[:spark][:bin][:dir] = "#{node[:spark][:package][:base]}/#{node[:spark][:package][:version]}"
 


### PR DESCRIPTION
Change the download url for spark to use the latest 2.0 build.

I'm not able to test this currently, but wanted to create this pr to reference.
