### PR TITLE
Fix regressions related to PR #636 and PR #683

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -86,25 +86,47 @@ end
 # item: chef vault item; 
 # key: the key to retrieve password in the item
 def get_config(key, item=node.chef_environment, bag="configs")
-  require 'chef-vault'
-  begin
-    entry = ChefVault::Item.load(bag, item)
-    return entry[key]
-  rescue ChefVault::Exceptions::KeysNotFound
-    if bag != "configs"
-    begin
-      entry = Chef::DataBagItem.load(bag,item)
-      return entry[key]
-    rescue Net::HTTPServerException
-      return nil
-    end
-    else
+
+  #
+  # This was the original get_config.
+  # It fetches things out of chef data bags.
+  #
+  def get_data_bag_item(key, item, bag)
+    if bag == 'configs'
       init_config if $dbi.nil?
-      Chef::Log.info  "------------ Fetching value for key \"#{key}\""
-      value = node['bcpc']['encrypt_data_bag'] ? $edbi[key] : $dbi[key]
-      return value
+      Chef::Log.info  "Fetching non-vaulted value for key \"#{key}\""
+      node['bcpc']['encrypt_data_bag'] ? $edbi[key] : $dbi[key]
+    else
+      begin
+        entry = Chef::DataBagItem.load(bag,item)
+        return entry[key]
+      rescue
+        nil
+      end
     end
   end
+
+  #
+  # This is the second iteration of get_config.
+  # Items are retrieved from chef-vault.
+  #
+  def get_vault_item(key, item, bag)
+    begin
+      require 'chef-vault'
+      ChefVault::Item.load(bag, item)[key]
+    rescue LoadError
+      Chef::Log.warn('Could not require chef-vault!')
+      nil
+    rescue ChefVault::Exceptions::KeysNotFound
+      nil
+    end
+  end
+
+  #
+  # We should always provide the vault item if possible.
+  # If that fails, fall back to the data bag.
+  #
+  get_vault_item(key, item, bag) || get_data_bag_item(key, item, bag)
 end
 
 def delete_config(key)

--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -33,9 +33,7 @@ end
 
 # memrize function to bootstrap info
 def get_bootstrap
-  return $bootstrap if defined? $bootstrap
-  $bootstrap = get_all_nodes.select{|s| s.hostname.include? 'bootstrap'}[0].fqdn
-  return $bootstrap
+  node.run_state['bootstrap_host'] ||= get_all_nodes.select{|s| s.hostname.include? 'bootstrap'}[0].fqdn
 end
 
 #

--- a/cookbooks/bcpc/recipes/cluster_local_repository.rb
+++ b/cookbooks/bcpc/recipes/cluster_local_repository.rb
@@ -26,23 +26,86 @@
 # any issues and update the apt sources.
 #
 
+#
+# On the bootstrap, the bootstrap-hosted apt mirror will be a local
+# filesystem path.  On all other nodes, it is an http path, to the
+# bootstrap.
+#
 require 'uri'
-bootstrap_uri = URI.parse(get_binary_server_url)
+apt_uri = if node[:fqdn] == get_bootstrap
+            URI.parse('file:///home/vagrant/chef-bcpc/bins')
+          else
+            URI.parse(get_binary_server_url)
+          end
 
-file '/etc/apt/apt.conf.d/99cluster_local_repository_proxy' do
-  mode 0444
-  content <<-EOM.gsub(/^ {4}/,'')
-    Acquire::http::Proxy {
-      #{bootstrap_uri.host} DIRECT;
-    };
-  EOM
+# No proxy will ever be necessary to reach the bootstrap.
+if apt_uri.host
+  file '/etc/apt/apt.conf.d/99cluster_local_repository_proxy' do
+    mode 0444
+    content <<-EOM.gsub(/^ {6}/,'')
+      Acquire::http::Proxy {
+        #{apt_uri.host} DIRECT;
+      };
+    EOM
+  end
+end
+
+#
+# We can't use the methods from bcpc utils.rb because chef-vault may
+# not have been installed yet.
+#
+# Fortunately, the public key for the apt repository is a standard
+# data bag item.
+#
+bcpc_public_key =
+  begin
+    dbi = data_bag_item('configs', node.chef_environment)
+    dbi['bootstrap-gpg-public_key_base64']
+  rescue
+    nil
+  end
+
+require 'tempfile'
+bcpc_apt_key_path = Tempfile.new('bootstrap-gpg-key').path
+
+if bcpc_public_key
+  file bcpc_apt_key_path do
+    mode 0444
+    content Base64.decode64(bcpc_public_key)
+  end
+
+  ruby_block 'get-bootstrap-gpg-fingerprint' do
+    block do
+      require 'mixlib/shellout'
+      cc = Mixlib::ShellOut.new('gpg', '--with-fingerprint', bcpc_apt_key_path)
+      cc.run_command
+      cc.error!
+      node.run_state['bootstrap_gpg_fingerprint'] =
+        cc.stdout.lines.select do |line|
+          line.include?('fingerprint =')
+        end.first.gsub(/.*fingerprint =/, '').gsub(/\s/, '').chomp
+    end
+  end
+
+  execute 'install-bootstrap-gpg' do
+    command "apt-key add '#{bcpc_apt_key_path}'"
+  end
 end
 
 apt_repository 'bcpc' do
-  uri get_binary_server_url
+  uri apt_uri.to_s
   distribution '0.5.0'
   arch 'amd64'
   components ['main']
-  trusted true
-  key URI.join(get_binary_server_url, 'apt_key.pub').to_s
+
+  #
+  # If we have a data bag item for the public key, use it.
+  # If we don't, trust the repo blindly.
+  #
+  if bcpc_public_key
+    key node.run_state['bootstrap_gpg_fingerprint']
+    trusted false
+  else
+    trusted true
+  end
 end

--- a/cookbooks/bcpc/recipes/cluster_local_repository.rb
+++ b/cookbooks/bcpc/recipes/cluster_local_repository.rb
@@ -1,0 +1,48 @@
+#
+# Cookbook Name:: bcpc
+# Recipe:: cluster_local_repository
+#
+# Copyright 2016, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This recipe configures clients to use the apt repository maintained
+# on the bootstrap node.
+#
+# This is normally done by "install-chef.sh" when the chef client is
+# installed.  We do it again during the chef run in order to correct
+# any issues and update the apt sources.
+#
+
+require 'uri'
+bootstrap_uri = URI.parse(get_binary_server_url)
+
+file '/etc/apt/apt.conf.d/99cluster_local_repository_proxy' do
+  mode 0444
+  content <<-EOM.gsub(/^ {4}/,'')
+    Acquire::http::Proxy {
+      #{bootstrap_uri.host} DIRECT;
+    };
+  EOM
+end
+
+apt_repository 'bcpc' do
+  uri get_binary_server_url
+  distribution '0.5.0'
+  arch 'amd64'
+  components ['main']
+  trusted true
+  key URI.join(get_binary_server_url, 'apt_key.pub').to_s
+end

--- a/cookbooks/bcpc/recipes/default.rb
+++ b/cookbooks/bcpc/recipes/default.rb
@@ -35,6 +35,7 @@ file '/etc/apt/apt.conf.d/99ubuntu_archive_proxy' do
 end
 
 include_recipe 'ubuntu'
+include_recipe 'bcpc::cluster_local_repository'
 
 require 'ipaddr'
 

--- a/cookbooks/bcpc/recipes/keepalived.rb
+++ b/cookbooks/bcpc/recipes/keepalived.rb
@@ -72,6 +72,7 @@ end
 # its job.
 #
 node.default[:bfd][:package][:source] = nil
+include_recipe 'bcpc::cluster_local_repository'
 include_recipe 'bfd::default'
 
 if node[:bcpc][:networks].length > 1

--- a/cookbooks/bcpc/recipes/mysql.rb
+++ b/cookbooks/bcpc/recipes/mysql.rb
@@ -100,6 +100,11 @@ apt_package 'percona-xtradb-cluster-56' do
           '-o Dpkg::Options::="--force-confold"'
 end
 
+directory '/var/run/mysql' do
+  owner 'mysql'
+  mode 0775
+end
+
 service 'mysql' do
   action [:enable, :start]
 end

--- a/cookbooks/bcpc/templates/default/apache-graphite-web.conf.erb
+++ b/cookbooks/bcpc/templates/default/apache-graphite-web.conf.erb
@@ -31,6 +31,16 @@ NameVirtualHost <%="#{node[:bcpc][:management][:ip]}"%>:443
       </IfVersion>
     </Directory>
 
+    <Directory /opt/graphite/webapp/>
+      <IfVersion < 2.4>
+        Order deny,allow
+        Allow from all
+      </IfVersion>
+      <IfVersion >= 2.4>
+        Require all granted
+      </IfVersion>
+    </Directory>
+
     Alias /static/ /opt/graphite/webapp/content/
     <Location "/content/">
         SetHandler None


### PR DESCRIPTION
The commit history has it all:
- Add the bootstrap-hosted apt repository to the chef recipes
- Store the bootstrap's apt key in a data bag item
- Use node.run_state for memoization in bcpc utils.rb 
- Affirmatively set permissions on /var/run/mysql to avoid umask issues 
- Fix permissions-related regression in graphite-web.conf