### PR TITLE
Use a default for viphost(name)

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -102,6 +102,8 @@ default['bcpc']['bootstrap']['interface'] = 'eth0'
 default['bcpc']['bootstrap']['pxe_interface'] = 'eth1'
 default['bcpc']['bootstrap']['server'] = '10.0.100.3'
 default['bcpc']['bootstrap']['vip'] = node['bcpc']['bootstrap']['server']
+default['bcpc']['bootstrap']['viphost'] = "#{node.chef_environment.downcase}." \
+                                          "#{node['bcpc']['domain_name']}"
 default['bcpc']['bootstrap']['dhcp_range'] = '10.0.100.14 10.0.100.250'
 default['bcpc']['bootstrap']['dhcp_subnet'] = '10.0.100.0'
 

--- a/stub-environment/environments/Test-Laptop.json
+++ b/stub-environment/environments/Test-Laptop.json
@@ -4,8 +4,7 @@
     "bcpc": {
       "domain_name" : "bcpc.example.com",
       "management": {
-        "vip" : "10.0.100.5",
-        "viphost": "test-laptop.bcpc.example.com"
+        "vip" : "10.0.100.5"
       },
       "floating": {
         "vip" : "192.168.100.5"
@@ -43,8 +42,8 @@
         "dhcp_subnet" : "10.0.100.0",
         "dhcp_range" : "10.0.100.14 10.0.100.250",
         "preseed": {
-	    "additional_packages": ["openssh-server","lldpd","virtualbox-guest-utils"]
-	}
+          "additional_packages": ["openssh-server","lldpd","virtualbox-guest-utils"]
+        }
       },
       "dns_servers" : [ "8.8.8.8", "8.8.4.4" ],
       "cluster" : {


### PR DESCRIPTION
This addresses code review issues from PR #751 that went unaddressed (and corrects to spaces from tabs for the environment's `node['bcpc']['bootstrap']['additional_packages']` entry).