### PR TITLE
Set required access restrictions on /user/history hdfs directory

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/historyserver.rb
+++ b/cookbooks/bcpc-hadoop/recipes/historyserver.rb
@@ -12,7 +12,7 @@ end
 
 ["", "done", "done_intermediate"].each do |dir|
   bash "create-hdfs-history-dir #{dir}" do
-    code "hdfs dfs -mkdir /user/history/#{dir} && hdfs dfs -chmod 0773 /user/history/#{dir} && hdfs dfs -chown yarn:mapred /user/history/#{dir}"
+    code "hdfs dfs -mkdir /user/history/#{dir} && hdfs dfs -chmod 1777 /user/history/#{dir} && hdfs dfs -chown yarn:mapred /user/history/#{dir}"
     user "hdfs"
     not_if "hdfs dfs -test -d /user/history/#{dir}", :user => "hdfs"
   end


### PR DESCRIPTION
In PR #607, permission for directories under ``/user/history`` ``hdfs`` directory was set to ``0773`` to resolve the issue where job history from user submitted ``mapred`` jobs were not visible through ``historyserver`` UI. Even though the PR consolidated code and fixed the issue, the root cause of the issue was due to the [unwanted code](https://github.com/bloomberg/chef-bach/blob/91dd89b57ecce140cb32f0a1a77f4959812fe132/cookbooks/bcpc-hadoop/recipes/namenode_master.rb#L252) which recursively sets the permission with sticky bit on all the directories under ``/user/history`` ``hdfs`` directory. This PR is to put back the original access permissions without recursive option so that when ``chef-client`` is run as a daemon, the directories created by ``mapred`` jobs are not set with the sticky bit.

**Testing Done**
- Created a new VM cluster with this change
- Ran a ``mapred`` job and verified that the job is showing up in the ``hostoryserver`` UI.
- Did a CAR of the VM cluster.
- Ran another `mapred`` job and verified that the job log can be viewed through the ``historyserver`` UI. 