### PR TITLE
Enable Yarn Aplication Timeline Server in chef-bach

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
@@ -157,6 +157,7 @@ service "hadoop-yarn-timelineserver" do
   subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
   subscribes :restart, "bash[hdp-select hadoop-yarn-resourcemanager]", :delayed
   subscribes :restart, "log[jdk-version-changed]", :delayed
+  only_if { node.roles.include?("BCPC-Hadoop-Head-YarnTimeLineServer") }
 end
 
 bash "reload mapreduce nodes" do

--- a/cookbooks/bcpc-hadoop/recipes/yarn_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/yarn_site.rb
@@ -241,7 +241,7 @@ if node.roles.include?("BCPC-Hadoop-Head-YarnTimeLineServer")
         node[:bcpc][:hadoop][:kerberos][:keytab][:dir] + '/' +
         node[:bcpc][:hadoop][:kerberos][:data][:resourcemanager][:keytab],
    } 
-  node.runs_state[:yarn_site_generated_values].merge!(yts_properties)
+  node.run_state[:yarn_site_generated_values].merge!(yts_properties)
 end
 
 # This is another set of cached node searches.

--- a/cookbooks/bcpc-hadoop/recipes/yarn_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/yarn_site.rb
@@ -241,7 +241,7 @@ if node.roles.include?("BCPC-Hadoop-Head-YarnTimeLineServer")
         node[:bcpc][:hadoop][:kerberos][:keytab][:dir] + '/' +
         node[:bcpc][:hadoop][:kerberos][:data][:resourcemanager][:keytab],
    } 
-  yarn_site_generated_values.merge!(yts_properties)
+  node.runs_state[:yarn_site_generated_values].merge!(yts_properties)
 end
 
 # This is another set of cached node searches.

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_tez-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_tez-site.xml.erb
@@ -20,4 +20,8 @@
     <name>tez.task.launch.cluster-default.cmd-opts</name>
     <value>-server -Djava.net.preferIPv4Stack=true -Dhdp.version=<%= node[:bcpc][:hadoop][:distribution][:active_release] %></value>
   </property>
+  <property>
+    <name>tez.history.logging.service.class</name>
+    <value>org.apache.tez.dag.history.logging.ats.ATSV15HistoryLoggingService</value>
+  </property>
 </configuration>

--- a/stub-environment/hadoop_cluster.txt
+++ b/stub-environment/hadoop_cluster.txt
@@ -1,3 +1,3 @@
 bcpc-vm1 08:00:27:56:A2:28 10.0.100.11 - bcpc_host_trusty bcpc.example.com role[BCPC-Hadoop-Head],role[BCPC-Hadoop-Head-Namenode],role[BCPC-Hadoop-Head-HBase],recipe[bcpc-hadoop::copylog]
-bcpc-vm2 08:00:27:E5:3A:00 10.0.100.12 - bcpc_host_trusty bcpc.example.com role[BCPC-Hadoop-Head],role[BCPC-Hadoop-Head-ResourceManager],role[BCPC-Hadoop-Head-Namenode-Standby],role[BCPC-Hadoop-Head-MapReduce],role[BCPC-Hadoop-Head-Hive],recipe[bcpc-hadoop::copylog]
+bcpc-vm2 08:00:27:E5:3A:00 10.0.100.12 - bcpc_host_trusty bcpc.example.com role[BCPC-Hadoop-Head],role[BCPC-Hadoop-Head-ResourceManager],role[BCPC-Hadoop-Head-Namenode-Standby],role[BCPC-Hadoop-Head-MapReduce],role[BCPC-Hadoop-Head-Hive],recipe[bcpc-hadoop::copylog],role[BCPC-Hadoop-Head-YarnTimeLineServer]
 bcpc-vm3 08:00:27:AD:1D:EA 10.0.100.13 - bcpc_host_trusty bcpc.example.com role[BCPC-Hadoop-Worker],recipe[bcpc-hadoop::copylog]

--- a/stub-environment/roles/BCPC-Hadoop-Head-YarnTimeLineServer.json
+++ b/stub-environment/roles/BCPC-Hadoop-Head-YarnTimeLineServer.json
@@ -1,0 +1,13 @@
+{
+  "name": "BCPC-Hadoop-Head-YarnTimeLineServer",
+  "json_class": "Chef::Role",
+  "run_list": [
+    "role[Basic]"
+  ],
+  "description": "A role to indicate YARN Application TimeLine Server Installation",
+  "chef_type": "role",
+  "default_attributes": {
+  },
+  "override_attributes": {
+  }
+}


### PR DESCRIPTION
Enable application timeline server primarily to make TEZ a first class citizen in the ecosystem
This pull request obsoletes #174 

Tested that applications complete with or without the timeline server running.

**BREAKING**: 
This change requires a cluster.txt change in order to assign BCPC-Hadoop-Head-YarnTimeLineServer role to a resource manager host, since YARN Timeline server is not yet HA, cluster operator should pick any ResourceManager