### PR TITLE
Remove timeout from nokogiri gem_install resource

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/default.rb
+++ b/cookbooks/bcpc-hadoop/recipes/default.rb
@@ -76,7 +76,6 @@ gem_package 'nokogiri' do
   gem_binary gem_path
   version '>=1.6.2'
   action :nothing
-  timeout 1800
 end.run_action(:install)
 
 Gem.clear_paths


### PR DESCRIPTION
After some fun investigation, we found this was yet another thing that's not actually present in Chef 11 releases, even though it's present in the Chef 11 branch on Github and the docs for 11/12. Since the issue with timing out is very likely already resolved when installing the libraries via apt and adding `--use-system-libraries`, we're going to remove the timeout from this resource entirely.