### PR TITLE
prevent precise-server-cloudimg-amd64-vagrant-disk1.box from being uploaded

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -12,3 +12,4 @@ provisioning
 roles
 vendor
 vbox
+precise-server-cloudimg-amd64-vagrant-disk1.box


### PR DESCRIPTION
We don't want this file to vendor as it is large and will cause "Entity too large" from nginx when cookbooks are being uploaded
