### PR TITLE
enable hbase timeline consistency

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hbase.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hbase.rb
@@ -81,5 +81,12 @@ default[:bcpc][:hadoop][:hbase][:site_xml].tap do |site_xml|
   site_xml['hbase.ipc.server.tcpnodelay'] = 'true'
   site_xml['hbase.replication'] = 'true'
   site_xml['hbase.coprocessor.abortonerror'] = node["bcpc"]["hadoop"]["hbase_rs"]["coprocessor"]["abortonerror"] 
+  site_xml['hbase.regionserver.storefile.refresh.period'] = 30000
+  site_xml['hbase.region.replica.replication.enabled'] = true
+  site_xml['hbase.master.hfilecleaner.ttl'] = 3600000
+  site_xml['hbase.master.loadbalancer.class'] = 'org.apache.hadoop.hbase.master.balancer.StochasticLoadBalancer'
+  site_xml['hbase.meta.replica.count'] = 3
+  site_xml['hbase.regionserver.meta.storefile.refresh.period'] = 30000
+  site_xml['hbase.region.replica.wait.for.primary.flush'] = true
 end
 


### PR DESCRIPTION
This change is to enable hbase timeline consistency / HA Read 

![region_replication](https://cloud.githubusercontent.com/assets/4019043/20690871/283903ee-b59b-11e6-9065-febecf60575f.jpg)

````
hbase(main):001:0> create 't1','cf1', {REGION_REPLICATION => 2}
0 row(s) in 2.6490 seconds

=> Hbase::Table - t1
hbase(main):002:0> put 't1','r1','cf1:c1','v1'
0 row(s) in 0.2110 seconds

hbase(main):003:0> scan 't1'
ROW                                  COLUMN+CELL
 r1                                  column=cf1:c1, timestamp=1480376425731, value=v1
1 row(s) in 0.0620 seconds

hbase(main):004:0> put 't1','r2','cf1:c1','v2'
0 row(s) in 0.0070 seconds

hbase(main):005:0> put 't1','r3','cf1:c1','v3'
0 row(s) in 0.0090 seconds

hbase(main):006:0> scan 't1'
ROW                                  COLUMN+CELL
 r1                                  column=cf1:c1, timestamp=1480376425731, value=v1
 r2                                  column=cf1:c1, timestamp=1480376436201, value=v2
 r3                                  column=cf1:c1, timestamp=1480376441296, value=v3
3 row(s) in 0.0170 seconds
````

N.B. Unfortunately it does not appear that HBase will offer any sort of tie ID/Key and it may be difficult to identify if one region is a replica of the other with multiple regions present