### PR TITLE
Re-order hbase env attribute loading to fix PR 668

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hbase.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hbase.rb
@@ -1,84 +1,160 @@
 # vim: tabstop=2:shiftwidth=2:softtabstop=2
-# Flag to set whether the HBase master restart process was successful or not
-default["bcpc"]["hadoop"]["hbase_master"]["restart_failed"] = false
-# Attribute to save the time when HBase master restart process failed
-default["bcpc"]["hadoop"]["hbase_master"]["restart_failed_time"] = ""
-# Flag to set whether the HBase region server restart process was successful or not
-default["bcpc"]["hadoop"]["hbase_regionserver"]["restart_failed"] = false
-# Attribute to save the time when HBase region server restart process failed
-default["bcpc"]["hadoop"]["hbase_regionserver"]["restart_failed_time"] = ""
-default['bcpc']['hadoop']['hbase']['root_dir'] = "#{node['bcpc']['hadoop']['hdfs_url']}/hbase"
-default['bcpc']['hadoop']['hbase']['bulkload_staging_dir'] = "/tmp/hbase"
-default["bcpc"]["hadoop"]["hbase"]["repl"]["enabled"] = false
-default["bcpc"]["hadoop"]["hbase"]["repl"]["peer_id"] = node.chef_environment.gsub("-","_")
-default["bcpc"]["hadoop"]["hbase"]["repl"]["target"] = ""
-default["bcpc"]["hadoop"]["hbase"]["superusers"] = ["hbase"]
-default["bcpc"]["hadoop"]["hbase"]["cluster"]["distributed"] = true
-default["bcpc"]["hadoop"]["hbase"]["defaults"]["for"]["version"]["skip"] = true
-default["bcpc"]["hadoop"]["hbase"]["dfs"]["client"]["read"]["shortcircuit"]["buffer"]["size"] = 131072
-default["bcpc"]["hadoop"]["hbase"]["regionserver"]["handler"]["count"] = 128
-# Interval in milli seconds when HBase major compaction need to be run. Disabled by default
-default["bcpc"]["hadoop"]["hbase"]["major_compact"]["time"] = 0
-default["bcpc"]["hadoop"]["hbase"]["bucketcache"]["enabled"] = false
-default["bcpc"]["hadoop"]["hbase_rs"]["coprocessor"]["abortonerror"] = true
-default["bcpc"]["hadoop"]["hbase"]["blockcache"]["size"] = 0.4
-default["bcpc"]["hadoop"]["hbase"]["bucketcache"]["size"] = 1434
-default["bcpc"]["hadoop"]["hbase"]["bucketcache"]["ioengine"] = "offheap"
-default["bcpc"]["hadoop"]["hbase"]["bucketcache"]["combinedcache"]["percentage"] = 0.71
-default["bcpc"]["hadoop"]["hbase"]["shortcircuit"]["read"] = false
-default["bcpc"]["hadoop"]["hbase"]["region"]["replication"]["enabled"] = false
-default["bcpc"]["hadoop"]["hbase"]["region"]["replica"]["storefile"]["refresh"]["memstore"]["multiplier"] = 4
-default["bcpc"]["hadoop"]["hbase"]["region"]["replica"]["wait"]["for"]["primary"]["flush"] = true
-default["bcpc"]["hadoop"]["hbase"]["hregion"]["memstore"]["block"]["multiplier"] = 8
-default["bcpc"]["hadoop"]["hbase"]["ipc"]["client"]["specificthreadforwriting"] = true
-default["bcpc"]["hadoop"]["hbase"]["client"]["primarycalltimeout"]["get"] = 100000
-default["bcpc"]["hadoop"]["hbase"]["client"]["primarycalltimeout"]["multiget"] = 100000
-default["bcpc"]["hadoop"]["hbase"]["meta"]["replica"]["count"] = 3
-default["bcpc"]["hadoop"]["hbase"]["ipc"]["warn"]["response"]["time"] = 250
-default["bcpc"]["hadoop"]["hbase"]["ipc"]["warn"]["response"]["size"] = 1048576
-default["bcpc"]["hadoop"]["hbase_master"]["hfilecleaner"]["ttl"] = 3600000
-default["bcpc"]["hadoop"]["hbase_master"]["jmx"]["port"] = 10101
-default["bcpc"]["hadoop"]["hbase_master"]["gc_thread"]["cpu_ratio"] = 0.2
-default["bcpc"]["hadoop"]["hbase_master"]["cmsinitiatingoccupancyfraction"] = 70
-default["bcpc"]["hadoop"]["hbase_master"]["PretenureSizeThreshold"] = "1m"
-default["bcpc"]["hadoop"]["hbase_master"]["xmn"]["size"] = 256
-default["bcpc"]["hadoop"]["hbase_master"]["xms"]["size"] = 1024
-default["bcpc"]["hadoop"]["hbase_master"]["xmx"]["size"] = 1024
-default["bcpc"]["hadoop"]["hbase_rs"]["jmx"]["port"] = 10102
-default["bcpc"]["hadoop"]["hbase_rs"]["xmn"]["size"] = 256
-default["bcpc"]["hadoop"]["hbase_rs"]["xms"]["size"] = 1024
-default["bcpc"]["hadoop"]["hbase_rs"]["xmx"]["size"] = 1024
-default["bcpc"]["hadoop"]["hbase_rs"]["mx_dir_mem"]["size"] = 256
-default["bcpc"]["hadoop"]["hbase_rs"]["hdfs_dir_mem"]["size"] = 128
-default["bcpc"]["hadoop"]["hbase_rs"]["gc_thread"]["cpu_ratio"] = 0.4
-default["bcpc"]["hadoop"]["hbase_rs"]["memstore"]["upperlimit"] = 0.4
-default["bcpc"]["hadoop"]["hbase_rs"]["memstore"]["lowerlimit"] = 0.2
-default["bcpc"]["hadoop"]["hbase_rs"]["storefile"]["refresh"]["all"] = false
-default["bcpc"]["hadoop"]["hbase_rs"]["storefile"]["refresh"]["period"] = 30000
-default["bcpc"]["hadoop"]["hbase_rs"]["cmsinitiatingoccupancyfraction"] = 70
-default["bcpc"]["hadoop"]["hbase_rs"]["PretenureSizeThreshold"] = "1m"
+#
+# Cookbook: bcpc-hadoop
+# File: attributes/hbase.rb
+#
+# Shared attributes for HBase configurations. hbase_env and
+# hbase_config rely on these settings.
+#
+# Since attribute files are loaded in alphabetical order, it is
+# important that filenames remain intact such that this file is loaded
+# first.
+#
 
-#Apache Phoenix related attributes 
-default["bcpc"]["hadoop"]["phoenix"]["tracing"]["enabled"] = false
+#
+# Flag to set whether the HBase master restart process was successful or not.
+# This flag is usually saved on the node object.
+#
+default['bcpc']['hadoop']['hbase_master']['restart_failed'] = false
 
-bucketcache_size = (node["bcpc"]["hadoop"]["hbase_rs"]["mx_dir_mem"]["size"] -  node["bcpc"]["hadoop"]["hbase_rs"]["hdfs_dir_mem"]["size"]).floor 
+#
+# Attribute to save the time when HBase master restart process failed.
+# This flag is usually saved on the node object.
+#
+default['bcpc']['hadoop']['hbase_master']['restart_failed_time'] = ''
+
+#
+# Flag to set whether the HBase region server restart process was successful.
+# This flag is usually saved on the node object.
+#
+default['bcpc']['hadoop']['hbase_regionserver']['restart_failed'] = false
+
+#
+# Attribute to save the time when HBase region server restart process failed.
+# This flag is usually saved on the node object.
+#
+default['bcpc']['hadoop']['hbase_regionserver']['restart_failed_time'] = ''
+
+default['bcpc']['hadoop']['hbase'].tap do |hbase|
+  hbase['root_dir'] = "#{node['bcpc']['hadoop']['hdfs_url']}/hbase"
+  hbase['bulkload_staging_dir'] = '/tmp/hbase'
+  hbase['repl']['enabled'] = false
+  hbase['repl']['peer_id'] = node.chef_environment.gsub('-','_')
+  hbase['repl']['target'] = ''
+  hbase['superusers'] = ['hbase']
+  hbase['cluster']['distributed'] = true
+  hbase['defaults']['for']['version']['skip'] = true
+  hbase['dfs']['client']['read']['shortcircuit']['buffer']['size'] = 131072
+  hbase['regionserver']['handler']['count'] = 128
+
+  #
+  # Interval in ms when HBase major compaction need to be
+  # run. Disabled by default
+  #
+  hbase['major_compact']['time'] = 0
+
+  hbase['bucketcache']['enabled'] = false
+  hbase['blockcache']['size'] = 0.4
+  hbase['bucketcache']['size'] = 1434
+  hbase['bucketcache']['ioengine'] = 'offheap'
+  hbase['bucketcache']['combinedcache']['percentage'] = 0.71
+  hbase['shortcircuit']['read'] = false
+
+  hbase['region'].tap do |region|
+    region['replication']['enabled'] = false
+    region['replica']['storefile']['refresh']['memstore']['multiplier'] = 4
+    region['replica']['wait']['for']['primary']['flush'] = true
+  end
+
+  hbase['hregion']['memstore']['block']['multiplier'] = 8
+  hbase['ipc']['client']['specificthreadforwriting'] = true
+  hbase['client']['primarycalltimeout']['get'] = 100000
+  hbase['client']['primarycalltimeout']['multiget'] = 100000
+  hbase['meta']['replica']['count'] = 3
+  hbase['ipc']['warn']['response']['time'] = 250
+  hbase['ipc']['warn']['response']['size'] = 1048576
+end
+
+default['bcpc']['hadoop']['hbase_master'].tap do |hbase_master|
+  hbase_master['hfilecleaner']['ttl'] = 3600000
+  hbase_master['jmx']['port'] = 10101
+  hbase_master['gc_thread']['cpu_ratio'] = 0.2
+  hbase_master['cmsinitiatingoccupancyfraction'] = 70
+  hbase_master['PretenureSizeThreshold'] = '1m'
+  hbase_master['xmn']['size'] = 256
+  hbase_master['xms']['size'] = 1024
+  hbase_master['xmx']['size'] = 1024
+end
+
+default['bcpc']['hadoop']['hbase_rs'].tap do |hbase_rs|
+  hbase_rs['coprocessor']['abortonerror'] = true
+  hbase_rs['jmx']['port'] = 10102
+  hbase_rs['xmn']['size'] = 256
+  hbase_rs['xms']['size'] = 1024
+  hbase_rs['xmx']['size'] = 1024
+  hbase_rs['mx_dir_mem']['size'] = 256
+  hbase_rs['hdfs_dir_mem']['size'] = 128
+  hbase_rs['gc_thread']['cpu_ratio'] = 0.4
+  hbase_rs['memstore']['upperlimit'] = 0.4
+  hbase_rs['memstore']['lowerlimit'] = 0.2
+  hbase_rs['storefile']['refresh']['all'] = false
+  hbase_rs['storefile']['refresh']['period'] = 30000
+  hbase_rs['cmsinitiatingoccupancyfraction'] = 70
+  hbase_rs['PretenureSizeThreshold'] = '1m'
+end
+
+# Apache Phoenix related attributes
+default['bcpc']['hadoop']['phoenix']['tracing']['enabled'] = false
+
+bucketcache_size = node['bcpc']['hadoop']['hbase_rs'].tap do |hbase_rs|
+  (hbase_rs['mx_dir_mem']['size'] -  hbase_rs['hdfs_dir_mem']['size']).floor
+end
 
 # These will become key/value pairs in 'hbase_site.xml'
 default[:bcpc][:hadoop][:hbase][:site_xml].tap do |site_xml|
-  site_xml['hbase.rootdir'] = "#{node['bcpc']['hadoop']['hbase']['root_dir']}"
-  site_xml['hbase.bulkload.staging.dir'] = "#{node['bcpc']['hadoop']['hbase']['bulkload_staging_dir']}"
-  site_xml['hbase.cluster.distributed'] = "#{node["bcpc"]["hadoop"]["hbase"]["cluster"]["distributed"]}"
-  site_xml['hbase.hregion.majorcompaction'] = "#{node["bcpc"]["hadoop"]["hbase"]["major_compact"]["time"]}"
-  site_xml['hbase.regionserver.ipc.address'] = "#{node["bcpc"]["floating"]["ip"]}"
-  site_xml['hbase.master.ipc.address'] = "#{node["bcpc"]["floating"]["ip"]}"
-  site_xml['hbase.defaults.for.version.skip'] = "#{node["bcpc"]["hadoop"]["hbase"]["defaults"]["for"]["version"]["skip"]}"
-  site_xml['hbase.regionserver.wal.codec'] = 'org.apache.hadoop.hbase.regionserver.wal.IndexedWALEditCodec'
-  site_xml['hbase.region.server.rpc.scheduler.factory.class'] = 'org.apache.hadoop.hbase.ipc.PhoenixRpcSchedulerFactory'
-  site_xml['hbase.rpc.controllerfactory.class'] =  'org.apache.hadoop.hbase.ipc.controller.ServerRpcControllerFactory'
-  site_xml['hbase.regionserver.handler.count'] = node["bcpc"]["hadoop"]["hbase"]["regionserver"]["handler"]["count"].to_s
-  site_xml['hbase.ipc.warn.response.time'] = node["bcpc"]["hadoop"]["hbase"]["ipc"]["warn"]["response"]["time"].to_s
-  site_xml['hbase.ipc.warn.response.size'] = node["bcpc"]["hadoop"]["hbase"]["ipc"]["warn"]["response"]["size"].to_s
+  site_xml['hbase.rootdir'] =
+    node['bcpc']['hadoop']['hbase']['root_dir'].to_s
+
+  site_xml['hbase.bulkload.staging.dir'] =
+    node['bcpc']['hadoop']['hbase']['bulkload_staging_dir'].to_s
+
+  site_xml['hbase.cluster.distributed'] =
+    node['bcpc']['hadoop']['hbase']['cluster']['distributed'].to_s
+
+  site_xml['hbase.hregion.majorcompaction'] =
+    node['bcpc']['hadoop']['hbase']['major_compact']['time'].to_s
+
+  site_xml['hbase.regionserver.ipc.address'] =
+    node['bcpc']['floating']['ip'].to_s
+
+  site_xml['hbase.master.ipc.address'] =
+    node['bcpc']['floating']['ip'].to_s
+
+  site_xml['hbase.defaults.for.version.skip'] =
+    node['bcpc']['hadoop']['hbase']['defaults']['for']['version']['skip'].to_s
+
+  site_xml['hbase.regionserver.wal.codec'] =
+    'org.apache.hadoop.hbase.regionserver.wal.IndexedWALEditCodec'
+
+  site_xml['hbase.region.server.rpc.scheduler.factory.class'] =
+    'org.apache.hadoop.hbase.ipc.PhoenixRpcSchedulerFactory'
+
+  site_xml['hbase.rpc.controllerfactory.class'] =
+    'org.apache.hadoop.hbase.ipc.controller.ServerRpcControllerFactory'
+
+  site_xml['hbase.regionserver.handler.count'] =
+    node['bcpc']['hadoop']['hbase']['regionserver']['handler']['count'].to_s
+
+  site_xml['hbase.ipc.warn.response.time'] =
+    node['bcpc']['hadoop']['hbase']['ipc']['warn']['response']['time'].to_s
+
+  site_xml['hbase.ipc.warn.response.size'] =
+    node['bcpc']['hadoop']['hbase']['ipc']['warn']['response']['size'].to_s
+
+  # Why are these boolean parameters strings?
   site_xml['hbase.ipc.server.tcpnodelay'] = 'true'
   site_xml['hbase.replication'] = 'true'
-  site_xml['hbase.coprocessor.abortonerror'] = node["bcpc"]["hadoop"]["hbase_rs"]["coprocessor"]["abortonerror"] 
+
+  site_xml['hbase.coprocessor.abortonerror'] =
+    node['bcpc']['hadoop']['hbase_rs']['coprocessor']['abortonerror']
 end

--- a/cookbooks/bcpc-hadoop/attributes/hbase_env.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hbase_env.rb
@@ -1,0 +1,79 @@
+# vim: tabstop=2:shiftwidth=2:softtabstop=2
+#
+# Cookbook: bcpc-hadoop
+# File: attributes/hbase_env.rb
+#
+# Attributes used in the generation of hbase_env.sh
+#
+
+#
+# Delete any hbase_env attributes accidentally saved into the node
+# object at 'normal' precedence.
+#
+node.set[:bcpc][:hadoop][:hbase][:env] = nil
+
+cpu_total = node['cpu']['total']
+cpu_ratio = node['bcpc']['hadoop']['hbase_rs']['gc_thread']['cpu_ratio']
+
+common_opts =
+  ' -server -XX:ParallelGCThreads=' +
+      [1, (cpu_total * cpu_ratio).ceil].max.to_s +
+  ' -XX:+UseCMSInitiatingOccupancyOnly' +
+  ' -XX:+HeapDumpOnOutOfMemoryError' +
+  ' -verbose:gc' +
+  ' -XX:+PrintHeapAtGC' +
+  ' -XX:+PrintGCDetails' +
+  ' -XX:+PrintGCTimeStamps' +
+  ' -XX:+PrintGCDateStamps' +
+  ' -XX:+UseParNewGC' +
+  ' -Xloggc:${HBASE_LOG_DIR}/gc/gc-pid-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log' +
+  ' -Xmn' + node['bcpc']['hadoop']['hbase_rs']['xmn']['size'].to_s + 'm' +
+  ' -Xms' + node['bcpc']['hadoop']['hbase_rs']['xms']['size'].to_s + 'm' +
+  ' -Xmx' + node['bcpc']['hadoop']['hbase_rs']['xmx']['size'].to_s + 'm' +
+  ' -XX:+ExplicitGCInvokesConcurrent' +
+  ' -XX:+PrintTenuringDistribution' +
+  ' -XX:+UseNUMA' +
+
+  ' -XX:+PrintGCApplicationStoppedTime' +
+  ' -XX:+UseCompressedOops' +
+  ' -XX:+PrintClassHistogram' +
+  ' -XX:+PrintGCApplicationConcurrentTime' +
+  ' -XX:+ExitOnOutOfMemoryError'
+
+node.default['bcpc']['hadoop']['hbase']['env'].tap do |hbase_env|
+  hbase_env['JAVA_HOME'] = node[:bcpc][:hadoop][:java]
+  hbase_env['HBASE_PID_DIR'] = '/var/run/hbase'
+  hbase_env['HBASE_LOG_DIR'] = '/var/log/hbase'
+  hbase_env['HBASE_MANAGES_ZK'] = 'false'
+
+  hbase_env['HBASE_JMX_BASE'] = '-Dcom.sun.management.jmxremote.ssl=false' +
+    ' -Dcom.sun.management.jmxremote.authenticate=false'
+
+  hbase_env['HBASE_OPTS'] = '$HBASE_OPTS -Djava.net.preferIPv4Stack=true' +
+    ' -XX:+UseConcMarkSweepGC'
+
+  hbase_env['HBASE_MASTER_OPTS'] =
+    '$HBASE_MASTER_OPTS' +
+     common_opts +
+    ' -XX:CMSInitiatingOccupancyFraction=' +
+      node['bcpc']['hadoop']['hbase_master']['cmsinitiatingoccupancyfraction'].to_s +
+    ' -XX:HeapDumpPath=${HBASE_LOG_DIR}/heap-dump-hm-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof' +
+    ' -XX:PretenureSizeThreshold=' +
+      node['bcpc']['hadoop']['hbase_master']['PretenureSizeThreshold'].to_s
+
+  hbase_env['HBASE_REGIONSERVER_OPTS'] =
+    '$HBASE_REGION_SERVER_OPTS' +
+    common_opts +
+    ' -XX:CMSInitiatingOccupancyFraction=' +
+      node['bcpc']['hadoop']['hbase_rs']['cmsinitiatingoccupancyfraction'].to_s +
+    ' -XX:HeapDumpPath=${HBASE_LOG_DIR}/heap-dump-rs-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof' +
+    ' -XX:PretenureSizeThreshold=' +
+      node['bcpc']['hadoop']['hbase_rs']['PretenureSizeThreshold'].to_s
+end
+
+if node['bcpc']['hadoop']['hbase']['bucketcache']['enabled'] == true then
+  node.default['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] =
+   node['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] +
+   ' -XX:MaxDirectMemorySize=' +
+     node['bcpc']['hadoop']['hbase_rs']['mx_dir_mem']['size'].to_s + 'm'
+end

--- a/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
@@ -1,96 +1,45 @@
-node.default['bcpc']['hadoop']['hbase']['env'] = {}
-# Chef Attributes for hbase-env.sh file
-cpu_total = node['cpu']['total']
-cpu_ratio = node['bcpc']['hadoop']['hbase_rs']['gc_thread']['cpu_ratio']
-common_opts =
-  ' -server -XX:ParallelGCThreads=' +
-      [1, (cpu_total * cpu_ratio).ceil].max.to_s +
-  ' -XX:+UseCMSInitiatingOccupancyOnly' +
-  ' -XX:+HeapDumpOnOutOfMemoryError' +
-  ' -verbose:gc' +
-  ' -XX:+PrintHeapAtGC' +
-  ' -XX:+PrintGCDetails' +
-  ' -XX:+PrintGCTimeStamps' +
-  ' -XX:+PrintGCDateStamps' +
-  ' -XX:+UseParNewGC' +
-  ' -Xloggc:${HBASE_LOG_DIR}/gc/gc-pid-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log' +
-  ' -Xmn' + node['bcpc']['hadoop']['hbase_rs']['xmn']['size'].to_s + 'm' +
-  ' -Xms' + node['bcpc']['hadoop']['hbase_rs']['xms']['size'].to_s + 'm' +
-  ' -Xmx' + node['bcpc']['hadoop']['hbase_rs']['xmx']['size'].to_s + 'm' +
-  ' -XX:+ExplicitGCInvokesConcurrent' +
-  ' -XX:+PrintTenuringDistribution' +
-  ' -XX:+UseNUMA' +
+#
+# Cookbook: bcpc-hadoop
+# File: recipes/hbase_env.rb
+#
+# This recipe generates the hbase-env.sh shell script from Chef
+# attributes.
+#
 
-  ' -XX:+PrintGCApplicationStoppedTime' +
-  ' -XX:+UseCompressedOops' +
-  ' -XX:+PrintClassHistogram' +
-  ' -XX:+PrintGCApplicationConcurrentTime' +
-  ' -XX:+ExitOnOutOfMemoryError'
-
-node.default['bcpc']['hadoop']['hbase']['env'].tap do |hbase_env|
-  hbase_env['JAVA_HOME'] = node[:bcpc][:hadoop][:java]
-  hbase_env['HBASE_PID_DIR'] = '/var/run/hbase'
-  hbase_env['HBASE_LOG_DIR'] = '/var/log/hbase'
-  hbase_env['HBASE_MANAGES_ZK'] = 'false'
-
-  hbase_env['HBASE_JMX_BASE'] = '-Dcom.sun.management.jmxremote.ssl=false' +
-    ' -Dcom.sun.management.jmxremote.authenticate=false'
-
-  hbase_env['HBASE_OPTS'] = '$HBASE_OPTS -Djava.net.preferIPv4Stack=true' +
-    ' -XX:+UseConcMarkSweepGC'
-
-  hbase_env['HBASE_MASTER_OPTS'] =
-    '$HBASE_MASTER_OPTS' +
-     common_opts +
-    ' -XX:CMSInitiatingOccupancyFraction=' +
-      node['bcpc']['hadoop']['hbase_master']['cmsinitiatingoccupancyfraction'].to_s +
-    ' -XX:HeapDumpPath=${HBASE_LOG_DIR}/heap-dump-hm-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof' +
-    ' -XX:PretenureSizeThreshold=' +
-      node['bcpc']['hadoop']['hbase_master']['PretenureSizeThreshold'].to_s
-
-  hbase_env['HBASE_REGIONSERVER_OPTS'] =
-    '$HBASE_REGION_SERVER_OPTS' +
-    common_opts +
-    ' -XX:CMSInitiatingOccupancyFraction=' +
-      node['bcpc']['hadoop']['hbase_rs']['cmsinitiatingoccupancyfraction'].to_s +
-    ' -XX:HeapDumpPath=${HBASE_LOG_DIR}/heap-dump-rs-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof' +
-    ' -XX:PretenureSizeThreshold=' +
-      node['bcpc']['hadoop']['hbase_rs']['PretenureSizeThreshold'].to_s
-end
-
-if node["bcpc"]["hadoop"]["hbase"]["bucketcache"]["enabled"] == true then
-  node.default['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] =
-   node['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] +
-   ' -XX:MaxDirectMemorySize=' +
-     node['bcpc']['hadoop']['hbase_rs']['mx_dir_mem']['size'].to_s + 'm'
-end
-
-if node[:bcpc][:hadoop][:kerberos][:enable] == true then
-    node.default['bcpc']['hadoop']['hbase']['env']['HBASE_OPTS'] =
-      node['bcpc']['hadoop']['hbase']['env']['HBASE_OPTS'] +
+#
+# For some reason, node[:bcpc][:hadoop][:kerberos] doesn't exist when
+# attr files are loaded, so we have to do this in a recipe.
+#
+if node[:bcpc][:hadoop][:kerberos][:enable]
+    node.default[:bcpc][:hadoop][:hbase][:env]['HBASE_OPTS'] =
+      node[:bcpc][:hadoop][:hbase][:env]['HBASE_OPTS'].to_s +
       ' -Djava.security.auth.login.config=/etc/hbase/conf/hbase-client.jaas'
-    node.default['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] =
-      node['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] +
+
+    node.default[:bcpc][:hadoop][:hbase][:env]['HBASE_MASTER_OPTS'] =
+      node[:bcpc][:hadoop][:hbase][:env]['HBASE_MASTER_OPTS'].to_s +
       ' -Djava.security.auth.login.config=/etc/hbase/conf/hbase-server.jaas'
-    node.default['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] =
-      node['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] +
+
+    node.default[:bcpc][:hadoop][:hbase][:env]['HBASE_REGIONSERVER_OPTS'] =
+      node[:bcpc][:hadoop][:hbase][:env]['HBASE_REGIONSERVER_OPTS'].to_s +
       ' -Djava.security.auth.login.config=/etc/hbase/conf/regionserver.jaas'
 end
 
 #
-# HBASE Master and RegionServer env.sh variables are updated with JMX related options when JMX is enabled
+# HBASE Master and RegionServer env.sh variables are updated with JMX
+# related options when JMX is enabled
 #
-if node[:bcpc][:hadoop].attribute?(:jmx_enabled) and node[:bcpc][:hadoop][:jmx_enabled] then
+if node[:bcpc][:hadoop][:jmx_enabled]
   node.default['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] =
-    node['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] +
+    node['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'].to_s +
     ' $HBASE_JMX_BASE ' +
     ' -Dcom.sun.management.jmxremote.port=' +
-      node[:bcpc][:hadoop][:hbase_master][:jmx][:port].to_s
-   node.default['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] =
-    node['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] +
+    node[:bcpc][:hadoop][:hbase_master][:jmx][:port].to_s
+
+  node.default['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] =
+    node['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'].to_s +
     ' $HBASE_JMX_BASE ' +
     ' -Dcom.sun.management.jmxremote.port=' +
-      node[:bcpc][:hadoop][:hbase_rs][:jmx][:port].to_s
+    node[:bcpc][:hadoop][:hbase_rs][:jmx][:port].to_s
 end
 
 template '/etc/hbase/conf/hbase-env.sh' do


### PR DESCRIPTION
This PR should fix both the node.set issue, and the attribute precedence issues that pull #668 sought to remedy.

I moved most attributes back into attribute files, and deleted duplicate settings.  We were setting the hbase env settings for JMX and Kerberos twice, in two different recipes.  Lev's PR caught one of two, and the second ended up being a nil access without the first one happening.
