### PR TITLE
Fix log spam in C-A-R and chef client invocations

### DIFF
--- a/cluster_assign_roles.rb
+++ b/cluster_assign_roles.rb
@@ -17,6 +17,7 @@
 # - if a chef object is provided, e.g. role[ROLE-NAME] or
 #   recipe[RECIPE-NAME], only nodes marked for that action are attempted
 #
+
 require 'json'
 require 'mixlib/shellout'
 require 'net/ssh'
@@ -24,8 +25,6 @@ require 'parallel'
 require 'pry'
 require 'uri'
 require_relative 'lib/cluster_data'
-
-Ridley::Logging.logger.level = Logger.const_get 'ERROR'
 
 class ClusterAssignRoles
   include BACH::ClusterData

--- a/cookbooks/bcpc/templates/default/knife.rb.erb
+++ b/cookbooks/bcpc/templates/default/knife.rb.erb
@@ -1,10 +1,30 @@
+# -*- mode: ruby -*-
+
 require 'rubygems'
 require 'ohai'
+
+#
+#
+# Workaround for older versions of ChefDK.
+#
+# https://github.com/berkshelf/berkshelf/pull/1668/
+# https://github.com/intridea/hashie/issues/394
+#
+require 'hashie'
+require 'hashie/logger'
+Hashie.logger = Logger.new(nil)
+
+#
+# Disable the Ohai password module which explodes on a
+# Single-Sign-On-joined system
+#
+begin
+  ohai.disabled_plugins = ['passwd']
+rescue
+  Ohai::Config[:disabled_plugins] = ['passwd']
+end
+
 o = Ohai::System.new
-
-# Disable the Ohai password module which explodes on a Single-Sign-On-joined system
-Ohai::Config[:disabled_plugins] = [ "passwd" ]
-
 o.all_plugins(['hostname','ipaddress'])
 
 log_level                :info
@@ -16,6 +36,9 @@ validation_key           '/etc/chef-server/chef-validator.pem'
 chef_server_url          'https://<%= node[:bcpc][:bootstrap][:server] %>'
 syntax_check_cache_path  '/home/vagrant/chef-bcpc/.chef/syntax_check_cache'
 cookbook_path            '/home/vagrant/chef-bcpc/vendor/cookbooks'
+
+ssl_verify_mode :verify_none
+client_name o[:hostname]
 
 <% if node[:bcpc][:bootstrap][:proxy] != nil -%>
 no_proxy_array = ["localhost", o[:ipaddress], o[:hostname], o[:fqdn], "<%= node[:bcpc][:bootstrap][:server] %>", "<%= node[:bcpc][:bootstrap][:server] %>"]

--- a/lib/cluster_data.rb
+++ b/lib/cluster_data.rb
@@ -11,7 +11,20 @@ require 'chef-vault'
 require 'json'
 require 'ohai'
 require 'pry'
+
+#
+#
+# Workaround log spam in older versions of ChefDK.
+#
+# https://github.com/berkshelf/berkshelf/pull/1668/
+# https://github.com/intridea/hashie/issues/394
+#
+require 'hashie'
+require 'hashie/logger'
+Hashie.logger = Logger.new(nil)
+
 require 'ridley'
+Ridley::Logging.logger.level = Logger.const_get 'ERROR'
 
 module BACH
   module ClusterData


### PR DESCRIPTION
This PR removes unwanted warning messages from the logs:

<tt>[2017-03-06T19:04:00+00:00] WARN: Ohai::Config[:disabled_plugins] is set. Ohai::Config[:disabled_plugins] is deprecated and will be removed in future releases of ohai. Use ohai.disabled_plugins in your configuration file to configure :disabled_plugins for ohai.</tt>

and

<tt>W, [2017-03-06T18:58:58.578311 #15844]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#class defined in Kernel. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.</tt>
