### PR TITLE
Changes to use version 256 of JMXTrans

### DIFF
--- a/build_bins.sh
+++ b/build_bins.sh
@@ -58,9 +58,9 @@ if [[ -z `gem list --local fpm | grep fpm | cut -f1 -d" "` ]]; then
 fi
 
 # Download jmxtrans tar.gz file
-if ! [[ -f jmxtrans-254-dist.tar.gz ]]; then
-  while ! $(file jmxtrans-254-dist.tar.gz | grep -q 'gzip compressed data'); do
-    $CURL -O -L -k http://central.maven.org/maven2/org/jmxtrans/jmxtrans/254/jmxtrans-254-dist.tar.gz
+if ! [[ -f jmxtrans-256-dist.tar.gz ]]; then
+  while ! $(file jmxtrans-256-dist.tar.gz | grep -q 'gzip compressed data'); do
+    $CURL -O -L -k http://central.maven.org/maven2/org/jmxtrans/jmxtrans/256/jmxtrans-256-dist.tar.gz
    done
 fi
 FILES="jmxtrans-254-dist.tar.gz $FILES"

--- a/cookbooks/bcpc_jmxtrans/attributes/default.rb
+++ b/cookbooks/bcpc_jmxtrans/attributes/default.rb
@@ -1,8 +1,7 @@
 #
 # Name of jmxtrans software downloaded
 #
-default['jmxtrans']['version'] = "254"
-default['jmxtrans']['sw'] = "jmxtrans-254-dist.tar.gz"
+default['jmxtrans']['version'] = "256"
 #
 # Add additional JMX queries following the existing queries as sample
 # Also refer to the jmxtrans community cookbook if queries of the category you are planning to add is


### PR DESCRIPTION
There is an [issue reported](https://github.com/jmxtrans/jmxtrans/issues/441) that version 254 of ``JMXTrans`` is using CPU heavily and version 256 of ``JMXTrans`` released with required fixes. The change in this PR is to use version 256 of ``JMXTrans``.

**Note**
On existing clusters tar.gz file for version 256 of JMXTrans need to be manually staged. i.e. this is a breaking change.  