### PR TITLE
Ensure the bootstrap is snapshotted and Chef environment passes through

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ Static Code Analysis:
 
 Otherwise generally follow [bbatsov/ruby-style-guide](https://github.com/bbatsov/ruby-style-guide)
 
+For shell scripts:
+* Do not write shell scripts
+* If you must, please try to follow [Google's Shell Style Guide](https://google.github.io/styleguide/shell.xml)
+
 The GitHub workflow we follow is captured below:
 ![Flow Chart of GitHub Workflow from Issue or PR created to PR in progress and Code Review to Issue or PR resolved][gh_workflow]
 

--- a/cookbooks/bcpc-hadoop/recipes/hive_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hive_config.rb
@@ -129,6 +129,8 @@ elsif hive_site_vars[:hs2_auth] == 'LDAP'
     'hive.server2.authentication.ldap.Domain' =>
       hive_site_vars[:hs2_ldap_domain]
   }
+else
+  hs2_auth_values = {}
 end
 
 generated_values.merge!(hs2_auth_values)

--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -38,11 +38,11 @@ else
 fi
 
 if [ "$CLUSTER_TYPE" == "Kafka" ]; then
-    printf "Using kafka_cluster.txt\n"
-    cp stub-environment/kafka_cluster.txt ../cluster/cluster.txt
+  printf "Using kafka_cluster.txt\n"
+  cp stub-environment/kafka_cluster.txt ../cluster/cluster.txt
 else
-    printf "Using hadoop_cluster.txt\n"
-    cp stub-environment/hadoop_cluster.txt ../cluster/cluster.txt
+  printf "Using hadoop_cluster.txt\n"
+  cp stub-environment/hadoop_cluster.txt ../cluster/cluster.txt
 fi
 
 # Remove unused files.
@@ -60,11 +60,11 @@ create_bootstrap_VM || ( echo "############## VBOX CREATE BOOTSTRAP VM RETURNED 
 
 # Copy cluster mutable data to bootstrap.
 if [[ -d ../cluster ]]; then
-    tar -C .. -cf - cluster | vagrant ssh -c 'cd ~; tar -xvf -'
+  tar -C .. -cf - cluster | vagrant ssh -c 'cd ~; tar -xvf -'
 elif [[ -f ./cluster.tgz ]]; then
-    gunzip -c cluster.tgz | vagrant ssh -c 'cd ~; tar -xvf -'
+  gunzip -c cluster.tgz | vagrant ssh -c 'cd ~; tar -xvf -'
 else
-    ( echo "############## No cluster data found in ../cluster or ./cluster.tgz! ##############" && exit 1 )
+  ( echo "############## No cluster data found in ../cluster or ./cluster.tgz! ##############" && exit 1 )
 fi
 
 create_cluster_VMs || ( echo "############## VBOX CREATE CLUSTER VMs RETURNED $? ##############" && exit 1 )
@@ -85,38 +85,41 @@ fi
 vms_started="False"
 for vm in ${VM_LIST[*]} bcpc-bootstrap; do
   vboxmanage showvminfo $vm | grep -q '^State:.*running' || vms_started="True"
-  vboxmanage showvminfo $vm | grep -q '^State:.*running' || VBoxManage snapshot $vm take Shoe-less
+  if [[ $(vboxmanage snapshot $vm list --machinereadable | grep -q 'Shoe-less') ]]; then
+    vboxmanage showvminfo $vm | grep -q '^State:.*running' || VBoxManage snapshot $vm take Shoe-less
+  fi
   vboxmanage showvminfo $vm | grep -q '^State:.*running' || VBoxManage startvm $vm --type headless
 done
 
 if hash screen; then
-    if [ "$(uname)" == "Darwin" ]; then
-	brew install coreutils
-	pushd $(greadlink -f $(dirname $0)) > /dev/null
-    else
-	pushd $(readlink -f $(dirname $0)) > /dev/null
-    fi
+  if [ "$(uname)" == "Darwin" ]; then
+    brew install coreutils
+    pushd $(greadlink -f $(dirname $0)) > /dev/null
+  else
+    pushd $(readlink -f $(dirname $0)) > /dev/null
+  fi
 
-    # Create a new screenrc with our VM list in it
-    cp ./screenrc ../../cluster/screenrc
+  # Create a new screenrc with our VM list in it
+  cp ./screenrc ../../cluster/screenrc
 
-    echo "cd `pwd`; cd .." >> ../../cluster/screenrc
+  echo "cd `pwd`; cd .." >> ../../cluster/screenrc
 
-    ii=1
-    for vm in ${VM_LIST[*]}; do
-      echo "screen -t \"$vm serial console\" $ii" \
-	   "./tests/virtualbox_serial_console.sh $vm" >> ../../cluster/screenrc
-      ((ii++))
-    done
-    popd > /dev/null
-    echo "Enter this command to view VM serial consoles:"
-    echo "  screen -S 'BACH serial consoles' `readlink -f ../cluster/screenrc`"
-    echo
+  ii=1
+  for vm in ${VM_LIST[*]}; do
+    echo "screen -t \"$vm serial console\" $ii" \
+         "./tests/virtualbox_serial_console.sh $vm" >> ../../cluster/screenrc
+    ((ii++))
+  done
+  popd > /dev/null
+  echo "Enter this command to view VM serial consoles:"
+  echo "  screen -S 'BACH serial consoles' `readlink -f ../cluster/screenrc`"
+  echo
 fi
 
 vagrant ssh -c "cd chef-bcpc; ./wait-for-hosts.sh ${VM_LIST[*]}"
 printf "Snapshotting post-Cobbler\n"
 for vm in ${VM_LIST[*]} bcpc-bootstrap; do
+  [[ $(vboxmanage snapshot $vm list --machinereadable | grep -q 'Post-Cobble') ]] && \
     [[ "$vms_started" == "True" ]] && VBoxManage snapshot $vm take Post-Cobble --live &
 done
 wait && printf "Done Snapshotting\n"
@@ -126,6 +129,7 @@ vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT Basic"
 
 printf "Snapshotting post-Basic\n"
 for vm in ${VM_LIST[*]} bcpc-bootstrap; do
+  [[ $(vboxmanage snapshot $vm list --machinereadable | grep -q 'Basic') ]] && \
     VBoxManage snapshot $vm take Basic --live &
 done
 wait && printf "Done Snapshotting\n"
@@ -135,15 +139,21 @@ printf "Cluster type: $CLUSTER_TYPE\n"
 
 
 if [ "$CLUSTER_TYPE" == "Hadoop" ]; then
-    printf "Running C-A-R 'bootstrap' before final C-A-R"
-    vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT Bootstrap"
-    printf "Running final C-A-R"
+  printf "Running C-A-R 'bootstrap' before final C-A-R"
+  vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT Bootstrap"
+  for vm in ${VM_LIST[*]} bcpc-bootstrap; do
+    [[ $(vboxmanage snapshot $vm list --machinereadable | grep -q 'Post-Bootstrap') ]] && \
+      VBoxManage snapshot $vm take Post-Bootstrap --live &
+  done
+  wait && printf "Done Snapshotting\n"
+  printf "Running final C-A-R"
 fi
 
 vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT $CLUSTER_TYPE"
 
 printf "Taking final snapshot\n"
 for vm in ${VM_LIST[*]} bcpc-bootstrap; do
+  [[ $(vboxmanage snapshot $vm list --machinereadable | grep -q 'Full-Shoes') ]] && \
     VBoxManage snapshot $vm take Full-Shoes --live &
 done
 wait && printf "Done Snapshotting\n"


### PR DESCRIPTION
This fixes using a non-standard environment name and ensures we sanpshot the bootstrap as the cluster is built, for later roll-back when developing.