### PR TITLE
Changes to control restart of ZooKeeper service one node at a time

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/zookeeper.rb
+++ b/cookbooks/bcpc-hadoop/attributes/zookeeper.rb
@@ -53,3 +53,9 @@ default[:bcpc][:hadoop][:zookeeper][:snap][:retain_count] = 5
 
 # ZooKeeper snapshot purge interval in hours
 default[:bcpc][:hadoop][:zookeeper][:snap][:purge_interval] = 24
+
+# Flag to set whether the ZooKeeper server restart process was successful or not
+default[:bcpc][:hadoop][:zookeeper_server][:restart_failed] = false
+
+# Attribute to save the time when ZooKeeper server restart process failed
+default[:bcpc][:hadoop][:zookeeper_server][:restart_failed_time] = ""

--- a/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
+++ b/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
@@ -77,15 +77,16 @@ file "#{node[:bcpc][:hadoop][:zookeeper][:data_dir]}/myid" do
   subscribes :create, "bash[init-zookeeper]", :immediate
 end
 
-service "zookeeper-server" do
-  supports :status => true, :restart => true, :reload => false
-  action [:enable, :start]
-  subscribes :restart, "link[/etc/init.d/zookeeper-server]", :immediate
-  subscribes :restart, "template[#{node[:bcpc][:hadoop][:zookeeper][:conf_dir]}/zoo.cfg]", :delayed
-  subscribes :restart, "template[#{node[:bcpc][:hadoop][:zookeeper][:conf_dir]}/zookeeper-env.sh]", :delayed
-  subscribes :restart, "link[/usr/lib/zookeeper/bin/zkServer.sh]", :delayed
-  subscribes :restart, "file[#{node[:bcpc][:hadoop][:zookeeper][:data_dir]}/myid]", :delayed
-  subscribes :restart, "user_ulimit[zookeeper]", :delayed
-  subscribes :restart, "bash[hdp-select zookeeper-server]", :delayed
-  subscribes :restart, "log[jdk-version-changed]", :delayed
+zk_service_dep = ["template[#{node[:bcpc][:hadoop][:zookeeper][:conf_dir]}/zoo.cfg]",
+                  "link[/etc/init.d/zookeeper-server]",
+                  "template[#{node[:bcpc][:hadoop][:zookeeper][:conf_dir]}/zookeeper-env.sh]",
+                  "link[/usr/lib/zookeeper/bin/zkServer.sh]",
+                  "file[#{node[:bcpc][:hadoop][:zookeeper][:data_dir]}/myid]",
+                  "user_ulimit[zookeeper]",
+                  "bash[hdp-select zookeeper-server]",
+                  "log[jdk-version-changed]"]
+
+hadoop_service "zookeeper-server" do
+  dependencies zk_service_dep
+  process_identifier "org.apache.zookeeper.server.quorum.QuorumPeerMain"
 end


### PR DESCRIPTION
Currently if an incorrect change is made to any of the config files or other components which results in restart of ``ZooKeeper`` server, there is the risk of complete ``ZooKeeper`` quorum being unavailable. The changes in this PR is to allow restart of ``ZooKeeper`` service one node at a time and if starting of the service on one of the node fails for any reason, other nodes will skip the restart process.

**Testing**
- [x]  - Create a new VM cluster and verify HBase services come up fine
- [x] - Verify that lock is taken before restarting ZooKeeper for config changes

**Note**
For a new cluster the locking process using ZooKeeper can be disabled by setting [skip_restart_coordination](https://github.com/bloomberg/chef-bach/blob/de1785bd2d2cfc5bc9697c165145dc7afe2e9f3b/cookbooks/bcpc-hadoop/attributes/default.rb#L27) to ``true``.  Without setting this attribute to ``true`` the cluster build will be successful but make take a few more minutes.