### PR TITLE
Change the permissions on the history server directories

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/historyserver.rb
+++ b/cookbooks/bcpc-hadoop/recipes/historyserver.rb
@@ -10,6 +10,14 @@ include_recipe 'bcpc-hadoop::hadoop_config'
   hdp_select(pkg, node[:bcpc][:hadoop][:distribution][:active_release])
 end
 
+["", "done", "done_intermediate"].each do |dir|
+  bash "create-hdfs-history-dir #{dir}" do
+    code "hdfs dfs -mkdir /user/history/#{dir} && hdfs dfs -chmod 0773 /user/history/#{dir} && hdfs dfs -chown yarn:mapred /user/history/#{dir}"
+    user "hdfs"
+    not_if "hdfs dfs -test -d /user/history/#{dir}", :user => "hdfs"
+  end
+end
+
 configure_kerberos 'historyserver_kerb' do
   service_name 'historyserver'
 end

--- a/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
@@ -247,9 +247,3 @@ bash "create-hdfs-user" do
   user "hdfs"
   not_if "sudo -u hdfs #{hdfs_cmd} dfs -test -d /user"
 end
-
-bash "create-hdfs-history" do
-  code "#{hdfs_cmd} dfs -mkdir /user/history; #{hdfs_cmd} dfs -chmod -R 1777 /user/history; #{hdfs_cmd} dfs -chown mapred:hdfs /user/history"
-  user "hdfs"
-  not_if "sudo -u hdfs #{hdfs_cmd} dfs -test -d /user/history"
-end

--- a/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
@@ -156,9 +156,3 @@ bash "create-hdfs-user" do
   user "hdfs"
   not_if "sudo -u hdfs #{hdfs_cmd} dfs -test -d /user"
 end
-
-bash "create-hdfs-history" do
-  code "#{hdfs_cmd} dfs -mkdir /user/history; #{hdfs_cmd} dfs -chmod -R 1777 /user/history; #{hdfs_cmd} dfs -chown mapred:hdfs /user/history"
-  user "hdfs"
-  not_if "sudo -u hdfs #{hdfs_cmd} dfs -test -d /user/history"
-end

--- a/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
@@ -20,14 +20,6 @@ node[:bcpc][:hadoop][:mounts].each do |i|
   end
 end
 
-["", "done", "done_intermediate"].each do |dir|
-  bash "create-hdfs-history-dir #{dir}" do
-    code "hdfs dfs -mkdir /user/history/#{dir} && hdfs dfs -chmod 1777 /user/history/#{dir} && hdfs dfs -chown yarn:mapred /user/history/#{dir}"
-    user "hdfs"
-    not_if "hdfs dfs -test -d /user/history/#{dir}", :user => "hdfs"
-  end
-end
-
 bash "create-hdfs-yarn-log" do
   code "hdfs dfs -mkdir -p /var/log/hadoop-yarn && hdfs dfs -chmod 0777 /var/log/hadoop-yarn && hdfs dfs -chown yarn:mapred /var/log/hadoop-yarn"
   user "hdfs"


### PR DESCRIPTION
The current permissions doesn't allow ``historyserver`` process to delete elements created in the history directory while ``map-reduce`` jobs are run. The changes in the PR is to set the correct permissions so that ``historyserver`` which is running as ``mapred`` user that belongs to ``mapred`` group can rename/delete elements under  ``/user/history/done_intermediate`` and ``/user/history/done`` directories.