### PR TITLE
Cluster assign roles boostrap fix and more automated_install idempotency

### DIFF
--- a/cluster_assign_roles.rb
+++ b/cluster_assign_roles.rb
@@ -31,6 +31,13 @@ class ClusterAssignRoles
   include BACH::ClusterData
 
   # If no runlist is provided, the runlist in cluster.txt will be used.
+  # arguments: 
+  #   nodes   -  a list of node objects (e.g. from parse_cluster_txt())
+  #   runlist -- a string for a Chef run_list
+  # returns: 
+  #   nothing
+  # side-affect:
+  #   updates Chef-server with runlists for nodes passed in
   def assign_roles(nodes:, runlist: nil)
     nodes.each do |node|
       chef_node_object = ridley.node.find(node[:fqdn])
@@ -43,6 +50,8 @@ class ClusterAssignRoles
         node[:runlist].split(',')
       elsif runlist.is_a?(String)
         runlist.split(',')
+      else
+        raise "No runlist for node #{node[:fqdn]}"
       end
 
       chef_node_object.run_list = target_runlist
@@ -167,7 +176,7 @@ class ClusterAssignRoles
 
     target_head_nodes = target_nodes & all_head_nodes
 
-    partial_runlist = ['role[BCPC-Hadoop-Head]']
+    partial_runlist = 'role[BCPC-Hadoop-Head]'
 
     # See comments in install_hadoop
     assign_roles(nodes: all_head_nodes, runlist: partial_runlist)

--- a/setup_chef_cookbooks.sh
+++ b/setup_chef_cookbooks.sh
@@ -15,14 +15,7 @@ ENVIRONMENT="${3-Test-Laptop}"
 # load binary_server_url and binary_server_host (usually the bootstrap)
 load_binary_server_info "$ENVIRONMENT"
 
-# make sure we do not have a previous .chef directory in place to allow re-runs
-if [[ -f .chef/knife.rb ]]; then
-  sudo knife node delete `hostname -f` -y -k /etc/chef-server/admin.pem -u admin || true
-  sudo knife client delete `hostname -f` -y -k /etc/chef-server/admin.pem -u admin || true
-  mv .chef/ ".chef_found_$(date +"%m-%d-%Y %H:%M:%S")"
-fi
-
-mkdir .chef
+mkdir -p .chef
 cat << EOF > .chef/knife.rb
 require 'rubygems'
 require 'ohai'


### PR DESCRIPTION
This corrects an issue where `cluster-assign-roles.sh <environment> Bootstrap` would fail with:
```
Assigned roles for bcpc-vm1, bcpc-vm2
Waiting for nodes to appear in search results (role:BCPC-Hadoop-Head)...
Waiting for nodes to appear in search results (role:BCPC-Hadoop-Head)...
Waiting for nodes to appear in search results (role:BCPC-Hadoop-Head)...
./cluster_assign_roles.rb:80:in `block in wait_for_indexed_roles': Did not find indexed roles for ["bcpc-vm1.bcpc.example.com", "bcpc-vm2.bcpc.example.com"] after 180 secs! (RuntimeError)
        from ./cluster_assign_roles.rb:65:in `times'
        from ./cluster_assign_roles.rb:65:in `wait_for_indexed_roles'
        from ./cluster_assign_roles.rb:175:in `install_bootstrap'
        from ./cluster_assign_roles.rb:444:in `car_cli'
        from ./cluster_assign_roles.rb:452:in `<main>'
Connection to 127.0.0.1 closed.
```

Further, this is a missing fix for making `automated_install.sh` idempotent by not removing `.chef` when re-running `setup_chef_cookbooks.sh`