### PR TITLE
Spark 2.0.2 with hadoop 2.7 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+AllCops:
+  TargetRubyVersion: 1.9
+

--- a/cookbooks/bach_repository/recipes/spark.rb
+++ b/cookbooks/bach_repository/recipes/spark.rb
@@ -9,15 +9,15 @@ bins_dir = node['bach']['repository']['bins_directory']
 spark_extract_dir = Dir.mktmpdir
 spark_install_dir = "/usr/spark"
 spark_pkg_prefix = "spark"
-spark_pkg_version = "1.6.0"
-spark_tar_file = "spark-#{spark_pkg_version}-bin-hadoop2.6.tgz"
-spark_extracted_file_name = "spark-#{spark_pkg_version}-bin-hadoop2.6"
+spark_pkg_version = "2.0.2"
+spark_tar_file = "spark-#{spark_pkg_version}-bin-hadoop2.7.tgz"
+spark_extracted_file_name = "spark-#{spark_pkg_version}-bin-hadoop2.7"
 spark_deb_path =
   "#{bins_dir}/#{spark_pkg_prefix}_#{spark_pkg_version}_amd64.deb"
 
 remote_file "#{bins_dir}/#{spark_tar_file}" do
   source "http://d3kbcqa49mib13.cloudfront.net/#{spark_tar_file}"
-  checksum '439fe7793e0725492d3d36448adcd1db38f438dd1392bffd556b58bb9a3a2601'
+  checksum 'e6349dd38ded84831e3ff7d391ae7f2525c359fb452b0fc32ee2ab637673552a'
   notifies :run, 'execute[extract_spark_tar]', :immediately
 end
 
@@ -40,7 +40,7 @@ execute 'build_spark_package' do
     "--prefix #{spark_install_dir}/#{spark_pkg_version} " \
     "-n #{spark_pkg_prefix}-#{spark_pkg_version} " \
     "-v #{spark_pkg_version} " \
-    "--description 'Spark Package with Hadoop 2.6' -p #{bins_dir} *"
+    "--description 'Spark Package with Hadoop 2.7' -p #{bins_dir} *"
   umask 0002
   action :nothing
 end

--- a/cookbooks/bach_repository/recipes/spark.rb
+++ b/cookbooks/bach_repository/recipes/spark.rb
@@ -7,13 +7,11 @@ require 'tmpdir'
 include_recipe 'bach_repository::directory'
 bins_dir = node['bach']['repository']['bins_directory']
 spark_extract_dir = Dir.mktmpdir
-spark_install_dir = "/usr/spark"
-spark_pkg_prefix = "spark"
-spark_pkg_version = "2.0.2"
+spark_install_dir = '/usr/spark'
+spark_pkg_prefix = 'spark'
+spark_pkg_version = '2.0.2'
 spark_tar_file = "spark-#{spark_pkg_version}-bin-hadoop2.7.tgz"
 spark_extracted_file_name = "spark-#{spark_pkg_version}-bin-hadoop2.7"
-spark_deb_path =
-  "#{bins_dir}/#{spark_pkg_prefix}_#{spark_pkg_version}_amd64.deb"
 
 remote_file "#{bins_dir}/#{spark_tar_file}" do
   source "http://d3kbcqa49mib13.cloudfront.net/#{spark_tar_file}"

--- a/cookbooks/bach_spark/attributes/default.rb
+++ b/cookbooks/bach_spark/attributes/default.rb
@@ -12,7 +12,7 @@ default[:spark][:bin][:dir] = "#{node[:spark][:package][:base]}/"\
 
 ## Spark Configuration
 default.bach_spark.config.spark.driver.extraLibraryPath = '/usr/hdp/current'\
-    'hadoop-client/lib/native:/usr/hdp/current'\
+    '/hadoop-client/lib/native:/usr/hdp/current'\
     '/hadoop-client/lib/native/Linux-amd64-64'
 default.bach_spark.config.spark.executor.extraLibraryPath = '/usr/hdp/current'\
     '/hadoop-client/lib/native:/usr/hdp/current/hadoop-client/lib'\

--- a/cookbooks/bach_spark/attributes/default.rb
+++ b/cookbooks/bach_spark/attributes/default.rb
@@ -7,29 +7,48 @@ default[:spark][:package][:base] = '/usr/spark'
 default[:spark][:package][:prefix] = 'spark'
 default[:spark][:package][:version] = '2.0.2'
 default[:spark][:hdfs_url] = node['bcpc']['hadoop']['hdfs_url']
-default[:spark][:bin][:dir] = "#{node[:spark][:package][:base]}/#{node[:spark][:package][:version]}"
-
+default[:spark][:bin][:dir] = "#{node[:spark][:package][:base]}/"\
+    "#{node[:spark][:package][:version]}"
 
 ## Spark Configuration
-default.bach_spark.config.spark.driver.extraLibraryPath = "/usr/hdp/current/hadoop-client/lib/native:/usr/hdp/current/hadoop-client/lib/native/Linux-amd64-64"
-default.bach_spark.config.spark.executor.extraLibraryPath = "/usr/hdp/current/hadoop-client/lib/native:/usr/hdp/current/hadoop-client/lib/native/Linux-amd64-64"
-default.bach_spark.config.spark.executor.extraJavaOptions = "-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+PrintTenuringDistribution -XX:+UseNUMA -XX:+PrintGCApplicationStoppedTime -XX:+UseCompressedOops -XX:+PrintClassHistogram -XX:+PrintGCApplicationConcurrentTime"
+default.bach_spark.config.spark.driver.extraLibraryPath = '/usr/hdp/current'\
+    'hadoop-client/lib/native:/usr/hdp/current'\
+    '/hadoop-client/lib/native/Linux-amd64-64'
+default.bach_spark.config.spark.executor.extraLibraryPath = '/usr/hdp/current'\
+    '/hadoop-client/lib/native:/usr/hdp/current/hadoop-client/lib'\
+    '/native/Linux-amd64-64'
+default.bach_spark.config.spark.executor.extraJavaOptions =
+    '-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails '\
+    '-XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps '\
+    '-XX:+PrintTenuringDistribution -XX:+UseNUMA '\
+    '-XX:+PrintGCApplicationStoppedTime -XX:+UseCompressedOops '\
+    '-XX:+PrintClassHistogram -XX:+PrintGCApplicationConcurrentTime'
 default.bach_spark.config.spark.shuffle.consolidateFiles = true
-default.bach_spark.config.spark.shuffle.io.numConnectionsPerPeer =  2
-default.bach_spark.config.spark.history.fs.logDirectory = "#{node['spark']['hdfs_url']}/spark-history"
-default.bach_spark.config.spark.eventLog.dir = "#{node['spark']['hdfs_url']}/spark-history" 
+default.bach_spark.config.spark.shuffle.io.numConnectionsPerPeer = 2
+default.bach_spark.config.spark.history.fs.logDirectory =
+    "#{node['spark']['hdfs_url']}/spark-history"
+default.bach_spark.config.spark.eventLog.dir =
+    "#{node['spark']['hdfs_url']}/spark-history"
 default.bach_spark.config.spark.eventLog.enabled = true
 default.bach_spark.config.spark.logConf = true
 default.bach_spark.config.spark.dynamicAllocation.enabled = true
 default.bach_spark.config.spark.shuffle.service.enabled = true
-default.bach_spark.config.spark.yarn.archive = "#{node['spark']['hdfs_url']}/apps/spark/#{node[:spark][:package][:version]}/spark_jars.tgz"  
-default.bach_spark.config.spark.master = "yarn-client"
+default.bach_spark.config.spark.yarn.archive = "#{node['spark']['hdfs_url']}"\
+    "/apps/spark/#{node[:spark][:package][:version]}/spark_jars.tgz"
+default.bach_spark.config.spark.master = 'yarn-client'
 
 # Spark environment configuration
 default.bach_spark.environment.SPARK_LOCAL_IP = node[:bcpc][:floating][:ip]
 default.bach_spark.environment.SPARK_PUBLIC_DNS = float_host(node['fqdn'])
-default.bach_spark.environment.HADOOP_CONF_DIR = "/etc/hadoop/conf"
-default.bach_spark.environment.HIVE_CONF_DIR = "/etc/hive/conf"
-default.bach_spark.environment.SPARK_DIST_CLASSPATH = "${HIVE_CONF_DIR}:${SPARK_LIBRARY_PATH}:$(for i in $(export IFS=\":\"; for i in $(hadoop classpath); do find $i -maxdepth 1 -name \"*.jar\"; done | egrep -v \"jackson-databind-.*.jar|jackson-core.jar|jackson-core-.*.jar|jackson-annotations-.*.jar\"); do echo -n \"${i}:\"; done | sed 's/:$//')"
-default.bach_spark.environment.SPARK_CLASSPATH = "$SPARK_DIST_CLASSPATH:$SPARK_CLASSPATH"
-default.bach_spark.environment.SPARK_LOCAL_DIRS = "${HOME}/.spark_logs"
+default.bach_spark.environment.HADOOP_CONF_DIR = '/etc/hadoop/conf'
+default.bach_spark.environment.HIVE_CONF_DIR = '/etc/hive/conf'
+default.bach_spark.environment.SPARK_DIST_CLASSPATH =
+    "${HIVE_CONF_DIR}:${SPARK_LIBRARY_PATH}:$(for i in $(export IFS=\":\"; "\
+    "for i in $(hadoop classpath); do find $i -maxdepth 1 -name \"*.jar\"; "\
+    "done | egrep -v \"jackson-databind-.*.jar|jackson-core.jar|"\
+    "jackson-core-.*.jar|jackson-annotations-.*.jar\"); "\
+    "do echo -n \"${i}:\"; done | sed 's/:$//')"
+default.bach_spark.environment.SPARK_CLASSPATH =
+    '$SPARK_DIST_CLASSPATH:$SPARK_CLASSPATH'
+default.bach_spark.environment.SPARK_LOCAL_DIRS = 
+    '${HOME}/.spark_logs'

--- a/cookbooks/bach_spark/attributes/default.rb
+++ b/cookbooks/bach_spark/attributes/default.rb
@@ -56,4 +56,5 @@ default.bach_spark.environment.LD_LIBRARY_PATH = '/usr/hdp/current'\
     '/hadoop-client/lib/native:/usr/hdp/current'\
     '/hadoop-client/lib/native/Linux-amd64-64:$LD_LIBRARY_PATH'
 default.bach_spark.environment.HADOOP_CONF = '/usr/hadoop/conf'
-default.bach_spark.environment.HADOOP_HOME = "/usr/hdp/#{node[:bcpc][:hadoop][:distribution][:release}]/hadoop”
+default.bach_spark.environment.HADOOP_HOME = '/usr/hdp'\
+    "/#{node[:bcpc][:hadoop][:distribution][:release}]/hadoop”

--- a/cookbooks/bach_spark/attributes/default.rb
+++ b/cookbooks/bach_spark/attributes/default.rb
@@ -1,11 +1,11 @@
 default[:spark][:download][:url] = 'http://d3kbcqa49mib13.cloudfront.net'
-default[:spark][:download][:file][:name] = 'spark-1.6.0-bin-hadoop2.6'
+default[:spark][:download][:file][:name] = 'spark-2.0.2-bin-hadoop2.7'
 default[:spark][:download][:file][:type] = 'tgz'
 default[:spark][:download][:dir] = '/home/vagrant/chef-bcpc/bins'
 default[:spark][:package][:install_meta] = false
 default[:spark][:package][:base] = '/usr/spark'
 default[:spark][:package][:prefix] = 'spark'
-default[:spark][:package][:version] = '1.6.0'
+default[:spark][:package][:version] = '2.0.2'
 default[:spark][:hdfs_url] = node['bcpc']['hadoop']['hdfs_url']
 default[:spark][:bin][:dir] = "#{node[:spark][:package][:base]}/#{node[:spark][:package][:version]}"
 
@@ -22,7 +22,7 @@ default.bach_spark.config.spark.eventLog.enabled = true
 default.bach_spark.config.spark.logConf = true
 default.bach_spark.config.spark.dynamicAllocation.enabled = true
 default.bach_spark.config.spark.shuffle.service.enabled = true
-default.bach_spark.config.spark.yarn.jar = "#{node['spark']['hdfs_url']}/apps/spark/#{node[:spark][:package][:version]}/spark-assembly.jar" 
+default.bach_spark.config.spark.yarn.archive = "#{node['spark']['hdfs_url']}/apps/spark/#{node[:spark][:package][:version]}/spark_jars.tgz"  
 default.bach_spark.config.spark.master = "yarn-client"
 
 # Spark environment configuration

--- a/cookbooks/bach_spark/attributes/default.rb
+++ b/cookbooks/bach_spark/attributes/default.rb
@@ -52,3 +52,8 @@ default.bach_spark.environment.SPARK_CLASSPATH =
     '$SPARK_DIST_CLASSPATH:$SPARK_CLASSPATH'
 default.bach_spark.environment.SPARK_LOCAL_DIRS = 
     '${HOME}/.spark_logs'
+default.bach_spark.environment.LD_LIBRARY_PATH = '/usr/hdp/current'\
+    '/hadoop-client/lib/native:/usr/hdp/current'\
+    '/hadoop-client/lib/native/Linux-amd64-64:$LD_LIBRARY_PATH'
+default.bach_spark.environment.HADOOP_CONF = '/usr/hadoop/conf'
+default.bach_spark.environment.HADOOP_HOME = "/usr/hdp/#{node[:bcpc][:hadoop][:distribution][:release}]/hadoop”

--- a/cookbooks/bach_spark/attributes/default.rb
+++ b/cookbooks/bach_spark/attributes/default.rb
@@ -57,4 +57,4 @@ default.bach_spark.environment.LD_LIBRARY_PATH = '/usr/hdp/current'\
     '/hadoop-client/lib/native/Linux-amd64-64:$LD_LIBRARY_PATH'
 default.bach_spark.environment.HADOOP_CONF = '/usr/hadoop/conf'
 default.bach_spark.environment.HADOOP_HOME = '/usr/hdp'\
-    "/#{node[:bcpc][:hadoop][:distribution][:release}]/hadoop”
+    "/#{node[:bcpc][:hadoop][:distribution][:release]}/hadoop”

--- a/cookbooks/bach_spark/attributes/default.rb
+++ b/cookbooks/bach_spark/attributes/default.rb
@@ -57,4 +57,4 @@ default.bach_spark.environment.LD_LIBRARY_PATH = '/usr/hdp/current'\
     '/hadoop-client/lib/native/Linux-amd64-64:$LD_LIBRARY_PATH'
 default.bach_spark.environment.HADOOP_CONF = '/usr/hadoop/conf'
 default.bach_spark.environment.HADOOP_HOME = '/usr/hdp'\
-    "/#{node[:bcpc][:hadoop][:distribution][:release]}/hadoop”
+    "/#{node['bcpc']['hadoop']['distribution']['release']}/hadoop"

--- a/cookbooks/bach_spark/recipes/cluster_install.rb
+++ b/cookbooks/bach_spark/recipes/cluster_install.rb
@@ -1,3 +1,5 @@
+# vim: tabstop=2:shiftwidth=2:softtabstop=2
+
 spark_pkg_version = node[:spark][:package][:version]
 spark_bin_dir = node[:spark][:bin][:dir]
 hdfs_url = node['spark']['hdfs_url']
@@ -12,12 +14,28 @@ bash "create-hdfs-spark-history-dir" do
   not_if "hdfs dfs -test -d #{hdfs_url}/spark-history", :user => 'hdfs'
 end
 
-bash "create-hdfs-spark-assembly-jar" do
-  code <<-EOH
-  hdfs dfs -mkdir -p #{hdfs_url}/apps/spark/#{spark_pkg_version}/
-  hdfs dfs -chown -R hdfs:hdfs #{hdfs_url}/apps/spark/#{spark_pkg_version}/
-  hdfs dfs -copyFromLocal  #{spark_bin_dir}/lib/spark-assembly-*.jar #{hdfs_url}/apps/spark/#{spark_pkg_version}/spark-assembly.jar
-  EOH
+execute "create spark #{spark_pkg_version} HDFS directory" do
+  command "hdfs dfs -mkdir -p #{hdfs_url}/apps/spark/#{spark_pkg_version}"
   user "hdfs"
-  not_if "hdfs dfs -test -f #{hdfs_url}/apps/spark/#{spark_pkg_version}/spark-assembly.jar", :user => 'hdfs'
+end
+
+execute "create spark #{spark_pkg_version} archive" do
+  command "tar -czvf /tmp/spark_#{spark_pkg_version}_jars.tgz -C #{spark_bin_dir}/jars ."
+  user "hdfs"
+  not_if "hdfs dfs -test -f #{hdfs_url}/apps/spark/#{spark_pkg_version}/spark_jars.tgz", :user => 'hdfs'
+  notifies :run, "execute[upload #{spark_pkg_version} archive to HDFS]", :immediately
+end
+
+execute "upload #{spark_pkg_version} archive to HDFS" do
+  command "hdfs dfs -copyFromLocal /tmp/spark_#{spark_pkg_version}_jars.tgz #{hdfs_url}/apps/spark/#{spark_pkg_version}/spark_jars.tgz"
+  user "hdfs"
+  action :nothing
+  not_if "hdfs dfs -test -f #{hdfs_url}/apps/spark/#{spark_pkg_version}/spark_jars.tgz", :user => 'hdfs'
+  notifies :run, "execute[cleanup /tmp/spark_#{spark_pkg_version}_jars.tgz]", :immediately
+end
+
+execute "cleanup /tmp/spark_#{spark_pkg_version}_jars.tgz" do 
+  command "rm /tmp/spark_#{spark_pkg_version}_jars.tgz"
+  user "hdfs"
+  action :nothing
 end

--- a/cookbooks/bach_spark/recipes/cluster_install.rb
+++ b/cookbooks/bach_spark/recipes/cluster_install.rb
@@ -4,38 +4,47 @@ spark_pkg_version = node[:spark][:package][:version]
 spark_bin_dir = node[:spark][:bin][:dir]
 hdfs_url = node['spark']['hdfs_url']
 
-bash "create-hdfs-spark-history-dir" do
+bash 'create-hdfs-spark-history-dir' do
   code <<-EOH
   hdfs dfs -mkdir -p #{hdfs_url}/spark-history/
   hdfs dfs -chmod -R 1777 #{hdfs_url}/spark-history/
   hdfs dfs -chown -R hdfs:hdfs #{hdfs_url}/spark-history
   EOH
-  user "hdfs"
-  not_if "hdfs dfs -test -d #{hdfs_url}/spark-history", :user => 'hdfs'
+  user 'hdfs'
+  not_if "hdfs dfs -test -d #{hdfs_url}/spark-history", user: 'hdfs'
 end
 
 execute "create spark #{spark_pkg_version} HDFS directory" do
   command "hdfs dfs -mkdir -p #{hdfs_url}/apps/spark/#{spark_pkg_version}"
-  user "hdfs"
+  user 'hdfs'
 end
 
 execute "create spark #{spark_pkg_version} archive" do
-  command "tar -czvf /tmp/spark_#{spark_pkg_version}_jars.tgz -C #{spark_bin_dir}/jars ."
-  user "hdfs"
-  not_if "hdfs dfs -test -f #{hdfs_url}/apps/spark/#{spark_pkg_version}/spark_jars.tgz", :user => 'hdfs'
-  notifies :run, "execute[upload #{spark_pkg_version} archive to HDFS]", :immediately
+  command "tar -czvf /tmp/spark_#{spark_pkg_version}_jars.tgz "\
+    "-C #{spark_bin_dir}/jars ."
+  user 'hdfs'
+  not_if "hdfs dfs -test -f #{hdfs_url}/apps/spark"\
+    "/#{spark_pkg_version}/spark_jars.tgz", user: 'hdfs'
+  notifies :run,
+           "execute[upload #{spark_pkg_version} archive to HDFS]",
+           :immediately
 end
 
 execute "upload #{spark_pkg_version} archive to HDFS" do
-  command "hdfs dfs -copyFromLocal /tmp/spark_#{spark_pkg_version}_jars.tgz #{hdfs_url}/apps/spark/#{spark_pkg_version}/spark_jars.tgz"
-  user "hdfs"
+  command "hdfs dfs -copyFromLocal /tmp/spark_#{spark_pkg_version}_jars.tgz "\
+    "#{hdfs_url}/apps/spark/#{spark_pkg_version}/spark_jars.tgz"
+  user 'hdfs'
   action :nothing
-  not_if "hdfs dfs -test -f #{hdfs_url}/apps/spark/#{spark_pkg_version}/spark_jars.tgz", :user => 'hdfs'
-  notifies :run, "execute[cleanup /tmp/spark_#{spark_pkg_version}_jars.tgz]", :immediately
+  not_if 'hdfs dfs -test -f '\
+         "#{hdfs_url}/apps/spark/#{spark_pkg_version}/spark_jars.tgz",
+         user: 'hdfs'
+  notifies :run,
+           "execute[cleanup /tmp/spark_#{spark_pkg_version}_jars.tgz]",
+           :immediately
 end
 
-execute "cleanup /tmp/spark_#{spark_pkg_version}_jars.tgz" do 
+execute "cleanup /tmp/spark_#{spark_pkg_version}_jars.tgz" do
   command "rm /tmp/spark_#{spark_pkg_version}_jars.tgz"
-  user "hdfs"
+  user 'hdfs'
   action :nothing
 end

--- a/cookbooks/bach_spark/recipes/default.rb
+++ b/cookbooks/bach_spark/recipes/default.rb
@@ -13,7 +13,7 @@ end
 
 template "#{spark_bin_dir}/conf/spark-env.sh" do
   source 'spark-env.sh.erb'
-  mode 0755
+  mode 0o0755
   helper :config do
     node.bach_spark.environment.sort_by(&:first)
   end
@@ -22,7 +22,7 @@ end
 
 template "#{spark_bin_dir}/conf/spark-defaults.conf" do
   source 'spark-defaults.conf.erb'
-  mode 0755
+  mode 0o0755
   helper :config do
     node.bach_spark.config.sort_by(&:first)
   end
@@ -34,7 +34,7 @@ link "/#{spark_bin_dir}/yarn/spark-yarn-shuffle.jar" do
 end
 
 link '/usr/spark/current' do
-  to "#{spark_bin_dir}"
+  to spark_bin_dir
 end
 
 # install fortran libs needed by some jobs

--- a/cookbooks/bach_spark/recipes/default.rb
+++ b/cookbooks/bach_spark/recipes/default.rb
@@ -29,8 +29,8 @@ template "#{spark_bin_dir}/conf/spark-defaults.conf" do
   helpers(Spark::Configuration)
 end
 
-link "/#{spark_bin_dir}/lib/spark-yarn-shuffle.jar" do
-  to "#{spark_bin_dir}/lib/spark-#{spark_pkg_version}-yarn-shuffle.jar"
+link "/#{spark_bin_dir}/yarn/spark-yarn-shuffle.jar" do
+  to "#{spark_bin_dir}/yarn/spark-#{spark_pkg_version}-yarn-shuffle.jar"
 end
 
 link '/usr/spark/current' do

--- a/cookbooks/bcpc-hadoop/recipes/yarn_env.rb
+++ b/cookbooks/bcpc-hadoop/recipes/yarn_env.rb
@@ -6,18 +6,18 @@ yarn_env_values = node[:bcpc][:hadoop][:yarn][:env_sh]
 # recipe.  These values will be merged with the yarn_env-Values
 yarn_env_generated_values = {}
 
-if(node.run_list.expand(node.chef_environment).recipes
-       .include?('bach_spark::default'))
+if node.run_list.expand(node.chef_environment)
+       .recipes.include?('bach_spark::default')
   yarn_env_generated_values[:YARN_USER_CLASSPATH] =
     '/usr/spark/current/yarn/spark-yarn-shuffle.jar'
 end
-if(node.run_list.expand(node.chef_environment).recipes
-        .include?('bcpc-hadoop::datanode'))
-  yarn_env_generated_values[:YARN_LOGFILE] = 
+if node.run_list.expand(node.chef_environment)
+       .recipes.include?('bcpc-hadoop::datanode')
+  yarn_env_generated_values[:YARN_LOGFILE] =
     'yarn-yarn-nodemanager-$(hostname).log'
-elsif(node.run_list.expand(node.chef_environment).recipes
-        .include?('bcpc-hadoop::resource_manager'))
-  yarn_env_generated_values[:YARN_LOGFILE] = 
+elsif node.run_list.expand(node.chef_environment)
+          .recipes.include?('bcpc-hadoop::resource_manager')
+  yarn_env_generated_values[:YARN_LOGFILE] =
     'yarn-yarn-resourcemanager-$(hostname).log'
 end
 
@@ -26,6 +26,6 @@ complete_yarn_env_hash =
 
 template '/etc/hadoop/conf/yarn-env.sh' do
   source 'generic_env.sh.erb'
-  mode 0555
-  variables(:options => complete_yarn_env_hash)
+  mode 0o0555
+  variables(options: complete_yarn_env_hash)
 end

--- a/cookbooks/bcpc-hadoop/recipes/yarn_env.rb
+++ b/cookbooks/bcpc-hadoop/recipes/yarn_env.rb
@@ -9,7 +9,7 @@ yarn_env_generated_values = {}
 if(node.run_list.expand(node.chef_environment).recipes
        .include?('bach_spark::default'))
   yarn_env_generated_values[:YARN_USER_CLASSPATH] =
-    '/usr/spark/current/lib/spark-yarn-shuffle.jar'
+    '/usr/spark/current/yarn/spark-yarn-shuffle.jar'
 end
 if(node.run_list.expand(node.chef_environment).recipes
         .include?('bcpc-hadoop::datanode'))


### PR DESCRIPTION
Deploy Spark 2.0.2 package built with hadoop 2.7 support

**Breaking**: Due to the package layout changes we will no longer be able to deploy Spark 1.x