### PR TITLE
Changes to export HBase master IPC stats to Graphite

### DIFF
--- a/cookbooks/bcpc_jmxtrans/attributes/default.rb
+++ b/cookbooks/bcpc_jmxtrans/attributes/default.rb
@@ -332,6 +332,11 @@ default['jmxtrans']['default_queries']['hbase_master'] = [
         "ritCountOverThreshold",
         "ritCount"
       ]
+  },
+  {
+    'obj' => "Hadoop:name=Master,service=HBase,sub=IPC",
+    'result_alias' => "hbm_ipc",
+    'attr' => []
   }
 ]
 default['jmxtrans']['default_queries']['hbase_rs'] = [


### PR DESCRIPTION
Will help with debugging and alerting on HBase master JMX stats. 