### PR TITLE
Correct http_proxy issue and failure to find environment/Test-Laptop.json

### DIFF
--- a/bootstrap_chef.sh
+++ b/bootstrap_chef.sh
@@ -69,6 +69,9 @@ else
 fi
 
 
+# cluster external environment will go here
+#$SSH_CMD "mkdir -p cluster"
+$SSH_CMD "tar -xzf /chef-bcpc-host/cluster.tgz -C /home/vagrant" || (echo '### Vagrant ssh failed to deploy cluster environment returned $? ###'; exit 1)
 echo "Building bins"
 $SSH_CMD "cd $BCPC_DIR && sudo ./build_bins.sh"
 echo "Setting up chef server"
@@ -77,9 +80,6 @@ echo "Setting up chef cookbooks"
 $SSH_CMD "cd $BCPC_DIR && ./setup_chef_cookbooks.sh ${IP} ${SSH_USER} ${CHEF_ENVIRONMENT}"
 set -x
 echo "Setting up chef environment, roles, and uploading cookbooks"
-# cluster external environment will go here
-#$SSH_CMD "mkdir -p cluster"
-$SSH_CMD "tar -xzf /chef-bcpc-host/cluster.tgz -C /home/vagrant" || (echo '### Vagrant ssh failed to deploy cluster environment returned $? ###'; exit 1)
 $SSH_CMD "cd $BCPC_DIR && sudo knife environment from file environments/${CHEF_ENVIRONMENT}.json -u admin -k /etc/chef-server/admin.pem"
 $SSH_CMD "cd $BCPC_DIR && sudo knife role from file roles/*.json -u admin -k /etc/chef-server/admin.pem; r=\$? && sudo knife role from file roles/*.rb -u admin -k /etc/chef-server/admin.pem; r=\$((r & \$? )) && [[ \$r -lt 1 ]]"
 $SSH_CMD "cd $BCPC_DIR && sudo knife cookbook upload -a -o vendor/cookbooks -u admin -k /etc/chef-server/admin.pem"

--- a/setup_chef_cookbooks.sh
+++ b/setup_chef_cookbooks.sh
@@ -40,6 +40,12 @@ cookbook_path '$(pwd)/vendor/cookbooks'
  
 # Disable the Ohai password module which explodes on a Single-Sign-On-joined system
 Ohai::Config[:disabled_plugins] = [ "passwd" ]
+
+File.umask(0007)
+EOF
+
+if [[ -n "$PROXY" ]]; then
+  cat << EOF >> .chef/knife.rb
 no_proxy_array = ["localhost", o[:ipaddress], o[:hostname], o[:fqdn], "${BOOTSTRAP_IP}", "${binary_server_host}"]
 no_proxy_array.insert("*#{o[:domain]}") unless o[:domain].nil?
 no_proxy_string = no_proxy_array.uniq * ","
@@ -51,8 +57,8 @@ http_proxy ENV['http_proxy']
 https_proxy ENV['https_proxy']
 no_proxy no_proxy_string
 ENV['GIT_SSL_NO_VERIFY'] = 'true'
-File.umask(0007)
 EOF
+fi
 
 mkdir -p ./vendor
 /opt/chefdk/bin/berks vendor ./vendor/cookbooks


### PR DESCRIPTION
This should fix Chef-BACH #663. It works by moving the expansion of `cluster.tgz` to before anything needing `../cluster` is run. Particularly the following is fixed:
````
++ python -c 'import json; print json.load(file('\''environments/Test-Laptop.json'\''))["override_attributes"]["bcpc"]["bootstrap"]["server"]+'\'':80'\'''
Traceback (most recent call last):
  File "<string>", line 1, in <module>
IOError: [Errno 2] No such file or directory: 'environments/Test-Laptop.json'
````
As it was caused by the following execution chain:
* [`bootstrap_chef.sh`:77](https://github.com/bloomberg/chef-bach/blob/9600c76c1288501e341cd6e82ee4b884d5fbf0c0/bootstrap_chef.sh#L77) calls `setup_chef_cookbooks.sh`
* [`setup_chef_cookbooks.sh`:16](https://github.com/bloomberg/chef-bach/blob/9600c76c1288501e341cd6e82ee4b884d5fbf0c0/setup_chef_cookbooks.sh#L16) calls `load_binary_server_info`
* [`load_binary_server_info`](https://github.com/bloomberg/chef-bach/blob/9600c76c1288501e341cd6e82ee4b884d5fbf0c0/proxy_setup.sh#L36) is defined in `proxy_setup.sh` and references `environments/${environment}.json`
* [`environments`](https://github.com/bloomberg/chef-bach/blob/6f9131102002525778c3cfa4309949d03003c1c9/environments) is a symlink to `../cluster/environments` -- which does not exist at this point

It is unsatisfying that this happened to work for folks in the past but I believe that to be due to poor state clean-up of the `../cluster` directory in the past. Any new clone in a new directory location would hit this issue.