### PR TITLE
Add restart logic to hdfs and yarn services for Java version/flavor changes

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -292,6 +292,7 @@ ruby_block "acquire_lock_to_restart_datanode" do
   subscribes :create, "user_ulimit[root]", :immediate
   subscribes :create, "bash[hdp-select hadoop-hdfs-datanode]", :immediate
   subscribes :create, "ruby_block[handle_prev_datanode_restart_failure]", :immediate
+  subscribes :create, "log[jdk-version-changed]", :immediate
 end
 #
 # If lock to restart datanode is acquired by the node, this ruby_block executes which is primarily used to notify the datanode service to restart
@@ -337,4 +338,5 @@ service "hadoop-yarn-nodemanager" do
   subscribes :restart, "template[/etc/hadoop/conf/mapred-site.xml]", :delayed
   subscribes :restart, "bash[hdp-select hadoop-yarn-nodemanager]", :delayed
   subscribes :restart, "user_ulimit[yarn]", :delayed
+  subscribes :restart, "log[jdk-version-changed]", :delayed
 end

--- a/cookbooks/bcpc-hadoop/recipes/historyserver.rb
+++ b/cookbooks/bcpc-hadoop/recipes/historyserver.rb
@@ -69,4 +69,5 @@ service "hadoop-mapreduce-historyserver" do
   subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/mapred-site.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/yarn-site.xml]", :delayed
+  subscribes :restart, "log[jdk-version-changed]", :delayed
 end

--- a/cookbooks/bcpc-hadoop/recipes/journalnode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/journalnode.rb
@@ -139,4 +139,5 @@ service "hadoop-hdfs-journalnode" do
   subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
   subscribes :restart, "file[#{keyTabDir}/#{jnKeytab}]", :delayed
   subscribes :restart, "file[#{keyTabDir}/#{nnKeytab}]", :delayed
+  subscribes :restart, "log[jdk-version-changed]", :delayed
 end

--- a/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
@@ -170,6 +170,7 @@ service "generally run hadoop-hdfs-namenode" do
   action [:enable, :start]
   supports :status => true, :restart => true, :reload => false
   service_name "hadoop-hdfs-namenode"
+  subscribes :restart, "log[jdk-version-changed]", :delayed
   subscribes :restart, "link[/etc/init.d/hadoop-hdfs-namenode]", :immediate
   subscribes :restart, "template[/etc/hadoop/conf/hadoop-metrics2.properties]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed

--- a/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
@@ -127,6 +127,7 @@ service "hadoop-hdfs-namenode" do
   subscribes :restart, "template[/etc/hadoop/conf/topology]", :delayed
   subscribes :restart, "user_ulimit[hdfs]", :delayed
   subscribes :restart, "bash[hdp-select hadoop-hdfs-namenode]", :delayed
+  subscribes :restart, "log[jdk-version-changed]", :delayed
 end
 
 bash "reload hdfs nodes" do

--- a/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
@@ -123,6 +123,7 @@ if @node['bcpc']['hadoop']['hdfs']['HA'] == true then
     subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
     subscribes :restart, "template[/etc/hadoop/conf/hdfs-policy.xml]", :delayed
     subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
+    subscribes :restart, "log[jdk-version-changed]", :delayed
   end
 
   link "/etc/init.d/hadoop-hdfs-namenode" do
@@ -151,6 +152,7 @@ if @node['bcpc']['hadoop']['hdfs']['HA'] == true then
     subscribes :restart, "directory[/var/log/hadoop-hdfs/gc/]", :delayed
     subscribes :restart, "file[/etc/hadoop/conf/ldap-conn-pass.txt]", :delayed
     subscribes :restart, "bash[hdp-select hadoop-hdfs-namenode]", :delayed
+    subscribes :restart, "log[jdk-version-changed]", :delayed
   end
 else
   Chef::Log.info "Not running standby namenode services yet -- HA disabled!"

--- a/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
@@ -92,6 +92,7 @@ service "hadoop-yarn-resourcemanager" do
   subscribes :restart, "template[/etc/hadoop/conf/core-site.xml]", :delayed
   subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
   subscribes :restart, "bash[hdp-select hadoop-yarn-resourcemanager]", :delayed
+  subscribes :restart, "log[jdk-version-changed]", :delayed
 end
 
 bash "reload mapreduce nodes" do

--- a/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
+++ b/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
@@ -87,4 +87,5 @@ service "zookeeper-server" do
   subscribes :restart, "file[#{node[:bcpc][:hadoop][:zookeeper][:data_dir]}/myid]", :delayed
   subscribes :restart, "user_ulimit[zookeeper]", :delayed
   subscribes :restart, "bash[hdp-select zookeeper-server]", :delayed
+  subscribes :restart, "log[jdk-version-changed]", :delayed
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,6 +13,7 @@ depends 'bcpc', '= 0.1.0'
 depends 'bcpc-hadoop', '= 0.1.0'
 depends 'bcpc_jmxtrans', '= 0.1.0'
 depends 'hannibal', '= 0.1.0'
+depends 'java','>= 1.41.0'
 depends 'kafka-bcpc', '= 0.1.0'
 
 # Transitive dependencies specified to retain Chef 11.x compatibility.


### PR DESCRIPTION
The changes are to restart ``hdfs``, ``yarn`` and ``zookeeper`` services when ``java`` version or flavor is changed in a cluster. The change is same as the one in PR #620 which was for ``hbase`` services.

**Note**
As mentioned in PR #620, this change requires ``java`` cookbook version >= 1.41.0 i.e this is a *breaking* if the ``java`` cookbook used doesn't match this requirement.