### PR TITLE
deployment of patched hadoop-common.jar for nested ldap groups support

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/core_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/core_site.rb
@@ -56,6 +56,8 @@ if node[:bcpc][:hadoop][:hdfs][:ldap][:integration]
 
      'hadoop.security.group.mapping.ldap.search.attr.group.name' =>
        'cn',
+     'hadoop.security.group.mapping.ldap.search.group.hierarchy.levels' =>
+       '1',
     }
   core_site_generated_values.merge!(ldap_properties)
 end

--- a/cookbooks/bcpc-hadoop/recipes/hadoop_patch.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hadoop_patch.rb
@@ -1,0 +1,55 @@
+directory '/usr/local/hadoop' do
+  owner 'root'
+  group 'root'
+  mode '0755'
+  action :create
+end
+remote_file '/usr/local/hadoop/hadoop-common-2.7.1.jar' do 
+  #source 'http://10.0.100.3/hadoop-common-2.7.1.jar'
+  source "#{get_binary_server_url}/hadoop-common-2.7.1.jar"
+  checksum = 'sha256:9ed127f5a9a21c2f3efced7fd73e36d782b73b8eb9820c7ebef5169a94ded8f0'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  action :create
+end
+# backup the previous file
+remote_file '/usr/hdp/2.3.4.0-3485/hadoop/hadoop-common-2.7.1.2.3.4.0-3485.jar.bak' do
+  #source 'http://10.0.100.3/hadoop-common-2.7.1.jar'
+  source "file:///usr/hdp/2.3.4.0-3485/hadoop/hadoop-common-2.7.1.2.3.4.0-3485.jar"
+  owner 'root'
+  group 'root'
+  mode '0644'
+  action :create
+end
+
+file '/usr/hdp/2.3.4.0-3485/hadoop/hadoop-common-2.7.1.2.3.4.0-3485.jar' do
+  owner 'root'
+  group 'root'
+  mode '0644'
+  action :delete
+end
+
+link '/usr/hdp/current/hadoop-client/hadoop-common.jar' do
+  action :delete
+  only_if 'test -L /usr/hdp/current/hadoop-client/hadoop-common.jar'
+end
+
+#link '/usr/hdp/current/hadoop/hadoop-common.jar' do
+#  action :delete
+#  only_if 'test -L /usr/hdp/current/hadoop/hadoop-common.jar'
+#end
+
+link '/usr/hdp/current/hadoop-client/hadoop-common.jar' do
+    to  '/usr/local/hadoop/hadoop-common-2.7.1.jar'
+    only_if {File.exists?'/usr/local/hadoop/hadoop-common-2.7.1.jar'}                                                                                                      
+    action :create
+    notifies :restart, "service[hadoop-hdfs-namenode]"
+end
+
+#link '/usr/hdp/current/hadoop/hadoop-common.jar' do
+#    to  '/usr/local/hadoop/hadoop-common-2.7.1.jar'
+#    only_if {File.exists?'/usr/local/hadoop/hadoop-common-2.7.1.jar'}                                                                                                      
+#    action :create
+#    notifies :restart, "service[hadoop-hdfs-namenode]"
+#end

--- a/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
@@ -70,7 +70,7 @@ directory "/var/log/hadoop-hdfs/gc/" do
   user "hdfs"
   group "hdfs"
   action :create
-  notifies :restart, "service[generally run hadoop-hdfs-namenode]", :delayed
+  notifies :restart, "service[hadoop-hdfs-namenode]", :delayed
 end
 
 user_ulimit "hdfs" do
@@ -109,7 +109,7 @@ bash "format-zk-hdfs-ha" do
   code "yes | #{hdfs_cmd} zkfc -formatZK"
   action :run
   user "hdfs"
-  notifies :restart, "service[generally run hadoop-hdfs-namenode]", :delayed
+  notifies :restart, "service[hadoop-hdfs-namenode]", :delayed
   zks = node[:bcpc][:hadoop][:zookeeper][:servers].map{|zkh| "#{float_host(zkh[:hostname])}:#{node[:bcpc][:hadoop][:zookeeper][:port]}"}.join(",")
   not_if { znode_exists?("/hadoop-ha/#{node.chef_environment}", zks) }
 end
@@ -166,7 +166,7 @@ bash "kill hdfs-namenode" do
   returns [0, 1]
 end
 
-service "generally run hadoop-hdfs-namenode" do
+service "hadoop-hdfs-namenode" do
   action [:enable, :start]
   supports :status => true, :restart => true, :reload => false
   service_name "hadoop-hdfs-namenode"


### PR DESCRIPTION
This will support rolling out a jar file that has a temporary patch for nested ldap groups support.  

**This must be rolled out with a corresponding change to the Namenode and Standby Name Node roles that add the new recipe to the runlist, as well as access to the specified jar.**

In order to deploy:
1. add jar to bins directory
2. deploy_bins.sh
3. upload cookbooks
4. CAR on the name node machines.
To test:
make sure the following command would work when the nested structure looks like this:
group_parent
   |
group_child
  |
user1

hdfs groups <user1> | <grep group_parent>