### PR TITLE
Restore (correctly) dangling quote in percona password preseed

### DIFF
--- a/cookbooks/bcpc/recipes/mysql.rb
+++ b/cookbooks/bcpc/recipes/mysql.rb
@@ -56,7 +56,7 @@ package 'debconf-utils'
   execute "percona-preseed-#{preseed_item}" do
     command 'echo "percona-xtradb-cluster-server-5.6 ' \
       "percona-xtradb-cluster-server/#{preseed_item} " \
-      "password \"#{root_password}\" | debconf-set-selections"
+      "password #{root_password}\" | debconf-set-selections"
     sensitive true if respond_to?(:sensitive)
   end
 end


### PR DESCRIPTION
Turns out that dangling quote was correct, the matching double quote is on line 57.