### PR TITLE
Enable hbase service restart when Java version or flavor is changed

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -96,7 +96,7 @@ service "hbase-master" do
   subscribes :restart, "bash[hdp-select hbase-master]", :delayed
   subscribes :restart, "user_ulimit[hbase]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
-  subscribes :restart, "template[/etc/profile.d/jdk.sh]", :delayed
+  subscribes :restart, "log[jdk-version-changed]", :delayed
 end
 
 if node["bcpc"]["hadoop"]["phoenix"]["tracing"]["enabled"]

--- a/cookbooks/bcpc-hadoop/recipes/region_server.rb
+++ b/cookbooks/bcpc-hadoop/recipes/region_server.rb
@@ -71,5 +71,5 @@ service "hbase-regionserver" do
   subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
   subscribes :restart, "bash[hdp-select hbase-regionserver]", :delayed
   subscribes :restart, "user_ulimit[hbase]", :delayed
-  subscribes :restart, "template[/etc/profile.d/jdk.sh]", :delayed
+  subscribes :restart, "log[jdk-version-changed]", :delayed
 end


### PR DESCRIPTION
``java`` community cookbook now provides a [standard resource](https://github.com/agileorbit-cookbooks/java/blob/7fdd8507991d35065c833fff3554f4642b072366/recipes/notify.rb#L29-L33) to subscribe to get notified when Java version or flavor got changed. This PR is to use this resource and restart ``HBase`` services when there is a change.

**Testing**
- Verified that the ``hbase`` services restart when Java version is changed from 7 to 8.

**Note**
- This PR requires ``java`` cookbook version >= 1.41.0 to be available in chef-server i.e. this can break chef-client runs in an existing cluster. 