### PR TITLE
Set JMXTrans log level to INFO from DEBUG

### DIFF
--- a/cookbooks/bcpc_jmxtrans/attributes/default.rb
+++ b/cookbooks/bcpc_jmxtrans/attributes/default.rb
@@ -475,3 +475,5 @@ default['jmxtrans']['default_queries']['hbase_rs'] = [
 # Override defaults for the jmxtrans cookbook
 default['jmxtrans']['run_interval'] = "15"
 
+# Set JMXTrans logging to INFO (the cookbook otherwise was defaulting to DEBUG)
+default["jmxtrans"]["log_level"] = "INFO"


### PR DESCRIPTION
Today we run JMXTrans with DEBUG logging. This is really verbose and seemingly needlessly; let's set it to INFO only.