### PR TITLE
Finish moving bcpc-hadoop::graphite_disk_wrapper to converge-time

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/graphite_disk_wrapper.rb
+++ b/cookbooks/bcpc-hadoop/recipes/graphite_disk_wrapper.rb
@@ -7,17 +7,22 @@ ruby_block 'graphite-directory-structure' do
 
     if reservation_requests.include?("graphite_disk") then
       disk_index = reservation_requests.index("graphite_disk")
+      graphite_dir = "/disk/#{disk_index}/graphite_disk"
 
-      Chef::Resource::Directory.new("graphite-#{disk_index}").tap do |dd|
-        dd.path "/disk/#{disk_index}/graphite_disk"
+      Chef::Resource::Directory.new("graphite-#{disk_index}",
+                                    run_context).tap do |dd|
+        dd.path graphite_dir
         dd.owner 'root'
         dd.group 'root'
         dd.recursive false
+        dd.run_action(:create)
       end
 
-      Chef::Resource::Link.new(node[:bcpc][:graphite][:install_dir]).tap do |ll|
-        ll.to "/disk/#{disk_index}/graphite_disk"
+      Chef::Resource::Link.new(node[:bcpc][:graphite][:install_dir],
+                               run_context).tap do |ll|
+        ll.to graphite_dir
         ll.link_type :symbolic
+        ll.run_action(:create)
       end
     end
   end


### PR DESCRIPTION
This was ported incorrectly from compile-time to converge time.  The "run_action" calls were missing, so the symlink was never created, and Graphite was writing its data directly to the root volume.

This PR fixes this issue.