### PR TITLE
Hbase TimeLine Consistency off by default

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hbase.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hbase.rb
@@ -82,11 +82,12 @@ default[:bcpc][:hadoop][:hbase][:site_xml].tap do |site_xml|
   site_xml['hbase.replication'] = 'true'
   site_xml['hbase.coprocessor.abortonerror'] = node["bcpc"]["hadoop"]["hbase_rs"]["coprocessor"]["abortonerror"] 
   site_xml['hbase.regionserver.storefile.refresh.period'] = 30000
-  site_xml['hbase.region.replica.replication.enabled'] = true
+  site_xml['hbase.region.replica.replication.enabled'] = false
   site_xml['hbase.master.hfilecleaner.ttl'] = 3600000
   site_xml['hbase.master.loadbalancer.class'] = 'org.apache.hadoop.hbase.master.balancer.StochasticLoadBalancer'
   site_xml['hbase.meta.replica.count'] = 3
   site_xml['hbase.regionserver.meta.storefile.refresh.period'] = 30000
   site_xml['hbase.region.replica.wait.for.primary.flush'] = true
+  site_xml['hbase.meta.replicas.use'] = false
 end
 


### PR DESCRIPTION
Due to a critical bug [HBASE-17238](https://issues.apache.org/jira/browse/HBASE-17238) feature is to be off by default