### PR TITLE
Revert "enable hbase timeline consistency"

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hbase.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hbase.rb
@@ -81,12 +81,5 @@ default[:bcpc][:hadoop][:hbase][:site_xml].tap do |site_xml|
   site_xml['hbase.ipc.server.tcpnodelay'] = 'true'
   site_xml['hbase.replication'] = 'true'
   site_xml['hbase.coprocessor.abortonerror'] = node["bcpc"]["hadoop"]["hbase_rs"]["coprocessor"]["abortonerror"] 
-  site_xml['hbase.regionserver.storefile.refresh.period'] = 30000
-  site_xml['hbase.region.replica.replication.enabled'] = true
-  site_xml['hbase.master.hfilecleaner.ttl'] = 3600000
-  site_xml['hbase.master.loadbalancer.class'] = 'org.apache.hadoop.hbase.master.balancer.StochasticLoadBalancer'
-  site_xml['hbase.meta.replica.count'] = 3
-  site_xml['hbase.regionserver.meta.storefile.refresh.period'] = 30000
-  site_xml['hbase.region.replica.wait.for.primary.flush'] = true
 end
 


### PR DESCRIPTION
Reverts bloomberg/chef-bach#713
This works has already been added elsewhere, in addition there are issues with having this enabled by default [HBASE-17238](https://issues.apache.org/jira/browse/HBASE-17238)
