### PR TITLE
Changes to enable HBase HDFS short-circuit read using wrapper cookbook

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hbase.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hbase.rb
@@ -89,7 +89,6 @@ default[:bcpc][:hadoop][:hbase][:site_xml].tap do |site_xml|
   #  site_xml['hbase.regionserver.keytab.file'] = "#{node[:bcpc][:hadoop][:kerberos][:keytab][:dir]}/#{node[:bcpc][:hadoop][:kerberos][:data][:hbase][:keytab]}"
   #  site_xml['hbase.rpc.engine'] = 'org.apache.hadoop.hbase.ipc.SecureRpcEngine'
   #end
-  site_xml['dfs.client.read.shortcircuit'] = node["bcpc"]["hadoop"]["hbase"]["shortcircuit"]["read"].to_s
   site_xml['hbase.regionserver.handler.count'] = node["bcpc"]["hadoop"]["hbase"]["regionserver"]["handler"]["count"].to_s
   site_xml['hbase.ipc.warn.response.time'] = node["bcpc"]["hadoop"]["hbase"]["ipc"]["warn"]["response"]["time"].to_s
   site_xml['hbase.ipc.warn.response.size'] = node["bcpc"]["hadoop"]["hbase"]["ipc"]["warn"]["response"]["size"].to_s

--- a/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
@@ -82,7 +82,8 @@ generated_values = {
   'hbase.regionserver.dns.interface' =>
       node["bcpc"]["networks"][subnet]["floating"]["interface"],
   'hbase.master.dns.interface' =>
-      node["bcpc"]["networks"][subnet]["floating"]["interface"]
+      node["bcpc"]["networks"][subnet]["floating"]["interface"],
+  'dfs.client.read.shortcircuit' => node["bcpc"]["hadoop"]["hbase"]["shortcircuit"]["read"].to_s
 }
 
 if node[:bcpc][:hadoop][:kerberos][:enable] == true then


### PR DESCRIPTION
This is related to issue #580. The changes in this PR will enable users enable/disable HBase HDFS short-circuit read through wrapper cookbook.