### PR TITLE
Disable NIC renaming to make installs go more smoothly on hardware with PCI NICs

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -27,7 +27,12 @@ default['bcpc']['bootstrap']['proxy'] = nil
 default['bcpc']['bootstrap']['preseed'].tap do |preseed|
   preseed['add_kernel_opts'] = 'console=ttyS0'
   preseed['additional_packages'] = %w[openssh-server lldpd]
-  preseed['late_command'] = 'true'
+
+  # Disable device renaming -- use the kernel's enumeration order.
+  preseed['late_command'] =
+    'rm /target/etc/udev/rules.d/70-persistent-net.rules; ' \
+    'touch /target/etc/udev/rules.d/75-persistent-net-generator.rules'
+
   #
   # All these lines get concatenated, hence the semicolons and
   # backslashes.

--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -31,9 +31,16 @@ def create_databag(name)
   end
 end
 
-# memrize function to bootstrap info
+# memoize bootstrap fqdn
 def get_bootstrap
-  node.run_state['bootstrap_host'] ||= get_all_nodes.select{|s| s.hostname.include? 'bootstrap'}[0].fqdn
+  node.run_state['bootstrap_host'] ||=
+    begin
+      get_all_nodes.select do |obj|
+        obj[:hostname].to_s.include?('bootstrap')
+      end.first.fqdn
+    rescue
+      nil
+    end
 end
 
 #

--- a/cookbooks/bcpc/recipes/certs.rb
+++ b/cookbooks/bcpc/recipes/certs.rb
@@ -28,7 +28,7 @@ template "/tmp/openssl.cnf" do
 end
 
 node.default[:temp][:value] = ""
-bootstrap = get_all_nodes.select{|s| s.hostname.include? 'bootstrap'}[0].fqdn
+bootstrap = get_bootstrap
 key = OpenSSL::PKey::RSA.new 2048;
 
 results = get_nodes_for("certs").map!{ |x| x['fqdn'] }.join(",")

--- a/cookbooks/bcpc/recipes/networking.rb
+++ b/cookbooks/bcpc/recipes/networking.rb
@@ -55,6 +55,26 @@ package 'powernap' do
   action :remove
 end
 
+log 'udev persistent-net.rules file found! Your NICs may have been renamed.' do
+  level :warn
+  only_if { File.exists?('/etc/udev/rules.d/70-persistent-nic.rules') }
+end
+
+#
+# Disable NIC renaming on future boots by creating an empty
+# persistent-net-generator to override the one in /lib/udev
+#
+file '/etc/udev/rules.d/75-persistent-net-generator.rules' do
+  content "# This file was created by Chef.\n" \
+          "# (It is intentionally empty.)\n"
+  mode 0444
+end
+
+# Remove existing NIC renaming rules.
+file '/etc/udev/rules.d/70-persistent-net.rules' do
+  action :delete
+end
+
 bash 'enable-ip-forwarding' do
   user 'root'
   code(


### PR DESCRIPTION
Ubuntu bundles udev rules to store persistent names for NICs.  On our current hardware, this can result in install-time enumeration orders being persisted to run-time, which breaks our ability to hardcode the 'slave' NICs in a bonding configuration.

This PR includes a "late_command" for the preseed and run-time changes in recipes to prevent NIC renaming.