### PR TITLE
Don't rewrite local repo keys on every chef run

### DIFF
--- a/cookbooks/bach_repository/recipes/gems.rb
+++ b/cookbooks/bach_repository/recipes/gems.rb
@@ -3,6 +3,7 @@
 # Recipe:: gems
 #
 include_recipe 'bach_repository::directory'
+include_recipe 'bach_repository::tools'
 bins_dir = node['bach']['repository']['bins_directory']
 gems_dir = "#{bins_dir}/gems"
 


### PR DESCRIPTION
This PR should prevent the bootstrap from replacing the local apt repo key on every run.  We will no longer clutter the apt-key lists on nodes with unused keys.