### PR TITLE
The "delete-temp-file" resource is no longer used as of #622 the tempfile is deleted before

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
@@ -85,14 +85,6 @@ bash "setup-mapreduce-app" do
   only_if "#{hdfs_write} && #{hdfs_remove}", :user => "hdfs"
 end
 
-bash "delete-temp-file" do
-  code <<-EOH
-  hdfs dfs -rm /user/hdfs/chef-mapred-test
-  EOH
-  user "hdfs"
-  action :nothing
-end
-
 service "hadoop-yarn-resourcemanager" do
   action [:enable, :start]
   supports :status => true, :restart => true, :reload => false


### PR DESCRIPTION
Just a simple clean up