### PR TITLE
hbase-site.xml properties for Phoenix query server security

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
@@ -98,6 +98,10 @@ if node[:bcpc][:hadoop][:kerberos][:enable] == true then
     "#{node[:bcpc][:hadoop][:kerberos][:data][:hbase][:principal]}/#{node[:bcpc][:hadoop][:kerberos][:data][:hbase][:princhost] == '_HOST' ? '_HOST' : node[:bcpc][:hadoop][:kerberos][:data][:hbase][:princhost]}@#{node[:bcpc][:hadoop][:kerberos][:realm]}"
   generated_values['hbase.regionserver.keytab.file'] =
     "#{node[:bcpc][:hadoop][:kerberos][:keytab][:dir]}/#{node[:bcpc][:hadoop][:kerberos][:data][:hbase][:keytab]}"
+  generated_values['phoenix.queryserver.kerberos.principal'] =
+    "#{node[:bcpc][:hadoop][:kerberos][:data][:hbase][:principal]}/#{node[:bcpc][:hadoop][:kerberos][:data][:hbase][:princhost] == '_HOST' ? '_HOST' : node[:bcpc][:hadoop][:kerberos][:data][:hbase][:princhost]}@#{node[:bcpc][:hadoop][:kerberos][:realm]}"
+  generated_values['phoenix.queryserver.keytab.file'] =
+    "#{node[:bcpc][:hadoop][:kerberos][:keytab][:dir]}/#{node[:bcpc][:hadoop][:kerberos][:data][:hbase][:keytab]}"
   generated_values['hbase.rpc.engine'] = 'org.apache.hadoop.hbase.ipc.SecureRpcEngine'
 end
 


### PR DESCRIPTION
Additional ``hbase-site.xml`` properties for *Phoenix* queryserver when a secured cluster is created.

**Note**: Not tested by creating a new cluster since the change is simple for it to be reviewed and merged.