### PR TITLE
Generate correct memory configuration for Yarn/MapReduce

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/mapred.rb
+++ b/cookbooks/bcpc-hadoop/attributes/mapred.rb
@@ -59,25 +59,4 @@ default[:bcpc][:hadoop][:mapreduce][:site_xml].tap do |site_xml|
 
   site_xml['yarn.app.mapreduce.am.staging-dir'] =
     node["bcpc"]["hadoop"]["yarn"]["app"]["mapreduce"]["am"]["staging-dir"]
-
-  min_allocation =
-    node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb']
-
-  site_xml['mapreduce.map.memory.mb'] =
-    min_allocation.round
- 
-  site_xml['mapreduce.map.java.opts'] =
-    "-Xmx" + (0.8 * min_allocation).round.to_s + "m"
-
-  site_xml['mapreduce.reduce.memory.mb'] =
-    2 * min_allocation.round
-  
-  site_xml['mapreduce.reduce.java.opts'] =
-    "-Xmx" + (0.8 * 2 * min_allocation).round.to_s + "m"
-
-  site_xml['yarn.app.mapreduce.am.resource.mb'] =
-    2 * min_allocation.round
-  
-  site_xml['yarn.app.mapreduce.am.command-opts'] =
-    "-Xmx" + (0.8 * 2 * min_allocation).round.to_s + "m"
 end

--- a/cookbooks/bcpc-hadoop/attributes/yarn.rb
+++ b/cookbooks/bcpc-hadoop/attributes/yarn.rb
@@ -111,8 +111,6 @@ default[:bcpc][:hadoop][:yarn][:site_xml].tap do |site_xml|
 
   site_xml['yarn.scheduler.fair.preemption'] = true
   
-  site_xml['yarn.scheduler.minimum-allocation-mb'] = 256
-  
   site_xml['yarn.scheduler.maximum-allocation-mb'] = yarn_max_memory.call
 
   site_xml['yarn.timeline-service.client.max-retries'] = 0

--- a/cookbooks/bcpc-hadoop/recipes/mapred_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/mapred_site.rb
@@ -48,6 +48,31 @@ if node[:bcpc][:hadoop][:kerberos][:enable]
   mapred_site_generated_values.merge!(kerberos_properties)
 end
 
+min_allocation =
+    node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb']
+
+memory_config_values =
+{
+ 'mapreduce.map.memory.mb' => min_allocation.round,
+
+ 'mapreduce.map.java.opts' =>
+    "-Xmx" + (0.8 * min_allocation).round.to_s + "m",
+
+  'mapreduce.reduce.memory.mb' =>
+    2 * min_allocation.round,
+
+  'mapreduce.reduce.java.opts' =>
+    "-Xmx" + (0.8 * 2 * min_allocation).round.to_s + "m",
+
+  'yarn.app.mapreduce.am.resource.mb' =>
+    2 * min_allocation.round,
+
+  'yarn.app.mapreduce.am.command-opts' =>
+    "-Xmx" + (0.8 * 2 * min_allocation).round.to_s + "m",
+}
+
+mapred_site_generated_values.merge!(memory_config_values)
+
 complete_mapred_site_hash =
   mapred_site_generated_values.merge(mapred_site_values)
 

--- a/cookbooks/bcpc-hadoop/recipes/yarn_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/yarn_site.rb
@@ -26,8 +26,10 @@ yarn_site_generated_values =
    mounts.map{ |d| "/disk/#{d}/yarn/logs" }.join(','),
 
  'yarn.nodemanager.aux-services' =>
-   node[:bcpc][:hadoop][:yarn][:aux_services].keys.join(',')
+   node[:bcpc][:hadoop][:yarn][:aux_services].keys.join(','),
 
+ 'yarn.scheduler.minimum-allocation-mb' =>
+   node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb']
 }
 
 yarn_aux_services = 


### PR DESCRIPTION
This PR makes sure that the configuration for `MapReduce` memory parameter is calculated correctly based on value defined in the wrapper cookbook.