### PR TITLE
Update bcpc::bootstrap_network for routed rack

### DIFF
--- a/cookbooks/bcpc/recipes/keepalived.rb
+++ b/cookbooks/bcpc/recipes/keepalived.rb
@@ -64,8 +64,17 @@ service "keepalived" do
     action [ :enable, :start ]
 end
 
+#
+# In bcpc::bootstrap, the newest bfd package should have been stuffed
+# into the bootstrap's "bins" directory, which is indexed as an apt repo.
+#
+# In that case, we can set the bfd package source to nil and let apt do
+# its job.
+#
+node.default[:bfd][:package][:source] = nil
+include_recipe 'bfd::default'
+
 if node[:bcpc][:networks].length > 1
-  include_recipe "bfd::default"
   bfd_session "Global Cluster Service VIP Connect" do
     subnet = node[:bcpc][:management][:subnet]
     action :connect
@@ -77,5 +86,13 @@ if node[:bcpc][:networks].length > 1
     action :up
     remote_ip node[:bcpc][:networks][subnet][:management][:gateway]
     local_ip node[:bcpc][:networks][subnet][:management][:vip]
+  end
+else
+  service 'bfdd-beacon' do
+    action [:stop, :disable]
+  end
+
+  execute 'killall bfdd-beacon' do
+    ignore_failure true
   end
 end


### PR DESCRIPTION
This PR makes changes to `bcpc::bootstrap_network` to support routed rack and Ubuntu 14.04

- Compare the `node[:bcpc][:bootstrap]` IP data to the list of networks to determine management subnet, instead of looking for the pre-RR attributes
- Use `ifup` and `ifdown` instead of the now-unsupported `service networking restart`