### PR TITLE
Workaround for inheritance of Timeout::timeout

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/default.rb
+++ b/cookbooks/bcpc-hadoop/recipes/default.rb
@@ -70,14 +70,15 @@ end
 # The "--use-system-libraries" switch is intended to force nokogiri
 # extconf.rb to compile against system libraries.
 #
-gem_package 'nokogiri' do
-  options "--clear-sources -s #{get_binary_server_url} " \
-    '-- --use-system-libraries'
-  gem_binary gem_path
-  version '>=1.6.2'
-  action :nothing
-  timeout 1800
-end.run_action(:install)
+nokogiri_geminstall = Timeout::timeout(1800) {
+  gem_package 'nokogiri' do
+    options "--clear-sources -s #{get_binary_server_url} " \
+      '-- --use-system-libraries'
+    gem_binary gem_path
+    version '>=1.6.2'
+    action :nothing
+  end.run_action(:install)
+}
 
 Gem.clear_paths
 require 'zookeeper'


### PR DESCRIPTION
During an upgrade to 2.1.1, it was noticed that `Timeout::timeout` is somehow being inherited. This somehow causes super strange behavior of the `timeout` method within the `gem_package` resource, hijacking just that particular method. Since no sane thing that was attempted could circumvent the inheritance and allow usage of `Chef::Resource::Package#timeout` (it's a private method), this was the best option I came up with for keeping the timeout.

```
================================================================================
Recipe Compile Error in /var/chef/cache/cookbooks/bcpc-hadoop/recipes/default.rb
================================================================================


LocalJumpError
--------------
no block given (yield)


Cookbook Trace:
---------------
  /var/chef/cache/cookbooks/bcpc-hadoop/recipes/default.rb:79:in `block in from_file'
  /var/chef/cache/cookbooks/bcpc-hadoop/recipes/default.rb:73:in `from_file'


Relevant File Content:
----------------------
/var/chef/cache/cookbooks/bcpc-hadoop/recipes/default.rb:

 72:  #
 73:  gem_package 'nokogiri' do
 74:    options "--clear-sources -s #{get_binary_server_url} " \
 75:      '-- --use-system-libraries'
 76:    gem_binary gem_path
 77:    version '>=1.6.2'
 78:    action :nothing
 79>>   timeout 1800
 80:  end.run_action(:install)
 81:  
 82:  Gem.clear_paths
 83:  require 'zookeeper'
 84:  
 85:  execute "correct-gem-permissions" do
 86:    command 'find /opt/chef/embedded/lib/ruby/gems -type f -exec chmod a+r {} \; && ' +
 87:            'find /opt/chef/embedded/lib/ruby/gems -type d -exec chmod a+rx {} \;'
 88:    user "root"
```