### PR TITLE
Add a screen session to automated_install.sh to watch the serial console output

### DIFF
--- a/tests/screenrc
+++ b/tests/screenrc
@@ -1,0 +1,24 @@
+echo ''
+echo ''
+echo ''
+echo ''
+echo '=================== Chef-BACH Ubuntu Install Progress ==================='
+echo 'Chef-BACH is PXE booting your VMs and using the netinstaller'
+echo 'to setup your machines. This is a GNU screen session with the'
+echo 'serial console open to monitor progress of each VM (windows 1'
+echo 'through 3 connect to bcpc-vm1 - bcpc-vm3) and a while loop '
+echo 'seeing if ssh has come alive on all three VMs. This session'
+echo 'will exit when all three VMs are running ssh.'
+echo 'Hitting: ^A h will get you the screen help'
+echo 'Hitting: return right now will skip this 120 second pause'
+echo '========================================================================='
+echo ''
+echo ''
+echo ''
+echo ''
+sleep 120
+
+screen -t "bcpc-vm1 serial console" 1 ./virtualbox_serial_console.sh bcpc-vm1
+screen -t "bcpc-vm2 serial console" 2 ./virtualbox_serial_console.sh bcpc-vm2
+screen -t "bcpc-vm3 serial console" 3 ./virtualbox_serial_console.sh bcpc-vm3
+screen -t "Checking Hosts Are Up" 0 bash -c 'echo "Checking if hosts respond to ssh:"; while ! nc -w 1 10.0.100.11 22 || !  nc -w 1 10.0.100.12 22 || !  nc -w 1 10.0.100.13 22; do sleep 60; printf "Hosts down: "; for m in 11 12 13; do nc -w 1 10.0.100.$m 22 > /dev/null || echo -n "10.0.100.$m "; done; printf "\n"; done; echo "===== All Hosts Are Up! Killing this screen session. ====="; sleep 1; kill $(ps -o ppid= $$)'

--- a/tests/virtualbox_serial_console.sh
+++ b/tests/virtualbox_serial_console.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Check we got a VM name
+if [[ "$#" != 1 ]]; then
+  echo "Usage: $(basename $0) <vm name>" >> /dev/stderr
+  echo -e '\tNeed the name of a VM to connect to' >> /dev/stderr
+  exit 2
+fi
+vm_name="$1"
+
+source $(readlink -f $(dirname $0)/..)/virtualbox_env.sh
+
+# If we are running on Ubuntu check socat(1) is installed
+socat_install_cmd='sudo apt-get install -y socat'
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  if [ "$(lsb_release -si)" == "Ubuntu" -a \
+     -z "$(dpkg -s socat 2>/dev/null | grep '^Status.*installed')" ]; then
+    echo "Did not find socat(1) installed; running: $socat_install_cmd" >> /dev/stderr
+    $socat_install_cmd
+  fi
+fi
+
+$VBM list runningvms | grep -q "\"$vm_name\"" || (echo "VM name: $1 not found"; exit 1)
+serial_socket=$($VBM showvminfo $vm_name | grep '^UART 1:' | sed -e "s/.* '//" -e "s/'$//")
+
+trap "stty sane" 0 1 2 3 15
+socat unix-connect:$serial_socket stdio,raw,echo=0,icanon=0


### PR DESCRIPTION
This is a crude shell script addition to watch the serial console output while we PXE boot the VM's. It seems people often get hung up here and have to figure out what's going on. This gives them some infrastructure to interact with their VM's if they are broken. Also the `virtualbox_serial_console.sh` script can be run by hand if one needs too.