### PR TITLE
Add configs for HBASE-12954 JIRA

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
@@ -77,6 +77,8 @@ generated_values = {
       node[:bcpc][:hadoop][:hb_hosts].length > 1 ? "true" : "false",
   'hbase.master.wait.on.regionservers.mintostart' => 
       "#{node[:bcpc][:hadoop][:rs_hosts].length/2+1}",
+  'hbase.master.hostname' => float_host(node[:fqdn]),
+  'hbase.regionserver.hostname' => float_host(node[:fqdn]),
   'hbase.regionserver.dns.interface' =>
       node["bcpc"]["networks"][subnet]["floating"]["interface"],
   'hbase.master.dns.interface' =>


### PR DESCRIPTION
This PR adds properties that are required for [HBASE-12954](https://issues.apache.org/jira/browse/HBASE-12954). After this one can specify a particular hostname that will be published in `Zookeeper` by `HBase` for master and regionserver. 