### PR TITLE
Uniquify hdfs test and cleanup tez.rb

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/tez.rb
+++ b/cookbooks/bcpc-hadoop/recipes/tez.rb
@@ -29,12 +29,11 @@ template "/etc/tez/conf/tez-site.xml" do
   mode 0655
 end
 
-bash "make_apps_tez_dir" do
+bash 'make_apps_tez_dir' do
   code <<EOH
-  hdfs dfs -mkdir -p /apps/tez
-EOH
-  user "hdfs"
-  not_if "hdfs dfs -test -d /apps/tez/", :user => "hdfs"
+    hdfs dfs -mkdir -p /apps/tez
+  EOH
+  user 'hdfs'
 end
 
 hdfs_testfile = "/user/hdfs/chef-tez-test-#{node['hostname']}"

--- a/cookbooks/bcpc-hadoop/recipes/tez.rb
+++ b/cookbooks/bcpc-hadoop/recipes/tez.rb
@@ -37,9 +37,10 @@ EOH
   not_if "hdfs dfs -test -d /apps/tez/", :user => "hdfs"
 end
 
-hdfs_write = "echo 'test' | hdfs dfs -copyFromLocal - /user/hdfs/chef-tez-test"
-hdfs_remove = "hdfs dfs -rm -skipTrash /user/hdfs/chef-tez-test"
-hdfs_test = "hdfs dfs -test -f /user/hdfs/chef-tez-test"
+hdfs_testfile = "/user/hdfs/chef-tez-test-#{node['hostname']}"
+hdfs_write = "echo 'test' | hdfs dfs -copyFromLocal - #{hdfs_testfile}"
+hdfs_remove = "hdfs dfs -rm -skipTrash #{hdfs_testfile}"
+hdfs_test = "hdfs dfs -test -f #{hdfs_testfile}"
 
 bash 'tez-remove-check-file' do
   code <<-EOH

--- a/cookbooks/bcpc-hadoop/recipes/tez.rb
+++ b/cookbooks/bcpc-hadoop/recipes/tez.rb
@@ -5,32 +5,32 @@
 #
 ::Chef::Recipe.send(:include, Bcpc_Hadoop::Helper)
 
-package hwx_pkg_str('tez', node[:bcpc][:hadoop][:distribution][:release]) do
+package hwx_pkg_str('tez', node['bcpc']['hadoop']['distribution']['release']) do
   action :install
 end
 
 directory "/etc/tez/conf.#{node.chef_environment}" do
-  owner "root"
-  group "root"
-  mode 00755
+  owner 'root'
+  group 'root'
+  mode 0o0755
   action :create
   recursive true
 end
 
-bash "update-tez-conf-alternatives" do
-  code %Q{
+bash 'update-tez-conf-alternatives' do
+  code %Q(
     update-alternatives --install /etc/tez/conf tez-conf /etc/tez/conf.#{node.chef_environment} 50
     update-alternatives --set tez-conf /etc/tez/conf.#{node.chef_environment}
-  }
+  )
 end
 
-template "/etc/tez/conf/tez-site.xml" do
-  source "hdp_tez-site.xml.erb"
-  mode 0655
+template '/etc/tez/conf/tez-site.xml' do
+  source 'hdp_tez-site.xml.erb'
+  mode 0o0655
 end
 
 bash 'make_apps_tez_dir' do
-  code <<EOH
+  code <<-EOH
     hdfs dfs -mkdir -p /apps/tez
   EOH
   user 'hdfs'
@@ -43,21 +43,21 @@ hdfs_test = "hdfs dfs -test -f #{hdfs_testfile}"
 
 bash 'tez-remove-check-file' do
   code <<-EOH
-  #{hdfs_remove}
+    #{hdfs_remove}
   EOH
   user 'hdfs'
-  only_if "#{hdfs_test}", :user => 'hdfs'
+  only_if "#{hdfs_test}", user: 'hdfs'
 end
 
-bash "make_dir_to_copy_tez_targz" do
-  code <<EOH
-  hdfs dfs -mkdir -p /hdp/apps/#{node[:bcpc][:hadoop][:distribution][:release]}/tez/ 
-  hdfs dfs -put /usr/hdp/#{node[:bcpc][:hadoop][:distribution][:release]}/tez/lib/tez.tar.gz /hdp/apps/#{node[:bcpc][:hadoop][:distribution][:release]}/tez/
-  hdfs dfs -chown -R hdfs:hadoop /hdp
-  hdfs dfs -chmod -R 555 /hdp/apps/#{node[:bcpc][:hadoop][:distribution][:release]}/tez
-  hdfs dfs -chmod -R 444 /hdp/apps/#{node[:bcpc][:hadoop][:distribution][:release]}/tez/tez.tar.gz
-EOH
-  user "hdfs"
-  not_if "hdfs dfs -test -f /hdp/apps/#{node[:bcpc][:hadoop][:distribution][:release]}/tez/tez.tar.gz", :user => "hdfs"
-  only_if "#{hdfs_write} && #{hdfs_remove}", :user => "hdfs"
+bash 'make_dir_to_copy_tez_targz' do
+  code <<-EOH
+    hdfs dfs -mkdir -p /hdp/apps/#{node['bcpc']['hadoop']['distribution']['release']}/tez/
+    hdfs dfs -put /usr/hdp/#{node['bcpc']['hadoop']['distribution']['release']}/tez/lib/tez.tar.gz /hdp/apps/#{node['bcpc']['hadoop']['distribution']['release']}/tez/
+    hdfs dfs -chown -R hdfs:hadoop /hdp
+    hdfs dfs -chmod -R 555 /hdp/apps/#{node['bcpc']['hadoop']['distribution']['release']}/tez
+    hdfs dfs -chmod -R 444 /hdp/apps/#{node['bcpc']['hadoop']['distribution']['release']}/tez/tez.tar.gz
+  EOH
+  user 'hdfs'
+  not_if "hdfs dfs -test -f /hdp/apps/#{node['bcpc']['hadoop']['distribution']['release']}/tez/tez.tar.gz", user: 'hdfs'
+  only_if "#{hdfs_write} && #{hdfs_remove}", user: 'hdfs'
 end


### PR DESCRIPTION
Fixes issue #793 and makes me feel better seeing yellow and purple highlights disappear from my editor. First commit changes only the test file name to append the hostname "key," second commit removes an unnecessary `not_if` for the resource that does an `hdfs mkdir -p` (redundancy), last commit makes foodcritic and rubocop stop yelling at me when I have this file open.