### PR TITLE
exposing dfs.datanode.balance.max.concurrent.moves so that it may be overridden and adjust balancer bandwidth

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -83,11 +83,6 @@ default["bcpc"]["hadoop"]["topology"]["script"] = "topology"
 default["bcpc"]["hadoop"]["topology"]["cookbook"] = "bcpc-hadoop"
 default["bcpc"]["hadoop"]["yarn"]["scheduler"]["minimum-allocation-mb"] = 256
 
-# Setting balancer bandwidth to default value as per hdfs-default.xml
-default["bcpc"]["hadoop"]["balancer"]["bandwidth"] = 1048576
-# Setting balancer max.concurrent.moves default value as per hdfs-default.xml
-default["bcpc"]["hadoop"]["balancer"]["max_concurrent_moves"] = 5
-
 #
 # Attributes for service rolling restart process
 #

--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -85,6 +85,8 @@ default["bcpc"]["hadoop"]["yarn"]["scheduler"]["minimum-allocation-mb"] = 256
 
 # Setting balancer bandwidth to default value as per hdfs-default.xml
 default["bcpc"]["hadoop"]["balancer"]["bandwidth"] = 1048576
+# Setting balancer max.concurrent.moves default value as per hdfs-default.xml
+default["bcpc"]["hadoop"]["balancer"]["max_concurrent_moves"] = 5
 
 #
 # Attributes for service rolling restart process

--- a/cookbooks/bcpc-hadoop/attributes/hdfs.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hdfs.rb
@@ -38,6 +38,9 @@ default[:bcpc][:hadoop][:hdfs][:site_xml].tap do |site_xml|
   site_xml['dfs.datanode.balance.bandwidthPerSec'] =
     node[:bcpc][:hadoop][:balancer][:bandwidth]
 
+  site_xml['dfs.datanode.balance.max.concurrent.moves'] =
+    node[:bcpc][:hadoop][:balancer][:max_concurrent_moves]
+
   site_xml['dfs.nameservices'] = node.chef_environment
 
   site_xml['dfs.datanode.failed.volumes.tolerated'] =

--- a/cookbooks/bcpc-hadoop/attributes/hdfs.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hdfs.rb
@@ -1,12 +1,8 @@
+# vim: tabstop=2:shiftwidth=2:softtabstop=2 
 # Setting balancer andwidth to default value as per hdfs-default.xml
 default["hadoop"]["hdfs"]["balancer"]["bandwidth"] = 1048576
-# Setting balancer max.concurrent.moves default value as per hdfs-default.xml
-# Apache docs recommend that the number of move threads a multiple
-# of data disks
+# balancer thread multiplier constant
 default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier"] = 10
-default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves"] =
-  node[:bcpc][:hadoop][:mounts].length *
-  default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier"]
 
 default[:bcpc][:hadoop][:hdfs][:dfs].tap do |dfs|
   dfs[:namenode][:audit][:log][:async] = true

--- a/cookbooks/bcpc-hadoop/attributes/hdfs.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hdfs.rb
@@ -1,10 +1,12 @@
+# In order to set balancer bandwidth we need to discover our floating interface
+# And find its bandwidth
 # Setting balancer bandwidth to default value as per hdfs-default.xml
 default["hadoop"]["hdfs"]["balancer"]["bandwidth"] = 1048576
 # Setting balancer max.concurrent.moves default value as per hdfs-default.xml
 # Apache docs recommend that the number of move threads a multiple
 # of data disks
 default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier_constant"] = 10
-default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves"] = node[:bcpc][:hadoop][:mounts] * default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier_constant"]
+default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves"] = node[:bcpc][:hadoop][:mounts].length * default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier_constant"]
 
 default[:bcpc][:hadoop][:hdfs][:dfs].tap do |dfs|
   dfs[:namenode][:audit][:log][:async] = true
@@ -47,7 +49,7 @@ default[:bcpc][:hadoop][:hdfs][:site_xml].tap do |site_xml|
     node[:bcpc][:hadoop][:balancer][:bandwidth]
 
   site_xml['dfs.datanode.balance.max.concurrent.moves'] =
-    node[:bcpc][:hadoop][:balancer][:max_concurrent_moves]
+    node[:hadoop][:hdfs][:balancer][:max_concurrent_moves]
 
   site_xml['dfs.nameservices'] = node.chef_environment
 

--- a/cookbooks/bcpc-hadoop/attributes/hdfs.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hdfs.rb
@@ -1,12 +1,12 @@
-# In order to set balancer bandwidth we need to discover our floating interface
-# And find its bandwidth
-# Setting balancer bandwidth to default value as per hdfs-default.xml
+# Setting balancer andwidth to default value as per hdfs-default.xml
 default["hadoop"]["hdfs"]["balancer"]["bandwidth"] = 1048576
 # Setting balancer max.concurrent.moves default value as per hdfs-default.xml
 # Apache docs recommend that the number of move threads a multiple
 # of data disks
-default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier_constant"] = 10
-default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves"] = node[:bcpc][:hadoop][:mounts].length * default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier_constant"]
+default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier"] = 10
+default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves"] =
+  node[:bcpc][:hadoop][:mounts].length *
+  default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier"]
 
 default[:bcpc][:hadoop][:hdfs][:dfs].tap do |dfs|
   dfs[:namenode][:audit][:log][:async] = true
@@ -44,9 +44,6 @@ default[:bcpc][:hadoop][:hdfs][:site_xml].tap do |site_xml|
   
   site_xml['dfs.namenode.audit.log.async'] =
     dfs[:namenode][:audit][:log][:async]
-
-  site_xml['dfs.datanode.balance.bandwidthPerSec'] =
-    node[:bcpc][:hadoop][:balancer][:bandwidth]
 
   site_xml['dfs.datanode.balance.max.concurrent.moves'] =
     node[:hadoop][:hdfs][:balancer][:max_concurrent_moves]

--- a/cookbooks/bcpc-hadoop/attributes/hdfs.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hdfs.rb
@@ -1,3 +1,11 @@
+# Setting balancer bandwidth to default value as per hdfs-default.xml
+default["hadoop"]["hdfs"]["balancer"]["bandwidth"] = 1048576
+# Setting balancer max.concurrent.moves default value as per hdfs-default.xml
+# Apache docs recommend that the number of move threads a multiple
+# of data disks
+default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier_constant"] = 10
+default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves"] = node[:bcpc][:hadoop][:mounts] * default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier_constant"]
+
 default[:bcpc][:hadoop][:hdfs][:dfs].tap do |dfs|
   dfs[:namenode][:audit][:log][:async] = true
   dfs[:webhdfs][:enabled] = true

--- a/cookbooks/bcpc-hadoop/attributes/hdfs.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hdfs.rb
@@ -41,8 +41,6 @@ default[:bcpc][:hadoop][:hdfs][:site_xml].tap do |site_xml|
   site_xml['dfs.namenode.audit.log.async'] =
     dfs[:namenode][:audit][:log][:async]
 
-  site_xml['dfs.datanode.balance.max.concurrent.moves'] =
-    node[:hadoop][:hdfs][:balancer][:max_concurrent_moves]
 
   site_xml['dfs.nameservices'] = node.chef_environment
 

--- a/cookbooks/bcpc-hadoop/recipes/hdfs_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hdfs_site.rb
@@ -1,18 +1,15 @@
-ruby_block "calculate_interface_bandwidth" do
-  block do
-    subnet = node[:bcpc][:management][:subnet]
-    interface = node[:bcpc][:networks][subnet][:floating][:interface]
-    fh = File::open("/sys/class/net/#{interface}/speed", "r")
-    node.run_state["balancer_bandwidth"] = do
-      # get if speed convert from MBps to bits
-      # convert to octets
-      if_speed =  fh.readline.chom.to_i * 1000000 / 8
-    rescue
-      node["hadoop"]["hdfs"]["balancer"]["bandwidth"]
-    end
-  end
+# vim: tabstop=2:shiftwidth=2:softtabstop=2 
+subnet = node[:bcpc][:management][:subnet]
+interface = node[:bcpc][:networks][subnet][:floating][:interface]
+node.run_state["balancer_bandwidth"] = begin
+  # get if speed convert from MBps to bits
+  # convert to octets
+  fh = File::open("/sys/class/net/#{interface}/speed", "r")
+  (fh.readline.chomp.to_i * 1000000 / 8).to_s
+rescue
+  node["hadoop"]["hdfs"]["balancer"]["bandwidth"]
 end
-      
+  
 hdfs_site_values = node[:bcpc][:hadoop][:hdfs][:site_xml]
 
 hdfs_site_generated_values =

--- a/cookbooks/bcpc-hadoop/recipes/hdfs_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hdfs_site.rb
@@ -14,7 +14,7 @@ hdfs_site_values = node[:bcpc][:hadoop][:hdfs][:site_xml]
 
 hdfs_site_generated_values =
 {
- 'dfs.datanode.balance.bandwidthPerSec' =
+ 'dfs.datanode.balance.bandwidthPerSec' =>
    node.run_state["balancer_bandwidth"],   
 
  'dfs.namenode.name.dir' =>

--- a/cookbooks/bcpc-hadoop/recipes/hdfs_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hdfs_site.rb
@@ -10,15 +10,20 @@ rescue
   node["hadoop"]["hdfs"]["balancer"]["bandwidth"]
 end
 
-default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves"] =
+# Setting balancer max.concurrent.moves default value as per hdfs-default.xml
+# Apache docs recommend that the number of move threads a multiple
+# of data disks
+node.default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves"] =
   node[:bcpc][:hadoop][:mounts].length *
-  default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier"]
+  node["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier"]
 
-  
 hdfs_site_values = node[:bcpc][:hadoop][:hdfs][:site_xml]
 
 hdfs_site_generated_values =
 {
+ 'dfs.datanode.balance.max.concurrent.moves' =>
+    node[:hadoop][:hdfs][:balancer][:max_concurrent_moves],
+
  'dfs.datanode.balance.bandwidthPerSec' =>
    node.run_state["balancer_bandwidth"],   
 

--- a/cookbooks/bcpc-hadoop/recipes/hdfs_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hdfs_site.rb
@@ -9,6 +9,11 @@ node.run_state["balancer_bandwidth"] = begin
 rescue
   node["hadoop"]["hdfs"]["balancer"]["bandwidth"]
 end
+
+default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves"] =
+  node[:bcpc][:hadoop][:mounts].length *
+  default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier"]
+
   
 hdfs_site_values = node[:bcpc][:hadoop][:hdfs][:site_xml]
 

--- a/cookbooks/bcpc-hadoop/recipes/hdfs_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hdfs_site.rb
@@ -1,253 +1,299 @@
-# vim: tabstop=2:shiftwidth=2:softtabstop=2 
+# vim: tabstop=2:shiftwidth=2:softtabstop=2:expandtabs 
 subnet = node[:bcpc][:management][:subnet]
-interface = node[:bcpc][:networks][subnet][:floating][:interface]
-node.run_state["balancer_bandwidth"] = begin
-  # get if speed convert from MBps to bits
-  # convert to octets
-  fh = File::open("/sys/class/net/#{interface}/speed", "r")
-  (fh.readline.chomp.to_i * 1000000 / 8).to_s
-rescue
-  node["hadoop"]["hdfs"]["balancer"]["bandwidth"]
+hdfs_site_values = node[:bcpc][:hadoop][:hdfs][:site_xml]
+
+ruby_block 'calculate_speed' do
+  block do
+    default_speed = node['hadoop']['hdfs']['balancer']['bandwidth']
+    maximum_nic_speed = Dir.glob('/sys/class/net/*/speed').map do |ff|
+      File.read(ff).chomp.to_i rescue 1000
+    end.compact.max
+
+    node.run_state['balancer_bandwidth'] =
+      [default_speed, maximum_nic_speed * 10**6 / 8].max
+  end
 end
 
 # Setting balancer max.concurrent.moves default value as per hdfs-default.xml
 # Apache docs recommend that the number of move threads a multiple
 # of data disks
-node.default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves"] =
-  node[:bcpc][:hadoop][:mounts].length *
-  node["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier"]
-
-hdfs_site_values = node[:bcpc][:hadoop][:hdfs][:site_xml]
-
-hdfs_site_generated_values =
-{
- 'dfs.datanode.balance.max.concurrent.moves' =>
-    node[:hadoop][:hdfs][:balancer][:max_concurrent_moves],
-
- 'dfs.datanode.balance.bandwidthPerSec' =>
-   node.run_state["balancer_bandwidth"],   
-
- 'dfs.namenode.name.dir' =>
-   node[:bcpc][:hadoop][:mounts]
-   .map{ |d| "file:///disk/#{d}/dfs/nn" }.join(','),
-
- "dfs.ha.namenodes.#{node.chef_environment}" =>
-   node[:bcpc][:hadoop][:nn_hosts]
-   .map{ |s| "namenode#{s[:node_number]}" }.join(','),
- 
- 'dfs.datanode.data.dir' =>
-   node[:bcpc][:hadoop][:mounts]
-   .map{ |d| "file:///disk/#{d}/dfs/dn" }.join(','),
-
- 'dfs.journalnode.edits.dir' =>
-   File.join('/disk', node[:bcpc][:hadoop][:mounts][0].to_s, 'dfs', 'jn'),
-
- 'dfs.client.local.interfaces' =>
-   node['bcpc']['floating']['ip'] + '/32'
-}
-
-# Using 'map', a hash is built for each host.
-# Using 'reduce', all host hashes are consolidated into a single hash.
-namenode_properties = node[:bcpc][:hadoop][:nn_hosts].map do |host|
-  {
-   'dfs.namenode.rpc-address.' + node.chef_environment +
-     '.namenode' + host[:node_number].to_s =>
-     float_host(host[:hostname]) + ':' +
-     node[:bcpc][:hadoop][:namenode][:rpc][:port].to_s,
-   
-   'dfs.namenode.http-address.' + node.chef_environment +
-     '.namenode' + host[:node_number].to_s =>
-     float_host(host[:hostname]) + ':' +
-     node[:bcpc][:hadoop][:namenode][:http][:port].to_s,
-   
-   'dfs.namenode.https-address.' + node.chef_environment +
-     '.namenode' + host[:node_number].to_s =>
-     float_host(host[:hostname]) + ':' +
-     node[:bcpc][:hadoop][:namenode][:https][:port].to_s,
-  }
-end.reduce({},:merge)
-hdfs_site_generated_values.merge!(namenode_properties)
-
-if node[:bcpc][:hadoop][:kerberos][:enable]
-  dfs = node[:bcpc][:hadoop][:hdfs][:dfs]
-
-  kerberos_data = node[:bcpc][:hadoop][:kerberos][:data]
-
-  if kerberos_data[:spnego][:princhost] == '_HOST'
-    spnego_host = '_HOST'
-  else
-    spnego_host = kerberos_data[:spnego][:princhost]
+ruby_block "calculate max_concurrent_moves" do
+  block do
+    node.run_state['max_concurrent_moves'] =
+      node[:bcpc][:hadoop][:mounts].length *
+      node['hadoop']['hdfs']['balancer']['max_concurrent_moves_multiplier']
   end
-
-  spnego_principal =
-    kerberos_data[:spnego][:principal] + '/' + spnego_host + '@' +
-    node[:bcpc][:hadoop][:kerberos][:realm]
-
-  spnego_keytab = File.join(node[:bcpc][:hadoop][:kerberos][:keytab][:dir],
-                            kerberos_data[:namenode][:spnego_keytab])
-
-  if kerberos_data[:namenode][:princhost] == '_HOST'
-    namenode_host = '_HOST'
-  else
-    namenode_host = kerberos_data[:namenode][:princhost]
-  end
-
-  namenode_principal =
-    kerberos_data[:namenode][:principal] + '/' + namenode_host + '@' +
-    node[:bcpc][:hadoop][:kerberos][:realm]
-
-  namenode_keytab = File.join(node[:bcpc][:hadoop][:kerberos][:keytab][:dir],
-                            kerberos_data[:namenode][:keytab])
-  
-  if kerberos_data[:datanode][:princhost] == '_HOST'
-    dn_host = if node.run_list.expand(node.chef_environment).recipes
-                  .include?('bcpc-hadoop::datanode')
-                float_host(node[:fqdn])
-              else
-                kerberos_data[:datanode][:princhost]
-              end
-  else
-    dn_host = kerberos_data[:datanode][:princhost]
-  end
-  
-  datanode_principal =
-    kerberos_data[:datanode][:principal] + '/' + dn_host + '@' +
-    node[:bcpc][:hadoop][:kerberos][:realm]
-
-  datanode_keytab = File.join(node[:bcpc][:hadoop][:kerberos][:keytab][:dir],
-                              kerberos_data[:datanode][:keytab])
-    
-
-  kerberos_properties =
-    {
-     'dfs.permissions.enabled' => true,
-
-     'dfs.block.access.token.enable' => true,
-
-     'dfs.permissions.superusergroup' =>
-       dfs[:permissions][:superusergroup],
-
-     'dfs.web.authentication.kerberos.principal' =>
-       spnego_principal,
-     
-     'dfs.web.authentication.kerberos.keytab' =>
-       spnego_keytab,
-
-     'dfs.namenode.kerberos.principal' =>
-       namenode_principal,
-     
-     'dfs.namenode.keytab.file' =>
-       namenode_keytab,
-
-     'dfs.datanode.kerberos.principal' =>
-       datanode_principal,
-     
-     'dfs.datanode.keytab.file' =>
-       datanode_keytab,
-
-     'dfs.cluster.administrators' =>
-       dfs[:cluster][:administrators],
-
-     'dfs.namenode.kerberos.internal.spnego.principal' =>
-       '${dfs.web.authentication.kerberos.principal}',
-
-     'dfs.secondary.namenode.kerberos.internal.spnego.principal' =>
-       '${dfs.web.authentication.kerberos.principal}',
-    }
-
-  if node.run_list.expand(node.chef_environment).recipes
-      .include?('bcpc-hadoop::journalnode')
-
-    if kerberos_data[:journalnode][:princhost] == '_HOST'
-      jn_host = "_HOST"
-    else
-      jn_host = kerberos_data[:journalnode][:princhost]
-    end
-    
-    jn_principal =
-      kerberos_data[:journalnode][:principal] + '/' + jn_host + '@' +
-      node[:bcpc][:hadoop][:kerberos][:realm]
-
-    jn_keytab = File.join(node[:bcpc][:hadoop][:kerberos][:keytab][:dir],
-                          kerberos_data[:journalnode][:keytab])
-    
-    jn_properties =
-      {
-       'dfs.journalnode.keytab.file' =>
-         jn_keytab,
-       
-       'dfs.journalnode.kerberos.principal' =>
-         jn_principal,
-       
-       'dfs.journalnode.kerberos.internal.spnego.principal' =>
-         spnego_principal
-      }
-    kerberos_properties.merge!(jn_properties)
-  end
-  
-  hdfs_site_generated_values.merge!(kerberos_properties)
 end
 
-if node.run_list.expand(node.chef_environment).recipes
-    .include?('bcpc-hadoop::journalnode')
-  
-  jn_properties =
+ruby_block "hdfs_site_generated_values_common" do
+  block do
+    node.run_state['hdfs_site_generated_values'] =
     {
-     'dfs.journalnode.rpc-address' =>
-       node[:bcpc][:floating][:ip] + ':8485',
+     'dfs.namenode.name.dir' =>
+       node[:bcpc][:hadoop][:mounts]
+       .map{ |d| "file:///disk/#{d}/dfs/nn" }.join(','),
+
+     "dfs.ha.namenodes.#{node.chef_environment}" =>
+       node[:bcpc][:hadoop][:nn_hosts]
+       .map{ |s| "namenode#{s[:node_number]}" }.join(','),
      
-     'dfs.journalnode.http-address' =>
-       node[:bcpc][:floating][:ip] + ':8480',
-     
-     'dfs.journalnode.https-address' =>
-       node[:bcpc][:floating][:ip] + ':8481',
-    }
+     'dfs.datanode.data.dir' =>
+       node[:bcpc][:hadoop][:mounts]
+       .map{ |d| "file:///disk/#{d}/dfs/dn" }.join(','),
 
-  hdfs_site_generated_values.merge!(jn_properties)
-end
-
-
-if node.run_list.expand(node.chef_environment).recipes
-    .include?('bcpc-hadoop::datanode')
-  
-  dn_properties =
-    {
-     'dfs.datanode.address' =>
-       node[:bcpc][:floating][:ip] + ':1004',
-     
-     'dfs.datanode.http.address' =>
-       node[:bcpc][:floating][:ip] + ':1006',
-    }
-
-  hdfs_site_generated_values.merge!(dn_properties)
-end
-
-if node[:bcpc][:hadoop][:hdfs][:HA]
-  # This is a cached node search.
-  zk_hosts = node[:bcpc][:hadoop][:zookeeper][:servers]
-  
-  ha_properties =
-    {
-     'ha.zookeeper.quorum' =>
-       zk_hosts.map{ |s| float_host(s[:hostname]) +
-         ":#{node[:bcpc][:hadoop][:zookeeper][:port]}" }.join(','),
-     
-     'dfs.namenode.shared.edits.dir' =>
-       'qjournal://' +
-       zk_hosts.map{ |s| float_host(s[:hostname]) + ":8485" }.join(";") +
-       '/' + node.chef_environment,
-
-     # Why is this added twice?
      'dfs.journalnode.edits.dir' =>
-       File.join('/disk', node[:bcpc][:hadoop][:mounts][0].to_s, 'dfs', 'jn')
+       File.join('/disk', node[:bcpc][:hadoop][:mounts][0].to_s, 'dfs', 'jn'),
+
+     'dfs.client.local.interfaces' =>
+       node['bcpc']['floating']['ip'] + '/32'
     }
-  hdfs_site_generated_values.merge!(ha_properties)
+  end
 end
 
-complete_hdfs_site_hash = hdfs_site_generated_values.merge(hdfs_site_values)
+ruby_block "hdfs_site_generated_values_balancer_properties" do
+  block do
+    balancer_properties = {
+     'dfs.datanode.balance.max.concurrent.moves' =>
+        node[:hadoop][:hdfs][:balancer][:max_concurrent_moves],
+
+     'dfs.datanode.balance.bandwidthPerSec' =>
+       node.run_state["balancer_bandwidth"]
+    }
+
+    node.run_state['hdfs_site_generated_values'].merge!(balancer_properties)
+  end
+end
+
+
+ruby_block "hdfs_site_generated_values_nn_properties" do
+  block do
+    # Using 'map', a hash is built for each host.
+    # Using 'reduce', all host hashes are consolidated into a single hash.
+    namenode_properties = node[:bcpc][:hadoop][:nn_hosts].map do |host|
+      {
+       'dfs.namenode.rpc-address.' + node.chef_environment +
+         '.namenode' + host[:node_number].to_s =>
+         float_host(host[:hostname]) + ':' +
+         node[:bcpc][:hadoop][:namenode][:rpc][:port].to_s,
+       
+       'dfs.namenode.http-address.' + node.chef_environment +
+         '.namenode' + host[:node_number].to_s =>
+         float_host(host[:hostname]) + ':' +
+         node[:bcpc][:hadoop][:namenode][:http][:port].to_s,
+       
+       'dfs.namenode.https-address.' + node.chef_environment +
+         '.namenode' + host[:node_number].to_s =>
+         float_host(host[:hostname]) + ':' +
+         node[:bcpc][:hadoop][:namenode][:https][:port].to_s,
+      }
+    end.reduce({},:merge)
+    node.run_state['hdfs_site_generated_values'].merge!(namenode_properties)
+  end
+end
+
+ruby_block "hdfs_site_generated_values_krb_properties" do
+  block do
+    if node[:bcpc][:hadoop][:kerberos][:enable]
+      dfs = node[:bcpc][:hadoop][:hdfs][:dfs]
+
+      kerberos_data = node[:bcpc][:hadoop][:kerberos][:data]
+
+      if kerberos_data[:spnego][:princhost] == '_HOST'
+        spnego_host = '_HOST'
+      else
+        spnego_host = kerberos_data[:spnego][:princhost]
+      end
+
+      spnego_principal =
+        kerberos_data[:spnego][:principal] + '/' + spnego_host + '@' +
+        node[:bcpc][:hadoop][:kerberos][:realm]
+
+      spnego_keytab = File.join(node[:bcpc][:hadoop][:kerberos][:keytab][:dir],
+                                kerberos_data[:namenode][:spnego_keytab])
+
+      if kerberos_data[:namenode][:princhost] == '_HOST'
+        namenode_host = '_HOST'
+      else
+        namenode_host = kerberos_data[:namenode][:princhost]
+      end
+
+      namenode_principal =
+        kerberos_data[:namenode][:principal] + '/' + namenode_host + '@' +
+        node[:bcpc][:hadoop][:kerberos][:realm]
+
+      namenode_keytab = File.join(node[:bcpc][:hadoop][:kerberos][:keytab][:dir],
+                                kerberos_data[:namenode][:keytab])
+      
+      if kerberos_data[:datanode][:princhost] == '_HOST'
+        dn_host = if node.run_list.expand(node.chef_environment).recipes
+                      .include?('bcpc-hadoop::datanode')
+                    float_host(node[:fqdn])
+                  else
+                    kerberos_data[:datanode][:princhost]
+                  end
+      else
+        dn_host = kerberos_data[:datanode][:princhost]
+      end
+      
+      datanode_principal =
+        kerberos_data[:datanode][:principal] + '/' + dn_host + '@' +
+        node[:bcpc][:hadoop][:kerberos][:realm]
+
+      datanode_keytab = File.join(node[:bcpc][:hadoop][:kerberos][:keytab][:dir],
+                                  kerberos_data[:datanode][:keytab])
+        
+
+      kerberos_properties =
+        {
+         'dfs.permissions.enabled' => true,
+
+         'dfs.block.access.token.enable' => true,
+
+         'dfs.permissions.superusergroup' =>
+           dfs[:permissions][:superusergroup],
+
+         'dfs.web.authentication.kerberos.principal' =>
+           spnego_principal,
+         
+         'dfs.web.authentication.kerberos.keytab' =>
+           spnego_keytab,
+
+         'dfs.namenode.kerberos.principal' =>
+           namenode_principal,
+         
+         'dfs.namenode.keytab.file' =>
+           namenode_keytab,
+
+         'dfs.datanode.kerberos.principal' =>
+           datanode_principal,
+         
+         'dfs.datanode.keytab.file' =>
+           datanode_keytab,
+
+         'dfs.cluster.administrators' =>
+           dfs[:cluster][:administrators],
+
+         'dfs.namenode.kerberos.internal.spnego.principal' =>
+           '${dfs.web.authentication.kerberos.principal}',
+
+         'dfs.secondary.namenode.kerberos.internal.spnego.principal' =>
+           '${dfs.web.authentication.kerberos.principal}',
+        }
+
+      if node.run_list.expand(node.chef_environment).recipes
+          .include?('bcpc-hadoop::journalnode')
+
+        if kerberos_data[:journalnode][:princhost] == '_HOST'
+          jn_host = "_HOST"
+        else
+          jn_host = kerberos_data[:journalnode][:princhost]
+        end
+        
+        jn_principal =
+          kerberos_data[:journalnode][:principal] + '/' + jn_host + '@' +
+          node[:bcpc][:hadoop][:kerberos][:realm]
+
+        jn_keytab = File.join(node[:bcpc][:hadoop][:kerberos][:keytab][:dir],
+                              kerberos_data[:journalnode][:keytab])
+        
+        jn_properties =
+          {
+           'dfs.journalnode.keytab.file' =>
+             jn_keytab,
+           
+           'dfs.journalnode.kerberos.principal' =>
+             jn_principal,
+           
+           'dfs.journalnode.kerberos.internal.spnego.principal' =>
+             spnego_principal
+          }
+        kerberos_properties.merge!(jn_properties)
+      end
+      
+      node.run_state['hdfs_site_generated_values'].merge!(kerberos_properties)
+    end
+  end
+end
+
+  
+ruby_block "hdfs_site_generated_values_jn_properties" do
+  block do
+    if node.run_list.expand(node.chef_environment).recipes
+        .include?('bcpc-hadoop::journalnode')
+      jn_properties =
+        {
+         'dfs.journalnode.rpc-address' =>
+           node[:bcpc][:floating][:ip] + ':8485',
+         
+         'dfs.journalnode.http-address' =>
+           node[:bcpc][:floating][:ip] + ':8480',
+         
+         'dfs.journalnode.https-address' =>
+           node[:bcpc][:floating][:ip] + ':8481',
+        }
+
+       node.run_state['hdfs_site_generated_values'].merge!(jn_properties)
+    end
+  end
+end
+
+
+ruby_block "hdfs_site_generated_values_dn_properties" do
+  block do
+    if node.run_list.expand(node.chef_environment).recipes
+        .include?('bcpc-hadoop::datanode')
+      
+      dn_properties =
+        {
+         'dfs.datanode.address' =>
+           node[:bcpc][:floating][:ip] + ':1004',
+         
+         'dfs.datanode.http.address' =>
+           node[:bcpc][:floating][:ip] + ':1006',
+        }
+
+      node.run_state['hdfs_site_generated_values'].merge!(dn_properties)
+    end
+  end
+end
+
+ruby_block "hdfs_site_generated_values_ha_properties" do
+  block do
+    if node[:bcpc][:hadoop][:hdfs][:HA]
+      # This is a cached node search.
+      zk_hosts = node[:bcpc][:hadoop][:zookeeper][:servers]
+      
+      ha_properties =
+        {
+         'ha.zookeeper.quorum' =>
+           zk_hosts.map{ |s| float_host(s[:hostname]) +
+             ":#{node[:bcpc][:hadoop][:zookeeper][:port]}" }.join(','),
+         
+         'dfs.namenode.shared.edits.dir' =>
+           'qjournal://' +
+           zk_hosts.map{ |s| float_host(s[:hostname]) + ":8485" }.join(";") +
+           '/' + node.chef_environment,
+
+         # Why is this added twice?
+         'dfs.journalnode.edits.dir' =>
+           File.join('/disk', node[:bcpc][:hadoop][:mounts][0].to_s, 'dfs', 'jn')
+        }
+      node.run_state['hdfs_site_generated_values'].merge!(ha_properties)
+    end
+  end
+end
+
+ruby_block "complete_hdfs_site_hash" do 
+  block do
+    node.run_state['complete_hdfs_site_hash'] = 
+      node.run_state['hdfs_site_generated_values'].merge(hdfs_site_values)
+  end
+end
 
 template "/etc/hadoop/conf/hdfs-site.xml" do
   source "generic_site.xml.erb"
   mode 0644
-  variables(:options => complete_hdfs_site_hash)
+  variables ( lazy { 
+    { :options => node.run_state['complete_hdfs_site_hash'] }
+  })
 end


### PR DESCRIPTION
set dfs.datanode.balance.max.concurrent.moves to multiplier constant * number of disks mounted /disk
````
node.default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves"] =
  node[:bcpc][:hadoop][:mounts].length *
  node["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier"]
````

set dfs.datanode.balance.bandwidthPerSec to the bandwidth of the interface, failing that default that can be overridden **default["hadoop"]["hdfs"]["balancer"]["bandwidth"] = 1048576**


