### PR TITLE
Create directory to store DN GC logs

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -104,6 +104,11 @@ directory "/var/run/hadoop-hdfs" do
   group "root"
 end
 
+directory "/var/log/hadoop-hdfs/gc" do
+  owner "hdfs"
+  group "hdfs"
+end
+
 directory "/sys/fs/cgroup/cpu/hadoop-yarn" do
   owner "yarn"
   group "yarn"


### PR DESCRIPTION
This PR creates `gc` directory under `/var/log/hadoop-hdfs`. The directory is needed for storing `GC` logs generated by `DN` process. 