### PR TITLE
Affirmatively upgrade xtrabackup, don't just verify installation

### DIFF
--- a/cookbooks/bcpc/recipes/mysql.rb
+++ b/cookbooks/bcpc/recipes/mysql.rb
@@ -102,7 +102,7 @@ end
 
 # This package is needed to be a donor in the SST process.
 package 'percona-xtrabackup' do
-  action :install
+  action :upgrade
 end
 
 directory '/var/run/mysql' do


### PR DESCRIPTION
This is another attempt to fix issue #700.

On hosts that already have xtrabackup installed, it can be too old a version for percona 5.6 to successfully do an initial state transfer.