### PR TITLE
Create HBase GC log directory and fix HBASE_REGIONSERVER_OPTS

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
@@ -172,7 +172,7 @@ env_sh[:HBASE_JMX_BASE] = '"-Dcom.sun.management.jmxremote.ssl=false ' +
 # Common env.sh options relevant to HBASE region servers
 #
 env_sh[:HBASE_REGIONSERVER_OPTS] = 
-  " -server -XX:ParallelGCThreads=#{[1, (node['cpu']['total'] * node['bcpc']['hadoop']['hbase_rs']['gc_thread']['cpu_ratio']).ceil].max} " +
+  " $HBASE_REGIONSERVER_OPTS -server -XX:ParallelGCThreads=#{[1, (node['cpu']['total'] * node['bcpc']['hadoop']['hbase_rs']['gc_thread']['cpu_ratio']).ceil].max} " +
   " -XX:+UseParNewGC -XX:CMSInitiatingOccupancyFraction=#{node['bcpc']['hadoop']['hbase_rs']['cmsinitiatingoccupancyfraction']} " + 
   "-XX:+UseCMSInitiatingOccupancyOnly -verbose:gc -XX:+PrintHeapAtGC " + 
   "-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps " + 
@@ -192,7 +192,7 @@ env_sh[:HBASE_REGIONSERVER_OPTS] =
 if node[:bcpc][:hadoop][:kerberos][:enable] == true then
  env_sh[:HBASE_OPTS] = '"$HBASE_OPTS -Djava.security.auth.login.config=/etc/hbase/conf/hbase-client.jaas"'
  env_sh[:HBASE_MASTER_OPTS] = '$HBASE_MASTER_OPTS -Djava.security.auth.login.config=/etc/hbase/conf/hbase-server.jaas'
- env_sh[:HBASE_REGIONSERVER_OPTS] = '$HBASE_REGIONSERVER_OPTS -Djava.security.auth.login.config=/etc/hbase/conf/regionserver.jaas'
+ env_sh[:HBASE_REGIONSERVER_OPTS] += ' -Djava.security.auth.login.config=/etc/hbase/conf/regionserver.jaas'
 end
 
 #

--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -76,6 +76,14 @@ template "/etc/init.d/hbase-master" do
   mode 0655
 end
 
+directory '/var/log/hbase/gc' do
+  owner 'hbase'
+  group 'hbase'
+  mode '0755'
+  action :create
+  notifies :restart, "service[hbase-master]", :delayed
+end
+
 service "hbase-master" do
   action [:enable, :start]
   supports :status => true, :restart => true, :reload => false

--- a/cookbooks/bcpc-hadoop/recipes/region_server.rb
+++ b/cookbooks/bcpc-hadoop/recipes/region_server.rb
@@ -46,6 +46,14 @@ configure_kerberos 'hbasers_kerb' do
   service_name 'hbase'
 end
 
+directory '/var/log/hbase/gc' do
+  owner 'hbase'
+  group 'hbase'
+  mode '0755'
+  action :create
+  notifies :restart, "service[hbase-regionserver]", :delayed
+end
+
 template "/etc/init.d/hbase-regionserver" do
   source "hdp_hbase-regionserver-initd.erb"
   mode 0655


### PR DESCRIPTION
This PR has two fixes

- Create ``/var/log/hbase/gc`` directory. Even though ``hbase`` processes run with ``-Xloggc`` option ``gc`` logs are not written due to the absence of this directory.
- Fix the bug in the [current code](https://github.com/ekund/chef-bach/blob/4c0c1d8bfd2857f7f8d7401061ec8a70a210ce13/cookbooks/bcpc-hadoop/recipes/hbase_config.rb#L173) so that  ``HBASE_REGIONSERVER_OPTS`` is set with all the JVM related parameters so that they take in effect when ``hbase`` region server processes start. 