### PR TITLE
Generate Heap Dump on OutOfMemory Error

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -39,10 +39,41 @@ default["bcpc"]["hadoop"]["datanode"]["xmx"]["max_size"] = 4096
 default["bcpc"]["hadoop"]["datanode"]["xmx"]["max_ratio"] = 0.25
 default["bcpc"]["hadoop"]["datanode"]["max"]["xferthreads"] = 16384
 default["bcpc"]["hadoop"]["datanode"]["jmx"]["port"] = 10112
-default["bcpc"]["hadoop"]["datanode"]["gc_opts"] = "-server -XX:ParallelGCThreads=4 -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:/var/log/hadoop-hdfs/gc/gc.log-datanode-$$-$(hostname)-$(date +'%Y%m%d%H%M').log -XX:+PrintTenuringDistribution -XX:+UseNUMA -XX:+PrintGCApplicationStoppedTime -XX:+UseCompressedOops -XX:+PrintClassHistogram -XX:+PrintGCApplicationConcurrentTime"
+
+common_opts =
+  '-XX:+UseParNewGC ' +
+  '-XX:+UseConcMarkSweepGC ' +  
+  '-verbose:gc -XX:+PrintHeapAtGC ' +
+  '-XX:+PrintGCDetails ' +
+  '-XX:+PrintGCTimeStamps ' + 
+  '-XX:+PrintGCDateStamps ' + 
+  '-XX:+UseNUMA ' +
+  '-XX:+PrintGCApplicationStoppedTime ' +
+  '-XX:+UseCompressedOops ' +
+  '-XX:+PrintClassHistogram ' + 
+  '-XX:+PrintGCApplicationConcurrentTime ' + 
+  '-XX:+UseCMSInitiatingOccupancyOnly ' + 
+  '-XX:CMSInitiatingOccupancyFraction=70 ' + 
+  '-XX:+HeapDumpOnOutOfMemoryError ' + 
+  '-XX:+PrintTenuringDistribution ' +
+  '-XX:+ExitOnOutOfMemoryError'
+
+# GC Options for DataNode
+default["bcpc"]["hadoop"]["datanode"]["gc_opts"] =  
+  '-server -XX:ParallelGCThreads=4 ' + 
+  '-Xloggc:/var/log/hadoop-hdfs/gc/gc.log-dn-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log ' + 
+  '-XX:HeapDumpPath=/var/log/hadoop-hdfs/heap-dump-dn-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof ' +
+  common_opts
+
+# GC Options for NameNode
+default["bcpc"]["hadoop"]["namenode"]["gc_opts"] = 
+  '-server -XX:ParallelGCThreads=14 ' + 
+  '-Xloggc:/var/log/hadoop-hdfs/gc/gc.log-nn-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log ' + 
+  '-XX:HeapDumpPath=/var/log/hadoop-hdfs/heap-dump-nn-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof ' +
+  common_opts
+
 default["bcpc"]["hadoop"]["mapreduce"]["framework"]["name"] = "yarn"
 default["bcpc"]["hadoop"]["namenode"]["handler"]["count"] = 100
-default["bcpc"]["hadoop"]["namenode"]["gc_opts"] = "-server -XX:ParallelGCThreads=14 -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:/var/log/hadoop-hdfs/gc/gc.log-namenode-$$-$(hostname)-$(date +'%Y%m%d%H%M').log -XX:+PrintTenuringDistribution -XX:+UseNUMA -XX:+PrintGCApplicationStoppedTime -XX:+UseCompressedOops -XX:+PrintClassHistogram -XX:+PrintGCApplicationConcurrentTime"
 default["bcpc"]["hadoop"]["namenode"]["xmx"]["max_size"] = 16384
 default["bcpc"]["hadoop"]["namenode"]["xmx"]["max_ratio"] = 0.25
 default["bcpc"]["hadoop"]["namenode"]["jmx"]["port"] = 10111

--- a/cookbooks/bcpc-hadoop/attributes/hbase.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hbase.rb
@@ -57,9 +57,9 @@ default["bcpc"]["hadoop"]["hbase_rs"]["storefile"]["refresh"]["all"] = false
 default["bcpc"]["hadoop"]["hbase_rs"]["storefile"]["refresh"]["period"] = 30000
 default["bcpc"]["hadoop"]["hbase_rs"]["cmsinitiatingoccupancyfraction"] = 70
 default["bcpc"]["hadoop"]["hbase_rs"]["PretenureSizeThreshold"] = "1m"
+
 #Apache Phoenix related attributes 
 default["bcpc"]["hadoop"]["phoenix"]["tracing"]["enabled"] = false
-
 
 bucketcache_size = (node["bcpc"]["hadoop"]["hbase_rs"]["mx_dir_mem"]["size"] -  node["bcpc"]["hadoop"]["hbase_rs"]["hdfs_dir_mem"]["size"]).floor 
 
@@ -67,42 +67,14 @@ bucketcache_size = (node["bcpc"]["hadoop"]["hbase_rs"]["mx_dir_mem"]["size"] -  
 default[:bcpc][:hadoop][:hbase][:site_xml].tap do |site_xml|
   site_xml['hbase.rootdir'] = "#{node['bcpc']['hadoop']['hbase']['root_dir']}"
   site_xml['hbase.bulkload.staging.dir'] = "#{node['bcpc']['hadoop']['hbase']['bulkload_staging_dir']}"
-  # the below value will be defined in recipe and merged in 
-  #site_xml['hbase.zookeeper.quorum'] = #{@zk_hosts.map{ |s| float_host(s[:hostname])}.join(",")}
-  # the below value will be defined in recipe and merged in 
-  #site_xml['hbase.zookeeper.property.clientPort'] = "#{node[:bcpc][:hadoop][:zookeeper][:port]}"
   site_xml['hbase.cluster.distributed'] = "#{node["bcpc"]["hadoop"]["hbase"]["cluster"]["distributed"]}"
   site_xml['hbase.hregion.majorcompaction'] = "#{node["bcpc"]["hadoop"]["hbase"]["major_compact"]["time"]}"
-  # the below value will be defined in recipe and merged in 
-  #site_xml['fail.fast.expired.active.master'] = "#{@master_hosts.length > 1 ? "true" : "false"}"
-  # the below value will be defined in recipe and merged in 
-  #site_xml['hbase.master.wait.on.regionservers.mintostart'] = "#{@rs_hosts.length/2+1}"
   site_xml['hbase.regionserver.ipc.address'] = "#{node["bcpc"]["floating"]["ip"]}"
   site_xml['hbase.master.ipc.address'] = "#{node["bcpc"]["floating"]["ip"]}"
-  # the below value will be defined in recipe and merged in 
-  #site_xml['hbase.regionserver.dns.nameserver'] = "#{@dns_server}"
-  # the below value will be defined in recipe and merged in 
-  #site_xml['hbase.master.dns.nameserver'] = "#{@dns_server}"
   site_xml['hbase.defaults.for.version.skip'] = "#{node["bcpc"]["hadoop"]["hbase"]["defaults"]["for"]["version"]["skip"]}"
   site_xml['hbase.regionserver.wal.codec'] = 'org.apache.hadoop.hbase.regionserver.wal.IndexedWALEditCodec'
   site_xml['hbase.region.server.rpc.scheduler.factory.class'] = 'org.apache.hadoop.hbase.ipc.PhoenixRpcSchedulerFactory'
   site_xml['hbase.rpc.controllerfactory.class'] =  'org.apache.hadoop.hbase.ipc.controller.ServerRpcControllerFactory'
-  # the below value will be defined in recipe and merged in 
-  #if node[:bcpc][:hadoop][:kerberos][:enable] == true then
-  #  site_xml['hbase.security.authorization'] = 'true'
-  #  site_xml['hbase.superuser'] = node[:bcpc][:hadoop][:hbase][:superusers].join(',')
-  #  site_xml['hbase.coprocessor.region.classes'] = 'org.apache.hadoop.hbase.security.token.TokenProvider,org.apache.hadoop.hbase.security.access.SecureBulkLoadEndpoint,org.apache.hadoop.hbase.security.access.AccessController'
-  #  site_xml['hbase.security.exec.permission.checks'] = 'true'
-  #  site_xml['hbase.coprocessor.regionserver.classes'] = 'org.apache.hadoop.hbase.security.access.AccessController'
-  #  site_xml['hbase.coprocessor.master.classes'] = 'org.apache.hadoop.hbase.security.access.AccessController'
-  #  site_xml['hbase.security.authentication'] = 'kerberos'
-  #  site_xml['hbase.master.kerberos.principal'] = "#{node[:bcpc][:hadoop][:kerberos][:data][:hbase][:principal]}/" +
-  #    "#{node[:bcpc][:hadoop][:kerberos][:data][:hbase][:princhost] == '_HOST' ? '_HOST' : node[:bcpc][:hadoop][:kerberos][:data][:hbase][:princhost]}@#{node[:bcpc][:hadoop][:kerberos][:realm]}"
-  #  site_xml['hbase.master.keytab.file'] = "#{node[:bcpc][:hadoop][:kerberos][:keytab][:dir]}/#{node[:bcpc][:hadoop][:kerberos][:data][:hbase][:keytab]}"
-  #  site_xml['hbase.regionserver.kerberos.principal'] = "#{node[:bcpc][:hadoop][:kerberos][:data][:hbase][:principal]}/#{node[:bcpc][:hadoop][:kerberos][:data][:hbase][:princhost] == '_HOST' ? '_HOST' : node[:bcpc][:hadoop][:kerberos][:data][:hbase][:princhost]}@#{node[:bcpc][:hadoop][:kerberos][:realm]}"
-  #  site_xml['hbase.regionserver.keytab.file'] = "#{node[:bcpc][:hadoop][:kerberos][:keytab][:dir]}/#{node[:bcpc][:hadoop][:kerberos][:data][:hbase][:keytab]}"
-  #  site_xml['hbase.rpc.engine'] = 'org.apache.hadoop.hbase.ipc.SecureRpcEngine'
-  #end
   site_xml['hbase.regionserver.handler.count'] = node["bcpc"]["hadoop"]["hbase"]["regionserver"]["handler"]["count"].to_s
   site_xml['hbase.ipc.warn.response.time'] = node["bcpc"]["hadoop"]["hbase"]["ipc"]["warn"]["response"]["time"].to_s
   site_xml['hbase.ipc.warn.response.size'] = node["bcpc"]["hadoop"]["hbase"]["ipc"]["warn"]["response"]["size"].to_s

--- a/cookbooks/bcpc-hadoop/attributes/hive.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hive.rb
@@ -50,13 +50,18 @@ default[:bcpc][:hadoop][:hive][:env_sh].tap do |env_sh|
     '-XX:+PrintGCTimeStamps ' +
     '-XX:+PrintGCDateStamps ' +
     '-Xloggc:/var/log/hive/gc/' +
-             'gc.log-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log ' +
+      'gc.log-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log ' +
     '-XX:+PrintTenuringDistribution ' +
     '-XX:+PrintGCApplicationStoppedTime ' +
     '-XX:+PrintGCApplicationConcurrentTime ' +
     '-XX:+UseConcMarkSweepGC ' +
+    '-XX:+UseCMSInitiatingOccupancyOnly ' +
+    '-XX:CMSInitiatingOccupancyFraction=70 ' +
+    '-XX:+HeapDumpOnOutOfMemoryError ' +
+    '-XX:HeapDumpPath=/var/log/hive/heap-dump-hive-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof ' +
     '-XX:+CMSClassUnloadingEnabled ' +
-    '-XX:+UseParNewGC' + 
+    '-XX:+UseParNewGC ' + 
+    '-XX:+ExitOnOutOfMemoryError' +
     '"'
   env_sh[:HIVE_LOG_DIR] = "/var/log/hive"
   env_sh[:HIVE_PID_DIR] = "/var/run/hive"

--- a/cookbooks/bcpc-hadoop/attributes/oozie.rb
+++ b/cookbooks/bcpc-hadoop/attributes/oozie.rb
@@ -1,5 +1,11 @@
 default["bcpc"]["hadoop"]["oozie"]["admins"] = []
-default["bcpc"]["hadoop"]["oozie"]["memory_opts"] = "-Xmx2048m -XX:MaxPermSize=256m"
+default["bcpc"]["hadoop"]["oozie"]["memory_opts"] = 
+  "$CATALINA_OPTS" +
+  " -Xmx2048m" +
+  " -XX:MaxPermSize=256m" +
+  " -XX:+HeapDumpOnOutOfMemoryError " +
+  " -XX:HeapDumpPath=/var/log/oozie/heap-dump-oozie-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof" +
+  " -XX:+ExitOnOutOfMemoryError"
 default["bcpc"]["hadoop"]["oozie"]["sharelib_checksum"] = nil
 default["bcpc"]["hadoop"]["oozie_config"] = "/etc/oozie/conf"
 default["bcpc"]["hadoop"]["oozie_data"] = "/var/lib/oozie"

--- a/cookbooks/bcpc-hadoop/attributes/yarn.rb
+++ b/cookbooks/bcpc-hadoop/attributes/yarn.rb
@@ -12,45 +12,65 @@ default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["port"] = 8032
 default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["jmx"]["port"] = 3131
 default["bcpc"]["hadoop"]["yarn"]["scheduler"]["fair"]["min-vcores"] = 2
 
+yarn_log_dir = '/var/log/hadoop-yarn'
+yarn_pid_dir = '/var/run/hadoop-yarn'
+yarn_user = 'yarn'
+yarn_conf_dir = '/etc/hadoop/conf'
+yarn_logfile = 'yarn-$(hostname).log'
+yarn_policyfile = 'hadoop-policy.xml'
+
 default[:bcpc][:hadoop][:yarn][:env_sh].tap do |env_sh|
-  env_sh[:YARN_LOG_DIR] = '/var/log/hadoop-yarn'
-  env_sh[:YARN_PID_DIR] = '/var/run/hadoop-yarn'
-  env_sh[:YARN_IDENT_STRING] = 'yarn'
-  env_sh[:HADOOP_YARN_USER] = 'yarn'
-  env_sh[:YARN_CONF_DIR] = '/etc/hadoop/conf'
+  env_sh[:YARN_LOG_DIR] = yarn_log_dir
+  env_sh[:YARN_PID_DIR] = yarn_pid_dir
+  env_sh[:YARN_IDENT_STRING] = yarn_user
+  env_sh[:HADOOP_YARN_USER] = yarn_user
+  env_sh[:YARN_CONF_DIR] = yarn_conf_dir
   env_sh[:JAVA_HOME] = node[:bcpc][:hadoop][:java]
   env_sh[:JAVA] = File.join(env_sh[:JAVA_HOME], 'bin', 'java')
   env_sh[:YARN_HEAPSIZE] = '1000' # megabytes
   env_sh[:JAVA_HEAP_MAX] = '1000' # megabytes
-  env_sh[:YARN_LOGFILE] = 'yarn.log'
-  env_sh[:YARN_POLICYFILE] =  'hadoop-policy.xml'
+  env_sh[:YARN_LOGFILE] = yarn_logfile
+  env_sh[:YARN_POLICYFILE] = yarn_policyfile
 
-  env_sh[:YARN_OPTS] =
-    "-Dhadoop.log.dir=#{env_sh[:YARN_LOG_DIR]} " +
-    "-Dyarn.log.dir=#{env_sh[:YARN_LOG_DIR]}  " +
-    "-Dhadoop.log.file=#{env_sh[:YARN_LOGFILE]} " +
-    "-Dyarn.log.dir=#{env_sh[:YARN_LOGFILE]} " +
-    "-Dyarn.id.str=#{env_sh[:YARN_IDENT_STRING]} " +
-    "-Dhadoop.root.logger=INFO,CONSOLE " +
-    "-Dyarn.root.logger=INFO,CONSOLE " +
-    "-Dyarn.policy.file=#{env_sh[:YARN_POLICYFILE]} " +
-    "-Djute.maxbuffer=#{node[:bcpc][:hadoop][:jute][:maxbuffer]}"
-
-  env_sh[:YARN_OPTS] = '"' + env_sh[:YARN_OPTS] + '"'
+  env_sh[:YARN_OPTS] = '"' +
+    ' -Dhadoop.log.dir=' + yarn_log_dir +
+    ' -Dyarn.log.dir=' + yarn_log_dir +
+    ' -Dhadoop.log.file=' + yarn_logfile  +
+    ' -Dyarn.log.dir=' + yarn_logfile +
+    ' -Dyarn.id.str=' + yarn_user +
+    ' -Dhadoop.root.logger=INFO,CONSOLE ' +
+    ' -Dyarn.root.logger=INFO,CONSOLE ' +
+    ' -Dyarn.policy.file=' + yarn_policyfile +
+    ' -Djute.maxbuffer=' + node[:bcpc][:hadoop][:jute][:maxbuffer].to_s +
+    '"'
 
   env_sh[:YARN_NODEMANAGER_OPTS] = '"' +
-    '-Dcom.sun.management.jmxremote.ssl=false ' +
-    '-Dcom.sun.management.jmxremote.authenticate=false ' +
-    '-Dcom.sun.management.jmxremote.port=' +
+   ' -Dcom.sun.management.jmxremote.port=' +
     node[:bcpc][:hadoop][:yarn][:nodemanager][:jmx][:port].to_s +
-   '"'
+   ' -XX:HeapDumpPath=/var/log/hadoop-yarn/heap-dump-nm-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof ' +
+   ' -XX:+UseCMSInitiatingOccupancyOnly' + 
+   ' -XX:CMSInitiatingOccupancyFraction=70' +
+   ' -XX:+HeapDumpOnOutOfMemoryError' + 
+   ' -XX:+ExitOnOutOfMemoryError' +
+   ' -XX:+UseParNewGC' +
+   ' -XX:+UseConcMarkSweepGC ' +
+   ' -Dcom.sun.management.jmxremote.ssl=false' +
+   ' -Dcom.sun.management.jmxremote.authenticate=false' +
+  '"'
 
   env_sh[:YARN_RESOURCEMANAGER_OPTS] = '"' +
-    '-Dcom.sun.management.jmxremote.ssl=false ' +
-    '-Dcom.sun.management.jmxremote.authenticate=false ' +
-    '-Dcom.sun.management.jmxremote.port=' +
+    ' -Dcom.sun.management.jmxremote.port=' +
     node[:bcpc][:hadoop][:yarn][:resourcemanager][:jmx][:port].to_s +
-    '"' 
+    ' -XX:HeapDumpPath=/var/log/hadoop-yarn/heap-dump-rm-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof' +
+    ' -XX:+UseCMSInitiatingOccupancyOnly' + 
+    ' -XX:CMSInitiatingOccupancyFraction=70' +
+    ' -XX:+HeapDumpOnOutOfMemoryError' + 
+    ' -XX:+ExitOnOutOfMemoryError' +
+    ' -XX:+UseParNewGC' +
+    ' -XX:+UseConcMarkSweepGC ' +
+    ' -Dcom.sun.management.jmxremote.ssl=false' +
+    ' -Dcom.sun.management.jmxremote.authenticate=false' +
+   '"' 
 end
 
 default[:bcpc][:hadoop][:yarn][:site_xml].tap do |site_xml|

--- a/cookbooks/bcpc-hadoop/recipes/yarn_env.rb
+++ b/cookbooks/bcpc-hadoop/recipes/yarn_env.rb
@@ -11,6 +11,15 @@ if(node.run_list.expand(node.chef_environment).recipes
   yarn_env_generated_values[:YARN_USER_CLASSPATH] =
     '/usr/spark/current/lib/spark-yarn-shuffle.jar'
 end
+if(node.run_list.expand(node.chef_environment).recipes
+        .include?('bcpc-hadoop::datanode'))
+  yarn_env_generated_values[:YARN_LOGFILE] = 
+    'yarn-yarn-nodemanager-$(hostname).log'
+elsif(node.run_list.expand(node.chef_environment).recipes
+        .include?('bcpc-hadoop::resource_manager'))
+  yarn_env_generated_values[:YARN_LOGFILE] = 
+    'yarn-yarn-resourcemanager-$(hostname).log'
+end
 
 complete_yarn_env_hash =
   yarn_env_generated_values.merge(yarn_env_values)


### PR DESCRIPTION
This  PR adds `GC` options to generate `Heap` dump when a `Java` process goes `OOM`.

Processes now seem to have correct options:
* HBase Master
```
hbase     4361  4346  4 08:26 ?        00:00:14 /usr/lib/jvm/java-8-oracle-amd64/bin/java -Dproc_master -XX:OnOutOfMemoryError=kill -9 %p -Dhdp.version=2.3.6.2-2 -Djava.net.preferIPv4Stack=true -XX:+UseConcMarkSweepGC -Djava.net.preferIPv4Stack=true -XX:+UseConcMarkSweepGC -Djava.net.preferIPv4Stack=true -XX:+UseConcMarkSweepGC -Djava.security.auth.login.config=/etc/hbase/conf/hbase-client.jaas -Djava.security.auth.login.config=/etc/hbase/conf/hbase-client.jaas -Djava.security.auth.login.config=/etc/hbase/conf/hbase-client.jaas -XX:CMSInitiatingOccupancyFraction=70 -XX:HeapDumpPath=/var/log/hbase/heap-dump-hm-4023-bcpc-vm1-201608310826.hprof -XX:PretenureSizeThreshold=1m -server -XX:ParallelGCThreads=2 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError -XX:+UseConcMarkSweepGC -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+UseParNewGC -Xloggc:/var/log/hbase/gc/gc.log-4023-bcpc-vm1-201608310826.log -Xmn256m -Xms1024m -Xmx1024m -XX:+ExplicitGCInvokesConcurrent -XX:+PrintTenuringDistribution -XX:+UseNUMA -XX:+PrintGCApplicationStoppedTime -XX:+UseCompressedOops -XX:+PrintClassHistogram -XX:+PrintGCApplicationConcurrentTime -XX:+ExitOnOutOfMemoryError -Djava.security.auth.login.config=/etc/hbase/conf/hbase-server.jaas -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=10101 -XX:CMSInitiatingOccupancyFraction=70 -XX:HeapDumpPath=/var/log/hbase/heap-dump-hm-4290-bcpc-vm1-201608310826.hprof -XX:PretenureSizeThreshold=1m -server -XX:ParallelGCThreads=2 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError -XX:+UseConcMarkSweepGC -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+UseParNewGC -Xloggc:/var/log/hbase/gc/gc.log-4290-bcpc-vm1-201608310826.log -Xmn256m -Xms1024m -Xmx1024m -XX:+ExplicitGCInvokesConcurrent -XX:+PrintTenuringDistribution -XX:+UseNUMA -XX:+PrintGCApplicationStoppedTime -XX:+UseCompressedOops -XX:+PrintClassHistogram -XX:+PrintGCApplicationConcurrentTime -XX:+ExitOnOutOfMemoryError -Djava.security.auth.login.config=/etc/hbase/conf/hbase-server.jaas -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=10101 -XX:CMSInitiatingOccupancyFraction=70 -XX:HeapDumpPath=/var/log/hbase/heap-dump-hm-4310-bcpc-vm1-201608310826.hprof -XX:PretenureSizeThreshold=1m -server -XX:ParallelGCThreads=2 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError -XX:+UseConcMarkSweepGC -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+UseParNewGC -Xloggc:/var/log/hbase/gc/gc.log-4310-bcpc-vm1-201608310826.log -Xmn256m -Xms1024m -Xmx1024m -XX:+ExplicitGCInvokesConcurrent -XX:+PrintTenuringDistribution -XX:+UseNUMA -XX:+PrintGCApplicationStoppedTime -XX:+UseCompressedOops -XX:+PrintClassHistogram -XX:+PrintGCApplicationConcurrentTime -XX:+ExitOnOutOfMemoryError -Djava.security.auth.login.config=/etc/hbase/conf/hbase-server.jaas -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=10101 -Dhbase.log.dir=/var/log/hbase -Dhbase.log.file=hbase-hbase-master-bcpc-vm1.log -Dhbase.home.dir=/usr/hdp/current/hbase-master -Dhbase.id.str=hbase -Dhbase.root.logger=INFO,RFA -Djava.library.path=:/usr/hdp/2.3.6.2-2/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.3.6.2-2/hadoop/lib/native:/usr/hdp/current/hbase-master/lib/native/Linux-amd64-64 -Dhbase.security.logger=INFO,RFAS org.apache.hadoop.hbase.master.HMaster start
```
* NameNode
```
hdfs     12215     1  0 Aug29 ?        00:20:37 /usr/lib/jvm/java-8-oracle-amd64/bin/java -Dproc_namenode -Xmx1000m -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Stack=true -Dhadoop.log.dir=/var/log/hadoop-hdfs -Dhadoop.log.file=hadoop.log -Dhadoop.home.dir=/usr/hdp/2.3.6.2-2/hadoop -Dhadoop.id.str=hdfs -Dhadoop.root.logger=INFO,console -Djava.library.path=:/usr/hdp/2.3.6.2-2/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.3.6.2-2/hadoop/lib/native -Dhadoop.policy.file=hadoop-policy.xml -Djava.net.preferIPv4Stack=true -Dhdp.version=2.3.6.2-2 -Dhadoop.log.dir=/var/log/hadoop-hdfs -Dhadoop.log.file=hadoop-hdfs-namenode-bcpc-vm1.log -Dhadoop.home.dir=/usr/hdp/2.3.6.2-2/hadoop -Dhadoop.id.str=hdfs -Dhadoop.root.logger=INFO,RFA -Djava.library.path=:/usr/hdp/2.3.6.2-2/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.3.6.2-2/hadoop/lib/native:/usr/hdp/2.3.6.2-2/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.3.6.2-2/hadoop/lib/native -Dhadoop.policy.file=hadoop-policy.xml -Djava.net.preferIPv4Stack=true -Xms3980m -Xmx3980m -Xmn498m -XX:PermSize=128m -XX:MaxPermSize=256m -server -XX:ParallelGCThreads=14 -Xloggc:/var/log/hadoop-hdfs/gc/gc.log-nn-12008-bcpc-vm1-201608291553.log -XX:HeapDumpPath=/var/log/hadoop-hdfs/heap-dump-nn-12008-bcpc-vm1-201608291553.hprof -XX:OnOutOfMemoryError="/usr/hdp/current/hadoop-hdfs-namenode/bin/kill-name-node"-XX:+UseParNewGC -XX:+UseConcMarkSweepGC -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+UseNUMA -XX:+PrintGCApplicationStoppedTime -XX:+UseCompressedOops -XX:+PrintClassHistogram -XX:+PrintGCApplicationConcurrentTime -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 -XX:+HeapDumpOnOutOfMemoryError -XX:+PrintTenuringDistribution -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=10111 -Dhadoop.security.logger=INFO,RFAS -Dhdfs.audit.logger=INFO,RFAAUDIT -Xms3980m -Xmx3980m -Xmn498m -XX:PermSize=128m -XX:MaxPermSize=256m -server -XX:ParallelGCThreads=14 -Xloggc:/var/log/hadoop-hdfs/gc/gc.log-nn-12153-bcpc-vm1-201608291553.log -XX:HeapDumpPath=/var/log/hadoop-hdfs/heap-dump-nn-12153-bcpc-vm1-201608291553.hprof -XX:OnOutOfMemoryError="/usr/hdp/current/hadoop-hdfs-namenode/bin/kill-name-node"-XX:+UseParNewGC -XX:+UseConcMarkSweepGC -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+UseNUMA -XX:+PrintGCApplicationStoppedTime -XX:+UseCompressedOops -XX:+PrintClassHistogram -XX:+PrintGCApplicationConcurrentTime -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 -XX:+HeapDumpOnOutOfMemoryError -XX:+PrintTenuringDistribution -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=10111 -Dhadoop.security.logger=INFO,RFAS -Dhdfs.audit.logger=INFO,RFAAUDIT -Xms3980m -Xmx3980m -Xmn498m -XX:PermSize=128m -XX:MaxPermSize=256m -server -XX:ParallelGCThreads=14 -Xloggc:/var/log/hadoop-hdfs/gc/gc.log-nn-12153-bcpc-vm1-201608291553.log -XX:HeapDumpPath=/var/log/hadoop-hdfs/heap-dump-nn-12153-bcpc-vm1-201608291553.hprof -XX:OnOutOfMemoryError="/usr/hdp/current/hadoop-hdfs-namenode/bin/kill-name-node"-XX:+UseParNewGC -XX:+UseConcMarkSweepGC -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+UseNUMA -XX:+PrintGCApplicationStoppedTime -XX:+UseCompressedOops -XX:+PrintClassHistogram -XX:+PrintGCApplicationConcurrentTime -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 -XX:+HeapDumpOnOutOfMemoryError -XX:+PrintTenuringDistribution -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=10111 -Dhadoop.security.logger=INFO,RFAS -Dhdfs.audit.logger=INFO,RFAAUDIT -Xms3980m -Xmx3980m -Xmn498m -XX:PermSize=128m -XX:MaxPermSize=256m -server -XX:ParallelGCThreads=14 -Xloggc:/var/log/hadoop-hdf
```

* NodeManager
```
yarn     10824     1  0 Aug30 ?        00:04:03 /usr/lib/jvm/java-8-oracle-amd64/bin/java -Dproc_nodemanager -Xmx1000m -Dhadoop.log.dir=/var/log/hadoop-yarn -Dyarn.log.dir=/var/log/hadoop-yarn -Dhadoop.log.file=yarn-bcpc-vm3.log -Dyarn.log.dir=yarn-bcpc-vm3.log -Dyarn.id.str=yarn -Dhadoop.root.logger=INFO,CONSOLE -Dyarn.root.logger=INFO,CONSOLE -Dyarn.policy.file=hadoop-policy.xml -Djute.maxbuffer=6291456 -server -Dcom.sun.management.jmxremote.port=3131 -XX:HeapDumpPath=/var/log/hadoop-yarn/heap-dump-nm-10824-bcpc-vm3-201608301604.hprof -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dhadoop.log.dir=/var/log/hadoop-yarn -Dyarn.log.dir=/var/log/hadoop-yarn -Dhadoop.log.file=yarn-bcpc-vm3.log -Dyarn.log.file=yarn-bcpc-vm3.log -Dyarn.home.dir=/usr/hdp/2.3.6.2-2/hadoop-yarn -Dhadoop.home.dir=/usr/hdp/2.3.6.2-2/hadoop -Dhadoop.root.logger=INFO,RFA -Dyarn.root.logger=INFO,RFA -Djava.library.path=:/usr/hdp/2.3.6.2-2/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.3.6.2-2/hadoop/lib/native:/usr/hdp/2.3.6.2-2/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.3.6.2-2/hadoop/lib/native -classpath /etc/hadoop/conf:/etc/hadoop/conf:/etc/hadoop/conf:/usr/hdp/2.3.6.2-2/hadoop/lib/*:/usr/hdp/2.3.6.2-2/hadoop/.//*:/usr/hdp/2.3.6.2-2/hadoop-hdfs/./:/usr/hdp/2.3.6.2-2/hadoop-hdfs/lib/*:/usr/hdp/2.3.6.2-2/hadoop-hdfs/.//*:/usr/hdp/2.3.6.2-2/hadoop-yarn/lib/*:/usr/hdp/2.3.6.2-2/hadoop-yarn/.//*:/usr/hdp/2.3.6.2-2/hadoop-mapreduce/lib/*:/usr/hdp/2.3.6.2-2/hadoop-mapreduce/.//*::/usr/share/java/jdbc-mysql.jar:/usr/share/java/mysql-connector-java-5.1.37-bin.jar:/usr/share/java/mysql-connector-java.jar:/etc/tez/conf:/usr/hdp//tez/*:/usr/hdp//tez/lib/*:/usr/share/java/jdbc-mysql.jar:/usr/share/java/mysql-connector-java-5.1.37-bin.jar:/usr/share/java/mysql-connector-java.jar:/etc/tez/conf:/usr/hdp//tez/*:/usr/hdp//tez/lib/*:/usr/hdp/2.3.6.2-2/tez/*:/usr/hdp/2.3.6.2-2/tez/lib/*:/usr/hdp/2.3.6.2-2/tez/conf:/usr/share/java/jdbc-mysql.jar:/usr/share/java/mysql-connector-java-5.1.37-bin.jar:/usr/share/java/mysql-connector-java.jar:/etc/tez/conf:/usr/hdp/2.3.6.2-2/tez/*:/usr/hdp/2.3.6.2-2/tez/lib/*:/usr/hdp/2.3.6.2-2/tez/*:/usr/hdp/2.3.6.2-2/tez/lib/*:/usr/hdp/2.3.6.2-2/tez/conf:/usr/hdp/2.3.6.2-2/hadoop-yarn/.//*:/usr/hdp/2.3.6.2-2/hadoop-yarn/lib/*:/usr/spark/current/lib/spark-yarn-shuffle.jar:/etc/hadoop/conf/nm-config/log4j.properties org.apache.hadoop.yarn.server.nodemanager.NodeManager
```

* DataNode
```
hdfs      8705  8663  0 Aug30 ?        00:03:20 jsvc.exec -Dproc_datanode -outfile /var/log/hadoop-hdfs/jsvc.out -errfile /var/log/hadoop-hdfs/jsvc.err -pidfile /var/run/hadoop-hdfs/hadoop_secure_dn.pid -nodetach -user hdfs -cp /usr/hdp/current/hadoop-hdfs-datanode/../hadoop/conf:/usr/hdp/2.3.6.2-2/hadoop/lib/*:/usr/hdp/2.3.6.2-2/hadoop/.//*:/usr/hdp/2.3.6.2-2/hadoop-hdfs/./:/usr/hdp/2.3.6.2-2/hadoop-hdfs/lib/*:/usr/hdp/2.3.6.2-2/hadoop-hdfs/.//*:/usr/hdp/2.3.6.2-2/hadoop-yarn/lib/*:/usr/hdp/2.3.6.2-2/hadoop-yarn/.//*:/usr/hdp/2.3.6.2-2/hadoop-mapreduce/lib/*:/usr/hdp/2.3.6.2-2/hadoop-mapreduce/.//*::/usr/share/java/jdbc-mysql.jar:/usr/share/java/mysql-connector-java-5.1.37-bin.jar:/usr/share/java/mysql-connector-java.jar:/etc/tez/conf:/usr/hdp//tez/*:/usr/hdp//tez/lib/*:/usr/share/java/jdbc-mysql.jar:/usr/share/java/mysql-connector-java-5.1.37-bin.jar:/usr/share/java/mysql-connector-java.jar:/etc/tez/conf:/usr/hdp//tez/*:/usr/hdp//tez/lib/*:/usr/hdp/2.3.6.2-2/tez/*:/usr/hdp/2.3.6.2-2/tez/lib/*:/usr/hdp/2.3.6.2-2/tez/conf:/usr/share/java/jdbc-mysql.jar:/usr/share/java/mysql-connector-java-5.1.37-bin.jar:/usr/share/java/mysql-connector-java.jar:/etc/tez/conf:/usr/hdp//tez/*:/usr/hdp//tez/lib/*:/usr/share/java/jdbc-mysql.jar:/usr/share/java/mysql-connector-java-5.1.37-bin.jar:/usr/share/java/mysql-connector-java.jar:/etc/tez/conf:/usr/hdp/2.3.6.2-2/tez/*:/usr/hdp/2.3.6.2-2/tez/lib/*:/usr/hdp/2.3.6.2-2/tez/*:/usr/hdp/2.3.6.2-2/tez/lib/*:/usr/hdp/2.3.6.2-2/tez/conf -Xmx1000m -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Stack=true -Dhadoop.log.dir=/var/log/hadoop-hdfs -Dhadoop.log.file=hadoop.log -Dhadoop.home.dir=/usr/hdp/2.3.6.2-2/hadoop -Dhadoop.id.str=root -Dhadoop.root.logger=INFO,console -Djava.library.path=:/usr/hdp/2.3.6.2-2/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.3.6.2-2/hadoop/lib/native -Dhadoop.policy.file=hadoop-policy.xml -Djava.net.preferIPv4Stack=true -Dhdp.version=2.3.6.2-2 -Dhadoop.log.dir=/var/log/hadoop-hdfs -Dhadoop.log.file=hadoop-hdfs-datanode-bcpc-vm3.log -Dhadoop.home.dir=/usr/hdp/2.3.6.2-2/hadoop -Dhadoop.id.str=root -Dhadoop.root.logger=INFO,RFA -Djava.library.path=:/usr/hdp/2.3.6.2-2/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.3.6.2-2/hadoop/lib/native:/usr/hdp/2.3.6.2-2/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.3.6.2-2/hadoop/lib/native -Dhadoop.policy.file=hadoop-policy.xml -Djava.net.preferIPv4Stack=true -Dhadoop.log.dir=/var/log/hadoop-hdfs -Dhadoop.id.str=hdfs -jvm server -Xms3980m -Xmx3980m -Xmn498m -XX:PermSize=128m -XX:MaxPermSize=256m -server -XX:ParallelGCThreads=4 -Xloggc:/var/log/hadoop-hdfs/gc/gc.log-dn-8510-bcpc-vm3-201608301603.log -XX:HeapDumpPath=/var/log/hadoop-hdfs/heap-dump-dn-8510-bcpc-vm3-201608301603.hprof -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+UseNUMA -XX:+PrintGCApplicationStoppedTime -XX:+UseCompressedOops -XX:+PrintClassHistogram -XX:+PrintGCApplicationConcurrentTime -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 -XX:+HeapDumpOnOutOfMemoryError -XX:+PrintTenuringDistribution -XX:+ExitOnOutOfMemoryError -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=10112 -Xms3980m -Xmx3980m -Xmn498m -XX:PermSize=128m -XX:MaxPermSize=256m -server -XX:ParallelGCThreads=4 -Xloggc:/var/log/hadoop-hdfs/gc/gc.log-dn-8599-bcpc-vm3-201608301604.log -XX:HeapDumpPath=/var/log/hadoop-hdfs/heap-dump-dn-8599-bcpc-vm3-201608301604.hprof -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+UseNUMA -XX:+PrintGCApplicationStoppedTime -XX:+UseCompressedOops -XX:+PrintClassHistogram -XX:+PrintGCApplicationConcurrentTime -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 -XX:+HeapDumpOnOutOfMemoryError -XX:+PrintTenuringDistribution -XX:+ExitOnOutOfMemoryError -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -
```
* HBase RegionServer
```
hbase    13383 13369 30 08:36 ?        00:00:11 /usr/lib/jvm/java-8-oracle-amd64/bin/java -Dproc_regionserver -XX:OnOutOfMemoryError=kill -9 %p -Dhdp.version=2.3.6.2-2 -Djava.net.preferIPv4Stack=true -XX:+UseConcMarkSweepGC -Djava.security.auth.login.config=/etc/hbase/conf/hbase-client.jaas -Djava.io.tmpdir=/tmp/java_tmp_dir/0 -Dcom.sun.management.jmxremote.port=10102 -XX:CMSInitiatingOccupancyFraction=70 -XX:HeapDumpPath=/var/log/hbase/heap-dump-rs-13333-bcpc-vm3-201608310836.hprof -XX:PretenureSizeThreshold=1m -server -XX:ParallelGCThreads=2 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError -XX:+UseConcMarkSweepGC -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+UseParNewGC -Xloggc:/var/log/hbase/gc/gc.log-13333-bcpc-vm3-201608310836.log -Xmn256m -Xms1024m -Xmx1024m -XX:+ExplicitGCInvokesConcurrent -XX:+PrintTenuringDistribution -XX:+UseNUMA -XX:+PrintGCApplicationStoppedTime -XX:+UseCompressedOops -XX:+PrintClassHistogram -XX:+PrintGCApplicationConcurrentTime -XX:+ExitOnOutOfMemoryError -Djava.security.auth.login.config=/etc/hbase/conf/regionserver.jaas -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=10102 -Dhbase.log.dir=/var/log/hbase -Dhbase.log.file=hbase-hbase-0-regionserver-bcpc-vm3.log -Dhbase.home.dir=/usr/hdp/current/hbase-regionserver -Dhbase.id.str=hbase-0 -Dhbase.root.logger=INFO,RFA -Djava.library.path=:/usr/hdp/2.3.6.2-2/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.3.6.2-2/hadoop/lib/native:/usr/hdp/current/hbase-regionserver/lib/native/Linux-amd64-64 -Dhbase.security.logger=INFO,RFAS org.apache.hadoop.hbase.regionserver.HRegionServer -D hbase.regionserver.port=60200 -D hbase.regionserver.info.port=60300 start
ubuntu   14776  2952  0 08:37 pts/2    00:00:00 grep --color=auto -i sweep
```
