### PR TITLE
Partially revert ulimit change - leave jmxtrans crippled

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -43,9 +43,10 @@ user_ulimit "hdfs" do
   process_limit 65536
 end
 
+# Intentionally hobble jmxtrans to ensure it doesn't destroy the system
 user_ulimit "jmxtrans" do
-  filehandle_limit 65536
-  process_limit 65536
+  filehandle_limit 1024
+  process_limit 1024
 end
 
 user_ulimit "mapred" do


### PR DESCRIPTION
This partially reverts #791 , leaving only the hbase fix. Based on past experience, `jmxtrans` should be intentionally hobbled.