### PR TITLE
Use fast LACPDUs by default (1s vs 30s) and monitor link status

### DIFF
--- a/cookbooks/bcpc/templates/default/network-interface-pre-up.sh.erb
+++ b/cookbooks/bcpc/templates/default/network-interface-pre-up.sh.erb
@@ -16,6 +16,12 @@ if ! grep 4 $MODE_PATH; then
     echo 4 > $MODE_PATH
 fi
 
+LACP_RATE_PATH=/sys/class/net/<%= @interface %>/bonding/lacp_rate
+if ! grep 1 $LACP_RATE_PATH; then
+    ip link set <%= @interface %> down
+    echo 1 > $LACP_RATE_PATH
+fi
+
 SLAVE_PATH=/sys/class/net/<%= @interface %>/bonding/slaves
 <% (@slaves or []).each do |slave| %>
 if ! grep <%= slave %> $SLAVE_PATH; then

--- a/cookbooks/bcpc/templates/default/network-interface-pre-up.sh.erb
+++ b/cookbooks/bcpc/templates/default/network-interface-pre-up.sh.erb
@@ -22,6 +22,12 @@ if ! grep 1 $LACP_RATE_PATH; then
     echo 1 > $LACP_RATE_PATH
 fi
 
+MIIMON_PATH=/sys/class/net/<%= @interface %>/bonding/miimon
+if ! grep 100 $MIIMON_PATH; then
+    ip link set <%= @interface %> down
+    echo 100 > $MIIMON_PATH
+fi
+
 SLAVE_PATH=/sys/class/net/<%= @interface %>/bonding/slaves
 <% (@slaves or []).each do |slave| %>
 if ! grep <%= slave %> $SLAVE_PATH; then

--- a/cookbooks/bcpc/templates/default/network-interface-pre-up.sh.erb
+++ b/cookbooks/bcpc/templates/default/network-interface-pre-up.sh.erb
@@ -28,6 +28,12 @@ if ! grep -q 100 $MIIMON_PATH; then
     echo 100 > $MIIMON_PATH
 fi
 
+XMIT_HASH_POLICY_PATH=/sys/class/net/<%= @interface %>/bonding/xmit_hash_policy
+if ! grep -q "layer3+4" $XMIT_HASH_POLICY_PATH; then
+    ip link set <%= @interface %> down
+    echo "layer3+4" > $XMIT_HASH_POLICY_PATH
+fi
+
 SLAVE_PATH=/sys/class/net/<%= @interface %>/bonding/slaves
 <% (@slaves or []).each do |slave| %>
 if ! grep -q "<%= slave %>" $SLAVE_PATH; then

--- a/cookbooks/bcpc/templates/default/network-interface-pre-up.sh.erb
+++ b/cookbooks/bcpc/templates/default/network-interface-pre-up.sh.erb
@@ -6,34 +6,34 @@
 #
 
 MASTERS_PATH=/sys/class/net/bonding_masters
-if ! grep <%= @interface %> $MASTERS_PATH; then
-    echo +<%= @interface %> > $MASTERS_PATH
+if ! grep -q "<%= @interface %>" $MASTERS_PATH; then
+    echo "+<%= @interface %>" > $MASTERS_PATH
 fi
 
 MODE_PATH=/sys/class/net/<%= @interface %>/bonding/mode
-if ! grep 4 $MODE_PATH; then
+if ! grep -q 4 $MODE_PATH; then
     ip link set <%= @interface %> down
     echo 4 > $MODE_PATH
 fi
 
 LACP_RATE_PATH=/sys/class/net/<%= @interface %>/bonding/lacp_rate
-if ! grep 1 $LACP_RATE_PATH; then
+if ! grep -q 1 $LACP_RATE_PATH; then
     ip link set <%= @interface %> down
     echo 1 > $LACP_RATE_PATH
 fi
 
 MIIMON_PATH=/sys/class/net/<%= @interface %>/bonding/miimon
-if ! grep 100 $MIIMON_PATH; then
+if ! grep -q 100 $MIIMON_PATH; then
     ip link set <%= @interface %> down
     echo 100 > $MIIMON_PATH
 fi
 
 SLAVE_PATH=/sys/class/net/<%= @interface %>/bonding/slaves
 <% (@slaves or []).each do |slave| %>
-if ! grep <%= slave %> $SLAVE_PATH; then
+if ! grep -q "<%= slave %>" $SLAVE_PATH; then
     ip link set <%= @interface %> down
     ip link set <%= slave %> down
-    echo +<%= slave %> > $SLAVE_PATH
+    echo "+<%= slave %>" > $SLAVE_PATH
 fi
 <% end %>
 


### PR DESCRIPTION
This change should ensure switches will notice downed interfaces faster, as it switches the LACPDU rate to fast mode - once per second. In theory, it could take up to 3 LACPDU intervals for a switch to mark an interface in a portchannel/bridge as unresponsive. This brings the potential delay from 90 seconds down to 3 seconds, at a very minimal cost of bandwidth (110-bytes per LACPDU). 