### PR TITLE
Create yarn.exclude after yarn user exists

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
@@ -48,6 +48,14 @@ link "/etc/init.d/hadoop-yarn-resourcemanager" do
   notifies :run, 'bash[kill yarn-resourcemanager]', :immediate
 end
 
+file "/etc/hadoop/conf/yarn.exclude" do
+  content node["bcpc"]["hadoop"]["decommission"]["hosts"].join("\n")
+  mode 0644
+  owner 'yarn'
+  group 'hdfs'
+  only_if { !node["bcpc"]["hadoop"]["decommission"]["hosts"].nil? }
+end
+
 bash "kill yarn-resourcemanager" do
   code "pkill -u yarn -f resourcemanager"
   action :nothing

--- a/cookbooks/bcpc-hadoop/recipes/yarn_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/yarn_config.rb
@@ -1,11 +1,3 @@
 include_recipe 'bcpc-hadoop::yarn_env'
 include_recipe 'bcpc-hadoop::yarn_schedulers'
 include_recipe 'bcpc-hadoop::yarn_site'
-
-file "/etc/hadoop/conf/yarn.exclude" do
-  content node["bcpc"]["hadoop"]["decommission"]["hosts"].join("\n")
-  mode 0644
-  owner 'yarn'
-  group 'hdfs'
-  only_if { !node["bcpc"]["hadoop"]["decommission"]["hosts"].nil? }
-end


### PR DESCRIPTION
This PR makes sure that `yarn.exclude` file is only created after `yarn` user is created on the machine.