### PR TITLE
Update number of process ulimits from 2^15 to 2^16 for all ulimit settings

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -34,22 +34,22 @@ end
 end
 
 user_ulimit "root" do
-  filehandle_limit 32769
+  filehandle_limit 65536
   process_limit 65536
 end
 
 user_ulimit "hdfs" do
-  filehandle_limit 32769
+  filehandle_limit 65536
   process_limit 65536
 end
 
 user_ulimit "mapred" do
-  filehandle_limit 32769
+  filehandle_limit 65536
   process_limit 65536
 end
 
 user_ulimit "yarn" do
-  filehandle_limit 32769
+  filehandle_limit 65536
   process_limit 65536
 end
 

--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -36,7 +36,7 @@ configure_kerberos 'hbase_kerb' do
 end
 
 user_ulimit "hbase" do
-  filehandle_limit 32769
+  filehandle_limit 65536
 end
 
 service "hbase-thrift" do

--- a/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
@@ -23,7 +23,7 @@ end
 end
 
 user_ulimit "hive" do
-  filehandle_limit 32769
+  filehandle_limit 65536
   process_limit 65536
 end
 

--- a/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
@@ -74,7 +74,7 @@ directory "/var/log/hadoop-hdfs/gc/" do
 end
 
 user_ulimit "hdfs" do
-  filehandle_limit 32769
+  filehandle_limit 65536
   process_limit 65536
 end
 

--- a/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
@@ -72,7 +72,7 @@ directory "/var/log/hadoop-hdfs/gc/" do
 end
 
 user_ulimit "hdfs" do
-  filehandle_limit 32769
+  filehandle_limit 65536
   process_limit 65536
 end
 

--- a/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
@@ -68,7 +68,7 @@ directory "/var/log/hadoop-hdfs/gc/" do
 end
 
 user_ulimit "hdfs" do
-  filehandle_limit 32769
+  filehandle_limit 65536
   process_limit 65536
 end
 

--- a/cookbooks/bcpc-hadoop/recipes/region_server.rb
+++ b/cookbooks/bcpc-hadoop/recipes/region_server.rb
@@ -24,7 +24,7 @@ end
 end
 
 user_ulimit "hbase" do
-  filehandle_limit 32769
+  filehandle_limit 65536
 end
 
 directory "/usr/hdp/#{node[:bcpc][:hadoop][:distribution][:active_release]}/hbase/lib/native/Linux-amd64-64" do

--- a/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
+++ b/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
@@ -10,7 +10,7 @@ include_recipe 'bcpc-hadoop::zookeeper_config'
 hdp_select('zookeeper-server', node[:bcpc][:hadoop][:distribution][:active_release])
 
 user_ulimit "zookeeper" do
-  filehandle_limit 32769
+  filehandle_limit 65536
 end
 
 configure_kerberos 'zookeeper_kerb' do


### PR DESCRIPTION
We have been seeing issues whereby HDFS datanodes fail to spawn `du` and livelock due to being unable to spawn more threads. It was pointed out the default number of handler threads are 32k and we only have 32k ulimits; ~64k is the in thing now...