### PR TITLE
use fs statistical aggregation in hive

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hive.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hive.rb
@@ -24,7 +24,7 @@ default[:bcpc][:hadoop][:hive][:site_xml].tap do |site_xml|
     '/tmp/${user.name}/operation_logs'
   site_xml['hive.server2.logging.operation.verbose'] = true
   site_xml['hive.stats.autogather'] = true
-  site_xml['hive.stats.dbclass'] = 'jdbc:mysql'
+  site_xml['hive.stats.dbclass'] = 'fs'
   site_xml['hive.stats.jdbcdriver'] = 'com.mysql.jdbc.Driver'
   site_xml['hive.support.concurrency'] = true
   site_xml['hive.warehouse.subdir.inherit.perms'] = true


### PR DESCRIPTION
This will prevent the following error from happening
````
[Error 30017]: Skipping stats aggregation by error 
org.apache.hadoop.hive.ql.metadata.HiveException: [Error 30001]: StatsPublisher 
cannot be initialized. There was a error in the initialization of 
StatsPublisher, and retrying might help. If you dont want the query to fail 
because accurate statistics could not be collected, set 
hive.stats.reliable=false
````