### PR TITLE
[HACK] - Take the easy way out when it comes to delayed convergence

### DIFF
--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -106,6 +106,9 @@ printf "Snapshotting post-Cobbler\n"
 printf "#### Chef all the nodes\n"
 vagrant ssh -c "sudo apt-get install -y sshpass"
 
+printf "#### Run Chef one time on the bootstrap node to force convergence\n"
+vagrant ssh -c "sudo chef-client --once"
+
 printf "#### Chef machine bcpc-vms\n"
 vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT Basic"
 vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT Bootstrap"


### PR DESCRIPTION
This resolves the issue where the initial Chef run of VMs will fail ( #729 ) , albeit in a somewhat bad way. Since this is what we've been doing to make our builds work on the first run anyway, we might as well merge it and fix the real issue later on.