### PR TITLE
Changes to automatically restart HBase services when Java is changed

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -88,6 +88,7 @@ service "hbase-master" do
   subscribes :restart, "bash[hdp-select hbase-master]", :delayed
   subscribes :restart, "user_ulimit[hbase]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
+  subscribes :restart, "template[/etc/profile.d/jdk.sh]", :delayed
 end
 
 if node["bcpc"]["hadoop"]["phoenix"]["tracing"]["enabled"]

--- a/cookbooks/bcpc-hadoop/recipes/region_server.rb
+++ b/cookbooks/bcpc-hadoop/recipes/region_server.rb
@@ -63,4 +63,5 @@ service "hbase-regionserver" do
   subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
   subscribes :restart, "bash[hdp-select hbase-regionserver]", :delayed
   subscribes :restart, "user_ulimit[hbase]", :delayed
+  subscribes :restart, "template[/etc/profile.d/jdk.sh]", :delayed
 end


### PR DESCRIPTION
This change requires ``Java`` cookbook version ``1.40.0`` where [this](https://github.com/agileorbit-cookbooks/java/pull/358) change in committed. For existing clusters (created before this change) what it means is that the ``Java`` cookbook need to be updated manually using ``knife cookbook site download java --config .chef/knife.rb``. 

Refer ``chef-bach`` issue #590 for additional details.

**To be double sure for someone who may not noticed the labels, this is a breaking change**.