### PR TITLE
Add paxos directory to support NN recovery

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/journalnode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/journalnode.rb
@@ -34,6 +34,7 @@ end
 
 jndisk="/disk/#{node[:bcpc][:hadoop][:mounts][0]}"
 jnfile="/dfs/jn/#{node.chef_environment}/current/VERSION"
+jncurrent="/dfs/jn/#{node.chef_environment}/current"
 jnfile2chk=jndisk + jnfile
 
 if get_config("jn_txn_fmt") then
@@ -61,6 +62,14 @@ bash "change-ownership-for-jnfile" do
   cwd "#{jndisk}/dfs/jn"
   code "chown -R hdfs:hdfs #{node.chef_environment}"
   action :nothing
+end
+
+directory "#{jndisk}#{jncurrent}/paxos" do
+  owner "hdfs"
+  group "hdfs"
+  mode 0755
+  action :create
+  recursive true
 end
 
 # need to ensure hdfs user is in hadoop and hdfs


### PR DESCRIPTION
This PR adds logic to create `paxos` directory under `JN` current directory. This is needed by `NN` to perform recovery when a `JN` node is re-installed. The `paxos` directory is only created during `initializedEdits`.