### PR TITLE
Use Berkshelf for VM builds

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -32,7 +32,6 @@ cookbook 'kafka-bcpc', path: './cookbooks/kafka-bcpc'
 #
 cookbook 'apt'
 cookbook 'chef-client'
-cookbook 'chef-ingredient'
 cookbook 'java'
 cookbook 'maven'
 cookbook 'ntp'
@@ -40,27 +39,25 @@ cookbook 'pam'
 cookbook 'ubuntu'
 
 #
-# Cookbooks absent from the supermarket
+# Transitive dependencies that have been forked for one reason or another.
 #
 
 # bfd is not on the supermarket
 cookbook 'bfd',
   git: 'https://github.com/bloomberg/openbfdd-cookbook'
 
+
 # cobblerd forked, pending destruction of earth by moon.
-cookbook 'cobblerd',
-  git: 'https://github.com/cbaenziger/cobbler-cookbook',
-  branch: 'cobbler_profile'
+cookbook 'cobblerd', 
+  git: 'https://github.com/bloomberg/cobbler-cookbook'
 
 # jmxtrans 1.0+ isn't on the supermarket.
-cookbook 'jmxtrans',
-  git: 'https://github.com/jmxtrans/jmxtrans-cookbook',
-  revision: 'd8ee2396eca91ef8e0e558490bde075869b787de'
+cookbook 'jmxtrans', 
+  git: 'https://github.com/bijugs/jmxtrans-cookbook',
+  branch: 'ver-2.0'
 
 # 'kafka' has an entry on the supermarket, but it's the wrong cookbook.
 cookbook 'kafka',
   git: 'https://github.com/mthssdrbrg/kafka-cookbook.git',
-  revision: '0e05b5bf562c39b7c1a2e059412be91b6402703f'
-
-cookbook 'graphite_handler',
-  git: 'https://github.com/mkoni/chef-graphite_handler.git'
+  tag: 'v2.0.2'
+ 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,82 +1,125 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
-
-# This is a Vagrant to automatically provision a bootstrap node with a
-# Chef server.
+#
+# This is a Vagrantfile to automatically provision a bootstrap node
+# with a Chef server.
+#
 # See http://www.vagrantup.com/ for info on Vagrant.
+#
 
 require 'json'
 
-# Since we run vagrant commands from ~/chef-bcpc and from ~/chef-bcpc/vbox directory, finding
-# correct location for environment file is important. To set the base_dir correct we check
-# if we are inside "vbox" directory or not and act accordingly
+#
+# You can override parts of the vagrant config by creating a
+# 'Vagrantfile.local.rb'
+#
+# (You may find this useful for SSL certificate injection.)
+#
+local_file =
+  if File.basename(File.expand_path('.')) == 'vbox'
+    File.expand_path('../Vagrantfile.local.rb')
+  else
+    "#{__FILE__}.local.rb"
+  end
 
-if File.basename(File.expand_path(".")) == "vbox"
-  base_dir = File.expand_path("../environments")
-else
-  base_dir = File.expand_path("./environments")
+if File.exist?(local_file)
+  puts "Found #{local_file}, including"
+  require local_file
 end
+
+#
+# Since we run vagrant commands from ~/chef-bcpc and from
+# ~/chef-bcpc/vbox directory, finding correct location for environment
+# file is important.
+#
+# To set the base_dir correct we check if we are inside "vbox"
+# directory or not and act accordingly
+#
+
+base_dir = if File.basename(File.expand_path('.')) == 'vbox'
+             File.expand_path('../environments')
+           else
+             File.expand_path('./environments')
+           end
 
 $stderr.puts "Base directory is : #{base_dir}"
 
-json_file = Dir[File.join("#{base_dir}/../environments/",'*.json')]
+json_file = Dir[File.join("#{base_dir}/../environments/", '*.json')]
 
 if json_file.empty?
-  $stderr.puts "No environment file found to parse. Please make sure at least one environment file exists."
+  $stderr.puts 'No environment file found to parse. ' \
+    'Please make sure at least one environment file exists.'
   exit
 end
 
 if json_file.length > 1
-  $stderr.puts "More than one environment file found."
+  $stderr.puts 'More than one environment file found.'
   exit
 end
 
-chef_env = JSON.parse(File.read(json_file.join(",")))
-cluster_environment = chef_env["name"]
-bootstrap_hostname = chef_env["override_attributes"]["bcpc"]["bootstrap"]["hostname"]
-bootstrap_domain = chef_env["override_attributes"]["bcpc"]["domain_name"]
+chef_env = JSON.parse(File.read(json_file.join(',')))
 
-$local_environment = cluster_environment
-$local_mirror = nil
+cluster_environment = chef_env['name']
 
-Vagrant.configure("2") do |config|
+bootstrap_hostname =
+  chef_env['override_attributes']['bcpc']['bootstrap']['hostname']
 
+bootstrap_domain =
+  chef_env['override_attributes']['bcpc']['domain_name']
+
+# We rely on global variables to deal with Vagrantfile scoping rules.
+# rubocop:disable Style/GlobalVars
+$bach_local_environment = cluster_environment
+$bach_local_mirror = nil
+
+Vagrant.configure('2') do |config|
   config.vm.define :bootstrap do |bootstrap|
     bootstrap.vm.hostname = "#{bootstrap_hostname}.#{bootstrap_domain}"
 
-    bootstrap.vm.network :private_network, ip: "10.0.100.3", netmask: "255.255.255.0", adapter_ip: "10.0.100.2"
-    bootstrap.vm.network :private_network, ip: "172.16.100.3", netmask: "255.255.255.0", adapter_ip: "172.16.100.2"
-    bootstrap.vm.network :private_network, ip: "192.168.100.3", netmask: "255.255.255.0", adapter_ip: "192.168.100.2"
+    bootstrap.vm.network(:private_network,
+                         ip: '10.0.100.3',
+                         netmask: '255.255.255.0',
+                         adapter_ip: '10.0.100.2')
 
-    bootstrap.vm.synced_folder "../", "/chef-bcpc-host"
+    bootstrap.vm.network(:private_network,
+                         ip: '172.16.100.3',
+                         netmask: '255.255.255.0',
+                         adapter_ip: '172.16.100.2')
+
+    bootstrap.vm.network(:private_network,
+                         ip: '192.168.100.3',
+                         netmask: '255.255.255.0',
+                         adapter_ip: '192.168.100.2')
+
+    bootstrap.vm.synced_folder '../', '/chef-bcpc-host'
 
     # set up repositories
-    if $local_mirror then
-      bootstrap.vm.provision :shell, :inline => <<-EOH
-        sed -i s/archive.ubuntu.com/#{$local_mirror}/g /etc/apt/sources.list
-        sed -i s/security.ubuntu.com/#{$local_mirror}/g /etc/apt/sources.list
+    if $bach_local_mirror
+      bootstrap.vm.provision :shell, inline: <<-EOH
+        sed -i s/archive.ubuntu.com/#{$bach_local_mirror}/g /etc/apt/sources.list
+        sed -i s/security.ubuntu.com/#{$bach_local_mirror}/g /etc/apt/sources.list
         sed -i s/^deb-src/\#deb-src/g /etc/apt/sources.list
       EOH
     end
   end
 
-  config.vm.box = "precise64"
-  config.vm.box_url = "precise-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.box = 'precise64'
+  config.vm.box_url = 'precise-server-cloudimg-amd64-vagrant-disk1.box'
 
-  memory = ( ENV["BOOTSTRAP_VM_MEM"] or "1024" )
-  cpus = ( ENV["BOOTSTRAP_VM_CPUs"] or "1" )
+  memory = ENV['BOOTSTRAP_VM_MEM'] || '1024'
+  cpus = ENV['BOOTSTRAP_VM_CPUs'] || '1'
 
   config.vm.provider :virtualbox do |vb|
-     # Don't boot with headless mode
-     vb.gui = true
-     vb.name = "#{bootstrap_hostname}"
-     vb.customize ["modifyvm", :id, "--nictype2", "82543GC"]
-     vb.customize ["modifyvm", :id, "--memory", memory]
-     vb.customize ["modifyvm", :id, "--cpus", cpus]
-     vb.customize ["modifyvm", :id, "--largepages", "on"]
-     vb.customize ["modifyvm", :id, "--nestedpaging", "on"]
-     vb.customize ["modifyvm", :id, "--vtxvpid", "on"]
-     vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
-     vb.customize ["modifyvm", :id, "--ioapic", "on"]
-   end
+    # Don't boot with headless mode
+    vb.gui = false
+    vb.name = bootstrap_hostname.to_s
+    vb.customize ['modifyvm', :id, '--nictype2', '82543GC']
+    vb.customize ['modifyvm', :id, '--memory', memory]
+    vb.customize ['modifyvm', :id, '--cpus', cpus]
+    vb.customize ['modifyvm', :id, '--largepages', 'on']
+    vb.customize ['modifyvm', :id, '--nestedpaging', 'on']
+    vb.customize ['modifyvm', :id, '--vtxvpid', 'on']
+    vb.customize ['modifyvm', :id, '--hwvirtex', 'on']
+    vb.customize ['modifyvm', :id, '--ioapic', 'on']
+  end
 end

--- a/bootstrap_chef.sh
+++ b/bootstrap_chef.sh
@@ -82,7 +82,7 @@ echo "Setting up chef environment, roles, and uploading cookbooks"
 $SSH_CMD "tar -xzf /chef-bcpc-host/cluster.tgz -C /home/vagrant" || (echo '### Vagrant ssh failed to deploy cluster environment returned $? ###'; exit 1)
 $SSH_CMD "cd $BCPC_DIR && sudo knife environment from file environments/${CHEF_ENVIRONMENT}.json -u admin -k /etc/chef-server/admin.pem"
 $SSH_CMD "cd $BCPC_DIR && sudo knife role from file roles/*.json -u admin -k /etc/chef-server/admin.pem; r=\$? && sudo knife role from file roles/*.rb -u admin -k /etc/chef-server/admin.pem; r=\$((r & \$? )) && [[ \$r -lt 1 ]]"
-$SSH_CMD "cd $BCPC_DIR && sudo knife cookbook upload -a -o cookbooks -u admin -k /etc/chef-server/admin.pem"
+$SSH_CMD "cd $BCPC_DIR && sudo knife cookbook upload -a -o vendor/cookbooks -u admin -k /etc/chef-server/admin.pem"
 
 echo "Enrolling local bootstrap node into chef"
 $SSH_CMD "cd $BCPC_DIR && ./setup_chef_bootstrap_node.sh ${IP} ${CHEF_ENVIRONMENT}"

--- a/build_bins.sh
+++ b/build_bins.sh
@@ -45,12 +45,13 @@ apt-get -y update
 # Install tools needed for packaging
 apt-get -y install git rubygems make pkg-config pbuilder python-mock python-configobj python-support cdbs python-all-dev python-stdeb libmysqlclient-dev libldap2-dev ruby-dev gcc patch rake ruby1.9.3 ruby1.9.1-dev python-pip python-setuptools dpkg-dev apt-utils haveged libtool autoconf automake autotools-dev unzip rsync autogen
 
-if [[ -z `gem list --local cabin | grep cabin | cut -f1 -d" "` ]]; then
-  gem install cabin --no-ri --no-rdoc -v 0.7.2
-fi
-
+# Install json gem first to avoid a too-new version being pulled in by other gems.
 if [[ -z `gem list --local json | grep json | cut -f1 -d" "` ]]; then
   gem install json --no-ri --no-rdoc -v 1.8.3
+fi
+
+if [[ -z `gem list --local cabin | grep cabin | cut -f1 -d" "` ]]; then
+  gem install cabin --no-ri --no-rdoc -v 0.7.2
 fi
 
 if [[ -z `gem list --local fpm | grep fpm | cut -f1 -d" "` ]]; then
@@ -147,6 +148,7 @@ FILES="cirros-0.3.0-x86_64-disk.img $FILES"
 
 # Grab the Ubuntu 12.04 installer image
 UBUNTU_IMAGE="ubuntu-12.04-mini.iso"
+
 if ! [[ -f $UBUNTU_IMAGE ]]; then
   # Download this ISO to get the latest kernel/X LTS stack installer
   #$CURL -o $UBUNTU_IMAGE http://archive.ubuntu.com/ubuntu/dists/precise-updates/main/installer-amd64/current/images/raring-netboot/mini.iso
@@ -282,7 +284,8 @@ FILES="zabbix-agent.tar.gz zabbix-server.tar.gz $FILES"
 
 # Gather the Chef packages and provide a dpkg repo
 opscode_urls="https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chef_11.12.8-2_amd64.deb
-https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chef-server_11.1.1-1_amd64.deb"
+https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chef-server_11.1.1-1_amd64.deb
+https://packages.chef.io/stable/ubuntu/12.04/chefdk_0.15.16-1_amd64.deb"
 for url in $opscode_urls; do
   if ! [[ -f $(basename $url) ]]; then
     $CURL -L -O $url

--- a/chefignore
+++ b/chefignore
@@ -1,8 +1,14 @@
+.chef
+.chef_found*
 .git
 .kitchen
 .vagrant
 chef
+cookbooks
+cluster.txt
+environments
 local-mode-cache
 provisioning
+roles
 vendor
 vbox

--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -125,14 +125,24 @@ default[:bcpc][:hadoop][:os][:group][:mapred][:members]=["yarn"]
 
 # Override defaults for the Java cookbook
 default['java']['jdk_version'] = 8
-default['java']['install_flavor'] = "oracle"
+default['java']['install_flavor'] = 'oracle'
 default['java']['accept_license_agreement'] = true
-default['java']['jdk']['8']['x86_64']['url'] = get_binary_server_url + 'jdk-8u101-linux-x64.tar.gz'
-default['java']['jdk']['8']['x86_64']['checksum'] = '467f323ba38df2b87311a7818bcbf60fe0feb2139c455dfa0e08ba7ed8581328'
+
+default['java']['jdk']['8']['x86_64']['url'] =
+  get_binary_server_url + 'jdk-8u101-linux-x64.tar.gz'
+
+default['java']['jdk']['8']['x86_64']['checksum'] =
+  '467f323ba38df2b87311a7818bcbf60fe0feb2139c455dfa0e08ba7ed8581328'
+
 default['java']['oracle']['jce']['enabled'] = true
-default['java']['oracle']['jce']['8']['url'] = get_binary_server_url + "jce_policy-8.zip"
+
+default['java']['oracle']['jce']['8']['url'] =
+  get_binary_server_url + 'jce_policy-8.zip'
 
 # Set the JAVA_HOME for Hadoop components
-default['bcpc']['hadoop']['java'] = '/usr/lib/jvm/default-java'
+default['bcpc']['hadoop']['java'] =
+  "/usr/lib/jvm/java-#{node[:java][:jdk_version]}-" \
+  "#{node[:java][:install_flavor]}-amd64"
 
-default['bcpc']['cluster']['file_path'] = "/home/vagrant/chef-bcpc/cluster.txt"
+default['bcpc']['cluster']['file_path'] =
+  '/home/vagrant/chef-bcpc/cluster.txt'

--- a/install-chef.sh
+++ b/install-chef.sh
@@ -16,7 +16,7 @@ grep -q $BINARY_SERVER_HOST /etc/apt/apt.conf || echo "Acquire::http::Proxy::$BI
 echo "deb [arch=amd64] $BINARY_SERVER_URL 0.5.0 main" > /etc/apt/sources.list.d/bcpc.list
 wget --no-proxy -O - ${BINARY_SERVER_URL}/apt_key.pub | apt-key add -
 apt-get update
-apt-get install -y chef
+apt-get install -y chef=11.12.8-2
 
 # setup OpenStack hint
 mkdir -p /etc/chef/ohai/hints/

--- a/proxy_setup.sh
+++ b/proxy_setup.sh
@@ -13,7 +13,7 @@ if [ -n "${PROXY-}" ]; then
   local_ips=$(ip addr list |grep 'inet '|sed -e 's/.* inet //' -e 's#/.*#,#')
   
   export http_proxy=http://${PROXY}
-  export https_proxy=https://${PROXY}
+  export https_proxy=http://${PROXY}
   export no_proxy="$(sed 's/ //g' <<< $local_ips)localhost,$(hostname),$(hostname -f),.$(domainname),10.0.100.,10.0.100.*"
   export NO_PROXY="$(sed 's/ //g' <<< $local_ips)localhost,$(hostname),$(hostname -f),.$(domainname),10.0.100.,10.0.100.*"
   

--- a/setup_chef_cookbooks.sh
+++ b/setup_chef_cookbooks.sh
@@ -36,7 +36,7 @@ validation_client_name   'chef-validator'
 validation_key           '/etc/chef-server/chef-validator.pem'
 chef_server_url          'https://${BOOTSTRAP_IP}'
 syntax_check_cache_path  '$(pwd)/.chef/syntax_check_cache'
-cookbook_path '$(pwd)/cookbooks'
+cookbook_path '$(pwd)/vendor/cookbooks'
  
 # Disable the Ohai password module which explodes on a Single-Sign-On-joined system
 Ohai::Config[:disabled_plugins] = [ "passwd" ]
@@ -53,25 +53,7 @@ no_proxy no_proxy_string
 ENV['GIT_SSL_NO_VERIFY'] = 'true'
 File.umask(0007)
 EOF
-cd cookbooks
 
-# allow versions on cookbooks via "cookbook version"
-for cookbook in "apt 2.4.0" python "build-essential 3.2.0" ubuntu cron "chef-client 4.2.4" "chef-vault 1.3.0" "ntp 1.10.1" yum "logrotate 1.9.2" yum-epel "sysctl 0.7.5" chef_handler 7-zip seven_zip "windows 1.36.6" ark sudo ulimit pam "ohai 3.0.1" "poise 1.0.12" graphite_handler java "maven 2.1.1" "krb5 2.0.0" homebrew; do
-  # unless the proxy was defined this knife config will be the same as the one generated above
-  if [[ ! -d ${cookbook% *} ]]; then
-    # 7-zip has been deprecated but recipies still depend on it, will force download
-    if [[ "$cookbook" == "7-zip" || "$cookbook" == "python" ]]; then
-      knife cookbook site download $cookbook --config ../.chef/knife.rb --force
-    else
-      knife cookbook site download $cookbook --config ../.chef/knife.rb
-    fi
-    tar zxf ${cookbook% *}*.tar.gz
-    rm ${cookbook% *}*.tar.gz
-  fi
-done
-if [[ ! -d kafka ]]; then
-  git clone https://github.com/mthssdrbrg/kafka-cookbook.git kafka
-fi
-[[ -d jmxtrans ]] || git clone https://github.com/bijugs/jmxtrans-cookbook.git -b ver-2.0 jmxtrans
-[[ -d cobblerd ]] || git clone https://github.com/bloomberg/cobbler-cookbook.git cobblerd
-[[ -d bfd ]] || git clone https://github.com/bloomberg/openbfdd-cookbook.git bfd
+mkdir -p ./vendor
+/opt/chefdk/bin/berks vendor ./vendor/cookbooks
+


### PR DESCRIPTION
This PR uses a Berkshelf provided by ChefDK to resolve dependency for test builds in VM clusters.

This is a breaking change only because it updates build_bins.sh with the expectation of a ChefDK 0.9.0 package.