### PR TITLE
Correction for PR #780 (should be bcpc management viphost not bcpc bootstrap viphost)

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -102,8 +102,6 @@ default['bcpc']['bootstrap']['interface'] = 'eth0'
 default['bcpc']['bootstrap']['pxe_interface'] = 'eth1'
 default['bcpc']['bootstrap']['server'] = '10.0.100.3'
 default['bcpc']['bootstrap']['vip'] = node['bcpc']['bootstrap']['server']
-default['bcpc']['bootstrap']['viphost'] = "#{node.chef_environment.downcase}." \
-                                          "#{node['bcpc']['domain_name']}"
 default['bcpc']['bootstrap']['dhcp_range'] = '10.0.100.14 10.0.100.250'
 default['bcpc']['bootstrap']['dhcp_subnet'] = '10.0.100.0'
 
@@ -113,6 +111,8 @@ default['bcpc']['bootstrap']['dhcp_subnet'] = '10.0.100.0'
 #
 ###########################################
 default['bcpc']['management']['vip'] = '1.2.3.5'
+default['bcpc']['management']['viphost'] = "#{node.chef_environment.downcase}"\
+                                           ".#{node['bcpc']['domain_name']}"
 default['bcpc']['management']['ip'] = '1.2.3.4'
 
 default['bcpc']['metadata']['ip'] = '169.254.169.254'


### PR DESCRIPTION
This corrects the default attribute from `node['bcpc']['bootstrap']['viphost']` to `node['bcpc']['management']['viphost']` where it should be.