### PR TITLE
Perform a BFD install in VM cluster builds

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -110,7 +110,7 @@ Vagrant.configure('2') do |config|
   config.vm.box = 'trusty64'
   config.vm.box_url = 'trusty-server-cloudimg-amd64-vagrant-disk1.box'
 
-  memory = ENV['BOOTSTRAP_VM_MEM'] || '1024'
+  memory = ENV['BOOTSTRAP_VM_MEM'] || '2048'
   cpus = ENV['BOOTSTRAP_VM_CPUs'] || '1'
 
   config.vm.provider :virtualbox do |vb|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ local_file =
   end
 
 if File.exist?(local_file)
-  puts "Found #{local_file}, including"
+  $stderr.puts "Found #{local_file}, including"
   require local_file
 end
 
@@ -110,7 +110,7 @@ Vagrant.configure('2') do |config|
   config.vm.box = 'trusty64'
   config.vm.box_url = 'trusty-server-cloudimg-amd64-vagrant-disk1.box'
 
-  memory = ENV['BOOTSTRAP_VM_MEM'] || '1024'
+  memory = ENV['BOOTSTRAP_VM_MEM'] || '4096'
   cpus = ENV['BOOTSTRAP_VM_CPUs'] || '1'
 
   config.vm.provider :virtualbox do |vb|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -110,7 +110,7 @@ Vagrant.configure('2') do |config|
   config.vm.box = 'trusty64'
   config.vm.box_url = 'trusty-server-cloudimg-amd64-vagrant-disk1.box'
 
-  memory = ENV['BOOTSTRAP_VM_MEM'] || '4096'
+  memory = ENV['BOOTSTRAP_VM_MEM'] || '1024'
   cpus = ENV['BOOTSTRAP_VM_CPUs'] || '1'
 
   config.vm.provider :virtualbox do |vb|

--- a/cookbooks/bcpc/metadata.rb
+++ b/cookbooks/bcpc/metadata.rb
@@ -8,6 +8,7 @@ version          '0.1.0'
 
 depends 'apt', '~> 2.4.0'
 depends 'bfd'
+depends 'build-essential'
 depends 'chef-client', '~> 4.2.4'
 depends 'chef-vault', '~> 1.3.0'
 depends 'cobblerd', '>= 0.2.0'

--- a/cookbooks/bcpc/recipes/networking.rb
+++ b/cookbooks/bcpc/recipes/networking.rb
@@ -328,7 +328,6 @@ ruby_block 'bcpc-deconfigure-dhcp-interfaces' do
   only_if 'pgrep dhclient'
 end
 
-
 if node[:bcpc][:networks][subnet][:management][:interface] !=
    node[:bcpc][:networks][subnet][:storage][:interface]
   bash 'routing-storage' do


### PR DESCRIPTION
I discovered last night that hardware cluster builds are currently broken out of the box, because the BFD package is absent.

This PR adds BFD to all builds, regardless of target.

Additionally, chef runs can fail on a bootstrap with only 1024 MB of RAM.  I've upgraded the bootstrap to 2048 MB of RAM.  (Forcing macbooks to swap is ostensibly better than having the build fail)