### PR TITLE
corrected service_cmd string in BCPC-Hadoop-Head-ResourceManager role

### DIFF
--- a/stub-environment/roles/BCPC-Hadoop-Head-ResourceManager.json
+++ b/stub-environment/roles/BCPC-Hadoop-Head-ResourceManager.json
@@ -13,7 +13,7 @@
                  {
                     "type": "resourcemanager",
                     "service": "hadoop-yarn-resourcemanager",
-                    "service_cmd": "org.apache.hadoop.yarn.server.resourcemanager.ResourceManagerver.quorum.QuorumPeerMain"
+                    "service_cmd": "org.apache.hadoop.yarn.server.resourcemanager.ResourceManager"
                  }
         ]
       }


### PR DESCRIPTION
This is intended to fix #573