### PR TITLE
Revert "Allow using environment to set datanodes to decommissioning state"

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hdfs.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hdfs.rb
@@ -15,7 +15,6 @@ default[:bcpc][:hadoop][:hdfs][:dfs].tap do |dfs|
   dfs[:namenode][:avoid][:read][:stale][:datanode] = true
   dfs[:namenode][:avoid][:write][:stale][:datanode] = true
   dfs[:hosts][:exclude] = "/etc/hadoop/conf/dfs.exclude"
-  dfs[:hosts][:exclude][:nodes] = []
   dfs[:datanode][:du][:reserved] = 209715200 # 200 MB
   dfs[:permissions][:superusergroup] = "hdfs"
   dfs[:cluster][:administrators] = "hdfs"

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_dfs.exclude.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_dfs.exclude.erb
@@ -1,3 +1,0 @@
-<% node['bcpc']['hadoop']['hdfs']['dfs']['hosts']['exclude']['nodes'].each do |node| -%>
-<%= node %>
-<% end -%>


### PR DESCRIPTION
Reverts bloomberg/chef-bach#798

This was merged without adequate testing.