### PR TITLE
upgrade to hdp2.3.6.2-3

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -7,7 +7,7 @@
 default["bcpc"]["hadoop"] = {}
 default["bcpc"]["hadoop"]["distribution"]["version"] = 'HDP'
 default["bcpc"]["hadoop"]["distribution"]["key"] = 'hortonworks.key'
-default["bcpc"]["hadoop"]["distribution"]["release"] = '2.3.6.2-2'
+default["bcpc"]["hadoop"]["distribution"]["release"] = '2.3.6.2-3'
 default["bcpc"]["hadoop"]["distribution"]["active_release"] = node["bcpc"]["hadoop"]["distribution"]["release"]
 default["bcpc"]["hadoop"]["decommission"]["hosts"] = []
 # disks to use for Hadoop activities (expected to be an environment or role set variable)

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -103,7 +103,7 @@ default['bcpc']['repos'].tap do |repos|
     'http://ppa.launchpad.net/canonical-support/support-tools/ubuntu'
 
   repos['hortonworks'] =
-    'http://s3.amazonaws.com/dev.hortonworks.com/HDP/ubuntu12/2.x/BUILDS/2.3.6.2-2'
+    'http://s3.amazonaws.com/dev.hortonworks.com/HDP/ubuntu12/2.x/BUILDS/2.3.6.2-3'
 
   repos['hdp_utils'] =
     'http://s3.amazonaws.com/dev.hortonworks.com/HDP-UTILS-1.1.0.20/repos/ubuntu12'


### PR DESCRIPTION
This has the fix for zkfc init.d script that sets:
WORKING_DIR="$HADOOP_HOME"
instead of
WORKING_DIR="~/"

This should help for hdfs upgrades.