### PR TITLE
Requested fix for ruby-based C-A-R + unrelated cosmetic work

### DIFF
--- a/cookbooks/bach_spark/recipes/default.rb
+++ b/cookbooks/bach_spark/recipes/default.rb
@@ -37,11 +37,16 @@ link '/usr/spark/current' do
   to spark_bin_dir
 end
 
+# Spark 2.x expects to dynamically link LZO.
+package 'liblzo2-2' do
+  action :upgrade
+end
+
 # install fortran libs needed by some jobs
 package 'libatlas3gf-base' do
-  action :install
+  action :upgrade
 end
 
 package 'libopenblas-base' do
-  action :install
+  action :upgrade
 end

--- a/cookbooks/bach_spark/recipes/default.rb
+++ b/cookbooks/bach_spark/recipes/default.rb
@@ -1,3 +1,28 @@
+#
+# Cookbook Name:: bach_spark
+# Recipe:: default
+#
+# Copyright 2017, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This recipe installs spark to /usr/spark/ using a package
+# pre-generated on the bootstrap VM.  See bach_repository::spark for
+# the fpm invocation that creates the debian package.
+#
+
 spark_pkg_version = node[:spark][:package][:version]
 spark_bin_dir = node[:spark][:bin][:dir]
 

--- a/cookbooks/bcpc-hadoop/attributes/yarn.rb
+++ b/cookbooks/bcpc-hadoop/attributes/yarn.rb
@@ -12,6 +12,7 @@ default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["port"] = 8032
 default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["jmx"]["port"] = 3131
 default["bcpc"]["hadoop"]["yarn"]["scheduler"]["fair"]["min-vcores"] = 2
 default["bcpc"]["hadoop"]["yarn"]["min-free-space-per-disk-mb"] = 100
+default['bcpc']['hadoop']['yarn']['min_user_id'] = 1000
 
 yarn_log_dir = '/var/log/hadoop-yarn'
 yarn_pid_dir = '/var/run/hadoop-yarn'
@@ -33,7 +34,7 @@ default[:bcpc][:hadoop][:yarn][:env_sh].tap do |env_sh|
   env_sh[:YARN_LOGFILE] = yarn_logfile
   env_sh[:YARN_POLICYFILE] = yarn_policyfile
 
-  env_sh[:YARN_OPTS] =  
+  env_sh[:YARN_OPTS] =
     ' -Dhadoop.log.dir=' + yarn_log_dir +
     ' -Dyarn.log.dir=' + yarn_log_dir +
     ' -Dhadoop.log.file=' + yarn_logfile  +
@@ -42,34 +43,34 @@ default[:bcpc][:hadoop][:yarn][:env_sh].tap do |env_sh|
     ' -Dhadoop.root.logger=INFO,CONSOLE ' +
     ' -Dyarn.root.logger=INFO,CONSOLE ' +
     ' -Dyarn.policy.file=' + yarn_policyfile +
-    ' -Djute.maxbuffer=' + node[:bcpc][:hadoop][:jute][:maxbuffer].to_s 
-    
+    ' -Djute.maxbuffer=' + node[:bcpc][:hadoop][:jute][:maxbuffer].to_s
 
-  env_sh[:YARN_NODEMANAGER_OPTS] =  
+
+  env_sh[:YARN_NODEMANAGER_OPTS] =
    ' -Dcom.sun.management.jmxremote.port=' +
     node[:bcpc][:hadoop][:yarn][:nodemanager][:jmx][:port].to_s +
    ' -XX:HeapDumpPath=/var/log/hadoop-yarn/heap-dump-nm-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof ' +
-   ' -XX:+UseCMSInitiatingOccupancyOnly' + 
+   ' -XX:+UseCMSInitiatingOccupancyOnly' +
    ' -XX:CMSInitiatingOccupancyFraction=70' +
-   ' -XX:+HeapDumpOnOutOfMemoryError' + 
+   ' -XX:+HeapDumpOnOutOfMemoryError' +
    ' -XX:+ExitOnOutOfMemoryError' +
    ' -XX:+UseParNewGC' +
    ' -XX:+UseConcMarkSweepGC ' +
    ' -Dcom.sun.management.jmxremote.ssl=false' +
-   ' -Dcom.sun.management.jmxremote.authenticate=false' 
+   ' -Dcom.sun.management.jmxremote.authenticate=false'
 
-  env_sh[:YARN_RESOURCEMANAGER_OPTS] =  
+  env_sh[:YARN_RESOURCEMANAGER_OPTS] =
     ' -Dcom.sun.management.jmxremote.port=' +
     node[:bcpc][:hadoop][:yarn][:resourcemanager][:jmx][:port].to_s +
     ' -XX:HeapDumpPath=/var/log/hadoop-yarn/heap-dump-rm-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof' +
-    ' -XX:+UseCMSInitiatingOccupancyOnly' + 
+    ' -XX:+UseCMSInitiatingOccupancyOnly' +
     ' -XX:CMSInitiatingOccupancyFraction=70' +
-    ' -XX:+HeapDumpOnOutOfMemoryError' + 
+    ' -XX:+HeapDumpOnOutOfMemoryError' +
     ' -XX:+ExitOnOutOfMemoryError' +
     ' -XX:+UseParNewGC' +
     ' -XX:+UseConcMarkSweepGC ' +
     ' -Dcom.sun.management.jmxremote.ssl=false' +
-    ' -Dcom.sun.management.jmxremote.authenticate=false' 
+    ' -Dcom.sun.management.jmxremote.authenticate=false'
 end
 
 default[:bcpc][:hadoop][:yarn][:site_xml].tap do |site_xml|
@@ -102,7 +103,7 @@ default[:bcpc][:hadoop][:yarn][:site_xml].tap do |site_xml|
   site_xml["#{lce}.cgroups.mount-path"] = '/sys/fs/cgroup/'
 
   site_xml['yarn.nodemanager.remote-app-log-dir'] = '/var/log/hadoop-yarn/apps'
-  
+
   yarn_max_memory = lambda do
     avail_memory =
       node['bcpc']['hadoop']['yarn']['nodemanager']['avail_memory']
@@ -122,15 +123,15 @@ default[:bcpc][:hadoop][:yarn][:site_xml].tap do |site_xml|
       [1, (node['cpu']['total'] * avail_vcpu.call['ratio']).floor].max)
 
   site_xml['yarn.nodemanager.vmem-check-enabled'] = false
-                        
+
   site_xml['yarn.resourcemanager.nodes.exclude-path'] =
     '/etc/hadoop/conf/yarn.exclude'
 
-  site_xml['yarn.resourcemanager.scheduler.class'] =  
+  site_xml['yarn.resourcemanager.scheduler.class'] =
     'org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler'
 
   site_xml['yarn.scheduler.fair.preemption'] = true
-  
+
   site_xml['yarn.scheduler.maximum-allocation-mb'] = yarn_max_memory.call
 
   site_xml['yarn.timeline-service.client.max-retries'] = 0

--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -358,16 +358,17 @@ ruby_block "release_datanode_restart_lock" do
   only_if { my_restart_lock?(lock_znode_path, zk_hosts, node[:fqdn]) }
 end
 
-service "hadoop-yarn-nodemanager" do
-  supports :status => true, :restart => true, :reload => false
+service 'hadoop-yarn-nodemanager' do
+  supports status: true, restart: true, reload: false
   action [:enable, :start]
-  subscribes :restart, "link[/etc/init.d/hadoop-yarn-nodemanager]", :delayed
-  subscribes :restart, "template[/etc/hadoop/conf/hadoop-env.sh]", :delayed
-  subscribes :restart, "template[/etc/hadoop/conf/yarn-env.sh]", :delayed
-  subscribes :restart, "template[/etc/hadoop/conf/yarn-site.xml]", :delayed
-  subscribes :restart, "template[/etc/hadoop/conf/hdfs-site.xml]", :delayed
-  subscribes :restart, "template[/etc/hadoop/conf/mapred-site.xml]", :delayed
-  subscribes :restart, "bash[hdp-select hadoop-yarn-nodemanager]", :delayed
-  subscribes :restart, "user_ulimit[yarn]", :delayed
-  subscribes :restart, "log[jdk-version-changed]", :delayed
+  subscribes :restart, 'link[/etc/init.d/hadoop-yarn-nodemanager]'
+  subscribes :restart, 'template[/etc/hadoop/conf/hadoop-env.sh]'
+  subscribes :restart, 'template[/etc/hadoop/conf/yarn-env.sh]'
+  subscribes :restart, 'template[/etc/hadoop/conf/yarn-site.xml]'
+  subscribes :restart, 'template[/etc/hadoop/conf/hdfs-site.xml]'
+  subscribes :restart, 'template[/etc/hadoop/conf/mapred-site.xml]'
+  subscribes :restart, 'template[/etc/hadoop/conf/container-executor.cfg]'
+  subscribes :restart, 'bash[hdp-select hadoop-yarn-nodemanager]'
+  subscribes :restart, 'user_ulimit[yarn]'
+  subscribes :restart, 'log[jdk-version-changed]'
 end

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_container-executor.cfg.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_container-executor.cfg.erb
@@ -2,4 +2,4 @@ yarn.nodemanager.local-dirs=<%=@mounts.map{ |d| "file:///disk/#{d}/yarn/local" }
 yarn.nodemanager.linux-container-executor.group=yarn
 yarn.nodemanager.log-dirs=<%=@mounts.map{ |d| "file:///disk/#{d}/yarn/logs" }.join(",")%>
 banned.users=hdfs,yarn,mapred,bin      
-min.user.id=1000
+min.user.id=<%= node['bcpc']['hadoop']['yarn']['min_user_id'] %>

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -248,10 +248,6 @@ default['bcpc']['zabbix_dbname'] = 'zabbix'
 
 default['bcpc']['admin_email'] = 'admin@example.com'
 
-# Memory where InnoDB caches table and index data (in MB). Default is 128M.
-default['bcpc']['mysql']['innodb_buffer_pool_size'] =
-  ([(node[:memory][:total].to_i / 1024 * 0.02).floor, 128].max)
-
 #################################################
 #  attributes for chef vault download and install
 #################################################

--- a/cookbooks/bcpc/attributes/mysql.rb
+++ b/cookbooks/bcpc/attributes/mysql.rb
@@ -1,0 +1,6 @@
+# Memory where InnoDB caches table and index data (in MB). Default is 128M.
+default['bcpc']['mysql']['innodb_buffer_pool_size'] =
+  ([(node[:memory][:total].to_i / 1024 * 0.02).floor, 128].max)
+
+# Maximum connections per MySQL host. The MySQL default is 151.
+default['bcpc']['mysql']['max_connections'] = 500

--- a/cookbooks/bcpc/recipes/mysql.rb
+++ b/cookbooks/bcpc/recipes/mysql.rb
@@ -194,17 +194,12 @@ end
 
 mysql_nodes = get_nodes_for('mysql', 'bcpc')
 all_nodes = get_all_nodes
-max_connections =
-  [
-    (mysql_nodes.length * 50 + all_nodes.length * 5),
-    300
-  ].max
 pool_size = node['bcpc']['mysql']['innodb_buffer_pool_size']
 
 template '/etc/mysql/conf.d/wsrep.cnf' do
   source 'mysql/wsrep.cnf.erb'
   mode 00644
-  variables(max_connections: max_connections,
+  variables(max_connections: node['bcpc']['mysql']['max_connections'],
             innodb_buffer_pool_size: pool_size,
             servers: mysql_nodes)
   sensitive true if respond_to?(:sensitive)

--- a/cookbooks/bcpc/recipes/ssh.rb
+++ b/cookbooks/bcpc/recipes/ssh.rb
@@ -35,8 +35,8 @@ package 'openssh-server' do
 end
 
 service 'ssh' do
-  ignore_failure true
   action :enable
+  ignore_failure true
 end
 
 #
@@ -46,7 +46,10 @@ end
 #
 execute '/etc/init.d/ssh start' do
   action :run
-  ignore_failure true
+
+  if node[:lsb][:codename] == 'trusty'
+    ignore_failure true
+  end
 end
 
 template '/etc/ssh/sshd_config' do


### PR DESCRIPTION
This PR contains two important fixes:
- Warn the user and bail if cluster.txt is missing critical roles on head nodes
- Add `liblzo2` dependency for Spark 2.x to be able to read gzip files

Additionally there are minor, unrelated fixes:
- Make the yarn `min.user.id` parameterized to make VM clusters more pleasant to use with service principals
- Make sure ignore_failure is disabled on CentOS and Ubuntu 16.04 in `bcpc::ssh`
- Add copyright/license header to `bach_spark::default`