### PR TITLE
Fix bug in bcpc-hadoop/attributes/yarn.rb

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/yarn.rb
+++ b/cookbooks/bcpc-hadoop/attributes/yarn.rb
@@ -26,7 +26,7 @@ default[:bcpc][:hadoop][:yarn][:env_sh].tap do |env_sh|
 
   env_sh[:YARN_OPTS] = '"' +
     '-Dhadoop.log.dir=#{env_sh[:YARN_LOG_DIR]} ' +
-    '-Dyarn.log.dir=#{env_sh[:YARN_LOG_DIR]} " '
+    '-Dyarn.log.dir=#{env_sh[:YARN_LOG_DIR]} " ' +
     '-Dhadoop.log.file=#{env_sh[:YARN_LOGFILE]} ' +
     '-Dyarn.log.dir=#{env_sh[:YARN_LOGFILE]} ' +
     '-Dyarn.id.str=#{env_sh[:YARN_IDENT_STRING]} ' +


### PR DESCRIPTION
Currently ``yarn`` processes are running with incorrect settings due to unresolved ``chef`` attributes  The following is the  ``ps`` output from a ``yarn`` process. This PR is to resolve this issue.

```
yarn     21301     1  1 13:10 ?        00:00:44 /usr/lib/jvm/java-8-oracle-amd64/bin/java -Dproc_resourcemanager -Xmx1000m -Dhadoop.log.dir=#{env_sh[:YARN_LOG_DIR]} -Dyarn.log.dir=#{env_sh[:YARN_LOG_DIR]} -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=3131 -Dhadoop.log.dir=/var/log/hadoop-yarn -Dyarn.log.dir=/var/log/hadoop-yarn -Dhadoop.log.file=yarn.log -Dyarn.log.file=yarn.log -Dyarn.home.dir=/usr/hdp/2.3.4.0-3485/hadoop-yarn -Dhadoop.home.dir=/usr/hdp/2.3.4.0-3485/hadoop -Dhadoop.root.logger=INFO,RFA -Dyarn.root.logger=INFO,RFA -Djava.library.path=:/usr/hdp/2.3.4.0-3485/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.3.4.0-3485/hadoop/lib/native:/usr/hdp/2.3.4.0-3485/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.3.4.0-3485/hadoop/lib/native -classpath /etc/hadoop/conf:/etc/hadoop/conf:/etc/hadoop/conf:/usr/hdp/2.3.4.0-3485/hadoop/lib/*:/usr/hdp/2.3.4.0-3485/hadoop/.//*:/usr/hdp/2.3.4.0-3485/hadoop-hdfs/./:/usr/hdp/2.3.4.0-3485/hadoop-hdfs/lib/*:/usr/hdp/2.3.4.0-3485/hadoop-hdfs/.//*:/usr/hdp/2.3.4.0-3485/hadoop-yarn/lib/*:/usr/hdp/2.3.4.0-3485/hadoop-yarn/.//*:/usr/hdp/2.3.4.0-3485/hadoop-mapreduce/lib/*:/usr/hdp/2.3.4.0-3485/hadoop-mapreduce/.//*::/usr/share/java/jdbc-mysql.jar:/usr/share/java/mysql-connector-java-5.1.37-bin.jar:/usr/share/java/mysql-connector-java.jar:/etc/tez/conf:/usr/hdp//tez/*:/usr/hdp//tez/lib/*:/usr/share/java/jdbc-mysql.jar:/usr/share/java/mysql-connector-java-5.1.37-bin.jar:/usr/share/java/mysql-connector-java.jar:/etc/tez/conf:/usr/hdp//tez/*:/usr/hdp//tez/lib/*:/usr/hdp/2.3.4.0-3485/tez/*:/usr/hdp/2.3.4.0-3485/tez/lib/*:/usr/hdp/2.3.4.0-3485/tez/conf:/usr/share/java/jdbc-mysql.jar:/usr/share/java/mysql-connector-java-5.1.37-bin.jar:/usr/share/java/mysql-connector-java.jar:/etc/tez/conf:/usr/hdp/2.3.4.0-3485/tez/*:/usr/hdp/2.3.4.0-3485/tez/lib/*:/usr/hdp/2.3.4.0-3485/tez/*:/usr/hdp/2.3.4.0-3485/tez/lib/*:/usr/hdp/2.3.4.0-3485/tez/conf:/usr/hdp/2.3.4.0-3485/hadoop-yarn/.//*:/usr/hdp/2.3.4.0-3485/hadoop-yarn/lib/*:/etc/hadoop/conf/rm-config/log4j.properties org.apache.hadoop.yarn.server.resourcemanager.ResourceManager
```

``ps`` output after the change

```
yarn     20961     1  4 14:06 ?        00:00:14 /usr/lib/jvm/java-8-oracle-amd64/bin/java -Dproc_resourcemanager -Xmx1000m -Dhdp.version=2.3.4.0-3485 -Dhadoop.log.dir=/var/log/hadoop-yarn -Dyarn.log.dir=/var/log/hadoop-yarn -Dhadoop.log.file=yarn.log -Dyarn.log.file=yarn.log -Dyarn.home.dir=/usr/hdp/2.3.4.0-3485/hadoop-yarn -Dhadoop.home.dir=/usr/hdp/2.3.4.0-3485/hadoop -Dhadoop.root.logger=INFO,RFA -Dyarn.root.logger=INFO,RFA -Djava.library.path=:/usr/hdp/2.3.4.0-3485/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.3.4.0-3485/hadoop/lib/native:/usr/hdp/2.3.4.0-3485/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.3.4.0-3485/hadoop/lib/native -classpath /etc/hadoop/conf:/etc/hadoop/conf:/etc/hadoop/conf:/usr/hdp/2.3.4.0-3485/hadoop/lib/*:/usr/hdp/2.3.4.0-3485/hadoop/.//*:/usr/hdp/2.3.4.0-3485/hadoop-hdfs/./:/usr/hdp/2.3.4.0-3485/hadoop-hdfs/lib/*:/usr/hdp/2.3.4.0-3485/hadoop-hdfs/.//*:/usr/hdp/2.3.4.0-3485/hadoop-yarn/lib/*:/usr/hdp/2.3.4.0-3485/hadoop-yarn/.//*:/usr/hdp/2.3.4.0-3485/hadoop-mapreduce/lib/*:/usr/hdp/2.3.4.0-3485/hadoop-mapreduce/.//*::/usr/share/java/jdbc-mysql.jar:/usr/share/java/mysql-connector-java-5.1.37-bin.jar:/usr/share/java/mysql-connector-java.jar:/etc/tez/conf:/usr/hdp//tez/*:/usr/hdp//tez/lib/*:/usr/share/java/jdbc-mysql.jar:/usr/share/java/mysql-connector-java-5.1.37-bin.jar:/usr/share/java/mysql-connector-java.jar:/etc/tez/conf:/usr/hdp//tez/*:/usr/hdp//tez/lib/*:/usr/hdp/2.3.4.0-3485/tez/*:/usr/hdp/2.3.4.0-3485/tez/lib/*:/usr/hdp/2.3.4.0-3485/tez/conf:/usr/share/java/jdbc-mysql.jar:/usr/share/java/mysql-connector-java-5.1.37-bin.jar:/usr/share/java/mysql-connector-java.jar:/etc/tez/conf:/usr/hdp/2.3.4.0-3485/tez/*:/usr/hdp/2.3.4.0-3485/tez/lib/*:/usr/hdp/2.3.4.0-3485/tez/*:/usr/hdp/2.3.4.0-3485/tez/lib/*:/usr/hdp/2.3.4.0-3485/tez/conf:/usr/hdp/2.3.4.0-3485/hadoop-yarn/.//*:/usr/hdp/2.3.4.0-3485/hadoop-yarn/lib/*:/etc/hadoop/conf/rm-config/log4j.properties org.apache.hadoop.yarn.server.resourcemanager.ResourceManager
```