### PR TITLE
Version fixes

### DIFF
--- a/build_bins.sh
+++ b/build_bins.sh
@@ -49,6 +49,10 @@ if [[ -z `gem list --local cabin | grep cabin | cut -f1 -d" "` ]]; then
   gem install cabin --no-ri --no-rdoc -v 0.7.2
 fi
 
+if [[ -z `gem list --local json | grep json | cut -f1 -d" "` ]]; then
+  gem install json --no-ri --no-rdoc -v 1.8.3
+fi
+
 if [[ -z `gem list --local fpm | grep fpm | cut -f1 -d" "` ]]; then
   gem install fpm --no-ri --no-rdoc -v 1.3.3
 fi

--- a/setup_chef_cookbooks.sh
+++ b/setup_chef_cookbooks.sh
@@ -56,7 +56,7 @@ EOF
 cd cookbooks
 
 # allow versions on cookbooks via "cookbook version"
-for cookbook in "apt 2.4.0" python "build-essential 3.2.0" ubuntu cron "chef-client 4.2.4" "chef-vault 1.3.0" "ntp 1.10.1" yum logrotate yum-epel sysctl chef_handler 7-zip seven_zip "windows 1.36.6" ark sudo ulimit pam "ohai 3.0.1" "poise 1.0.12" graphite_handler java "maven 2.1.1" "krb5 2.0.0"; do
+for cookbook in "apt 2.4.0" python "build-essential 3.2.0" ubuntu cron "chef-client 4.2.4" "chef-vault 1.3.0" "ntp 1.10.1" yum logrotate yum-epel "sysctl 0.7.5" chef_handler 7-zip seven_zip "windows 1.36.6" ark sudo ulimit pam "ohai 3.0.1" "poise 1.0.12" graphite_handler java "maven 2.1.1" "krb5 2.0.0"; do
   # unless the proxy was defined this knife config will be the same as the one generated above
   if [[ ! -d ${cookbook% *} ]]; then
     # 7-zip has been deprecated but recipies still depend on it, will force download


### PR DESCRIPTION
* The newest sysctl cookbook drops Chef 11.x compatibility.  This PR reverts to v0.7.5
* The newest fpm and json gems drop ruby 1.9 compatibility.  This PR reverts to a prior json that retains 1.9.x support.