### PR TITLE
Zabbix use local ip

### DIFF
--- a/cookbooks/bcpc/templates/default/zabbix/server.conf.erb
+++ b/cookbooks/bcpc/templates/default/zabbix/server.conf.erb
@@ -5,7 +5,7 @@
 # Local changes will be reverted.
 #
 
-SourceIP=<%="#{node[:ipaddress]}"%>
+SourceIP=<%="#{node[:bcpc][:floating][:ip]}"%>
 
 LogFile=/var/log/zabbix/zabbix_server.log
 LogFileSize=32

--- a/cookbooks/bcpc/templates/default/zabbix/server.conf.erb
+++ b/cookbooks/bcpc/templates/default/zabbix/server.conf.erb
@@ -5,7 +5,7 @@
 # Local changes will be reverted.
 #
 
-SourceIP=<%="#{node[:bcpc][:management][:vip]}"%>
+SourceIP=<%="#{node[:ipaddress]}"%>
 
 LogFile=/var/log/zabbix/zabbix_server.log
 LogFileSize=32


### PR DESCRIPTION
zabbix server should use local ip rather than global virtual ip
Otherwise zabbix servers that are not holding the global vip won't be able to receive responses and will report the page to be unavailable.
