### PR TITLE
Tune oozie check action time

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/oozie.rb
+++ b/cookbooks/bcpc-hadoop/attributes/oozie.rb
@@ -30,3 +30,4 @@ default["bcpc"]["hadoop"]["oozie"]["service"]["JPAService"]["create"]["db"]["sch
 default["bcpc"]["hadoop"]["oozie"]["service"]["JPAService"]["pool"]["max"]["active"]["conn"] = 100
 default["bcpc"]["hadoop"]["oozie"]["authentication"]["token"]["validity"] = 36000
 default["bcpc"]["hadoop"]["oozie"]["service"]["ext"] = "org.apache.oozie.service.ZKLocksService,org.apache.oozie.service.ZKXLogStreamingService,org.apache.oozie.service.ZKJobsConcurrencyService,org.apache.oozie.service.ZKUUIDService"
+default['bcpc']['hadoop']['oozie']['check_action_delay'] = 90

--- a/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-site.xml.erb
@@ -384,4 +384,10 @@
     <value><%="-Xmx#{ (0.8 * 2 * node['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb']).round}m" %></value>
   </property>
 
+  <property>
+    <name>oozie.service.ActionCheckerService.action.check.delay</name>
+    <value><%= node['bcpc']['hadoop']['oozie']['check_action_delay'] %></value>
+  </property>
+
+
 </configuration>


### PR DESCRIPTION
 By default `Oozie` checks status of an action every 1 minute and if the action is not completed (reported as success) there will be a delay specified by `oozie.service.ActionCheckerService.action.check.delay (default value is 600 seconds)` to check the same action again. This default behavior  causes `oozie job -info <job_id>` to take `10 minutes` to report `success` for a job that was completed within a minute. The default delay of `600 seconds` can cause an `Oozie` workflow with multiple actions to take really long due to default delay added for each action in the workflow. 

This PR tunes the delay time for the same action to make `Oozie` jobs report success/failure status faster.

