### PR TITLE
delete hdfs check file before attempting a write

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
@@ -60,6 +60,17 @@ end
 
 hdfs_write = "echo 'test' | hdfs dfs -copyFromLocal - /user/hdfs/chef-mapred-test"
 hdfs_remove = "hdfs dfs -rm -skipTrash /user/hdfs/chef-mapred-test"
+hdfs_test = "hdfs dfs -test -f /user/hdfs/chef-mapred-test"
+
+# first, make sure the check file is not currently in hdfs, otherwise, the check for 
+# setup-mapreduce-app will fail
+bash 'remove-check-file' do
+  code <<-EOH
+  #{hdfs_remove}
+  EOH
+  user 'hdfs'
+  only_if "#{hdfs_test}", :user => 'hdfs'
+end
 
 bash "setup-mapreduce-app" do
   code <<-EOH


### PR DESCRIPTION
Ensure that the test file ` /user/hdfs/chef-mapred-test` is removed in case it exists on hdfs, so that the hdfs check for /hdp/apps does not fail.

Tested that /hdp/apps is created both when the file exists as well as when it does not.

This fixes https://github.com/bloomberg/chef-bach/issues/661