### PR TITLE
Update jmxtrans user ulimits + adjust nproc for hbase user

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -43,6 +43,11 @@ user_ulimit "hdfs" do
   process_limit 65536
 end
 
+user_ulimit "jmxtrans" do
+  filehandle_limit 65536
+  process_limit 65536
+end
+
 user_ulimit "mapred" do
   filehandle_limit 65536
   process_limit 65536

--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -37,6 +37,7 @@ end
 
 user_ulimit "hbase" do
   filehandle_limit 65536
+  process_limit 65536
 end
 
 service "hbase-thrift" do


### PR DESCRIPTION
Per a suggestion from HWX, the jmxtrans user should have the same ulimit values, and hbase user should have the same nproc.