### PR TITLE
Do not create paxos directory during namenode format

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/journalnode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/journalnode.rb
@@ -70,6 +70,7 @@ directory "#{jndisk}#{jncurrent}/paxos" do
   mode 0755
   action :create
   recursive true
+  only_if { File.exists?(jnfile2chk) }
 end
 
 # need to ensure hdfs user is in hadoop and hdfs


### PR DESCRIPTION
This PR makes sure that the `paxos` directory is only created when `JN` is being restored. Creating `paxos` directory during initial format of `NameNode` causes  failure to format the `hdfs` file system.