### PR TITLE
Kerberos Enhancements

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/kerberos.rb
+++ b/cookbooks/bcpc-hadoop/attributes/kerberos.rb
@@ -1,19 +1,111 @@
 # Kerberos settings 
 default[:bcpc][:hadoop][:kerberos][:enable] = true
 default[:bcpc][:hadoop][:kerberos][:realm] = "BCPC.EXAMPLE.COM"
-default[:bcpc][:hadoop][:kerberos][:data] = {
-        :namenode => {"principal" => "nn", "keytab" => "nn.service.keytab", "owner" => "hdfs", "princhost" => "_HOST", "perms"=> "0600", "spnego_keytab" => "nn.service.keytab"},
-        :datanode => {"principal" => "dn", "keytab" => "dn.service.keytab", "owner" => "hdfs", "princhost" => "_HOST", "perms"=> "0600", "spnego_keytab" => "dn.service.keytab"},
-        :journalnode => {"principal" => "jn", "keytab" => "jn.service.keytab", "owner" => "hdfs", "princhost" => "_HOST", "perms"=> "0600", "spnego_keytab" => "jn.service.keytab"},
-        :resourcemanager => {"principal" => "rm", "keytab" => "rm.service.keytab", "owner" => "yarn", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" => "rm.service.keytab"},
-        :nodemanager => {"principal" => "nm", "keytab" => "nm.service.keytab", "owner" => "yarn", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" => "nm.service.keytab"},
-        :historyserver => {"principal" => "jhs", "keytab" => "jhs.service.keytab", "owner" => "mapred", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" => "jhs.service.keytab"},
-        :spnego => {"principal" => "HTTP", "keytab" => "spnego.service.keytab", "owner" => "hdfs", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" => "spnego.service.keytab"},
-        :zookeeper => {"principal" => "zookeeper", "keytab" => "zookeeper.service.keytab", "owner" => "zookeeper", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" => "zookeeper.service.keytab"},
-        :hbase => {"principal" => "hbase", "keytab" => "hbase.service.keytab", "owner" => "hbase", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" =>  "hbase.service.keytab"},
-        :httpfs => {"principal" => "httpfs", "keytab" => "httpfs.service.keytab", "owner" => "httpfs", "princhost"  => "_HOST", "perms" => "0600", "spnego_keytab" => "httpfs.service.keytab"},
-        :hive => {"principal" => "hive", "keytab" => "hive.service.keytab", "owner" => "hive", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" => "hive.service.keytab"},
-        :flume=> {"principal" => "flume", "keytab" => "flume.service.keytab", "owner" => "flume", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" => "flume.service.keytab"},
-        :oozie => {"principal" => "oozie", "keytab" => "oozie.service.keytab", "owner" => "oozie", "princhost" => "_HOST", "perms" => "0600", "spnego_keytab" => "oozie.service.keytab"}}
+default['bcpc']['hadoop']['kerberos']['data'] = {
+  namenode: {
+    principal: 'hdfs',
+    keytab: 'hdfs.service.keytab',
+    owner: 'hdfs',
+    princhost: '_HOST',
+    perms: '0600',
+    spnego_keytab: 'hdfs.service.keytab'
+  },
+  datanode: {
+    principal: 'hdfs',
+    keytab: 'hdfs.service.keytab',
+    owner: 'hdfs',
+    princhost: '_HOST',
+    perms: '0600',
+    spnego_keytab: 'hdfs.service.keytab'
+  },
+  journalnode: {
+    principal: 'hdfs',
+    keytab: 'hdfs.service.keytab',
+    owner: 'hdfs',
+    princhost: '_HOST',
+    perms: '0600',
+    spnego_keytab: 'hdfs.service.keytab'
+  },
+  resourcemanager: {
+    principal: 'yarn',
+    keytab: 'yarn.service.keytab',
+    owner: 'yarn',
+    princhost: '_HOST',
+    perms: '0600',
+    spnego_keytab: 'yarn.service.keytab'
+  },
+  nodemanager: {
+    principal: 'yarn',
+    keytab: 'yarn.service.keytab',
+    owner: 'yarn',
+    princhost: '_HOST',
+    perms: '0600',
+    spnego_keytab: 'yarn.service.keytab'
+  },
+  historyserver: {
+    principal: 'mapred',
+    keytab: 'mapred.service.keytab',
+    owner: 'mapred',
+    princhost: '_HOST',
+    perms: '0600',
+    spnego_keytab: 'mapred.service.keytab'
+  },
+  spnego: {
+    principal: 'HTTP',
+    keytab: 'spnego.service.keytab',
+    owner: 'hdfs',
+    princhost: '_HOST',
+    perms: '0600',
+    spnego_keytab: 'spnego.service.keytab'
+  },
+  zookeeper: {
+    principal: 'zookeeper',
+    keytab: 'zookeeper.service.keytab',
+    owner: 'zookeeper',
+    princhost: '_HOST',
+    perms: '0600',
+    spnego_keytab: 'zookeeper.service.keytab'
+  },
+  hbase: {
+    principal: 'hbase',
+    keytab: 'hbase.service.keytab',
+    owner: 'hbase',
+    princhost: '_HOST',
+    perms: '0600',
+    spnego_keytab: 'hbase.service.keytab'
+  },
+  httpfs: {
+    principal: 'httpfs',
+    keytab: 'httpfs.service.keytab',
+    owner: 'httpfs',
+    princhost: '_HOST',
+    perms: '0600',
+    spnego_keytab: 'httpfs.service.keytab'
+  },
+  hive: {
+    principal: 'hive',
+    keytab: 'hive.service.keytab',
+    owner: 'hive',
+    princhost: '_HOST',
+    perms: '0600',
+    spnego_keytab: 'hive.service.keytab'
+  },
+  oozie: {
+    principal: 'oozie',
+    keytab: 'oozie.service.keytab',
+    owner: 'oozie',
+    princhost: '_HOST',
+    perms: '0600',
+    spnego_keytab: 'oozie.service.keytab'
+  },
+  flume: {
+    principal: 'flume',
+    keytab: 'flume.service.keytab',
+    owner: 'flume',
+    princhost: '_HOST',
+    perms: '0600',
+    spnego_keytab: 'flume.service.keytab'
+  }
+}
 default[:bcpc][:hadoop][:kerberos][:keytab][:dir] = "/etc/security/keytabs"
 default[:bcpc][:hadoop][:kerberos][:keytab][:recreate] = false

--- a/cookbooks/bcpc-hadoop/attributes/kerberos.rb
+++ b/cookbooks/bcpc-hadoop/attributes/kerberos.rb
@@ -6,104 +6,117 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     principal: 'hdfs',
     keytab: 'hdfs.service.keytab',
     owner: 'hdfs',
+    group: 'hadoop',
     princhost: '_HOST',
-    perms: '0600',
+    perms: '0440',
     spnego_keytab: 'hdfs.service.keytab'
   },
   datanode: {
     principal: 'hdfs',
     keytab: 'hdfs.service.keytab',
     owner: 'hdfs',
+    group: 'hadoop',
     princhost: '_HOST',
-    perms: '0600',
+    perms: '0440',
     spnego_keytab: 'hdfs.service.keytab'
   },
   journalnode: {
     principal: 'hdfs',
     keytab: 'hdfs.service.keytab',
     owner: 'hdfs',
+    group: 'hadoop',
     princhost: '_HOST',
-    perms: '0600',
+    perms: '0440',
     spnego_keytab: 'hdfs.service.keytab'
   },
   resourcemanager: {
     principal: 'yarn',
     keytab: 'yarn.service.keytab',
     owner: 'yarn',
+    group: 'hadoop',
     princhost: '_HOST',
-    perms: '0600',
+    perms: '0440',
     spnego_keytab: 'yarn.service.keytab'
   },
   nodemanager: {
     principal: 'yarn',
     keytab: 'yarn.service.keytab',
     owner: 'yarn',
+    group: 'hadoop',
     princhost: '_HOST',
-    perms: '0600',
+    perms: '0440',
     spnego_keytab: 'yarn.service.keytab'
   },
   historyserver: {
     principal: 'mapred',
     keytab: 'mapred.service.keytab',
     owner: 'mapred',
+    group: 'hadoop',
     princhost: '_HOST',
-    perms: '0600',
+    perms: '0440',
     spnego_keytab: 'mapred.service.keytab'
   },
   spnego: {
     principal: 'HTTP',
     keytab: 'spnego.service.keytab',
     owner: 'hdfs',
+    group: 'hadoop',
     princhost: '_HOST',
-    perms: '0600',
+    perms: '0440',
     spnego_keytab: 'spnego.service.keytab'
   },
   zookeeper: {
     principal: 'zookeeper',
     keytab: 'zookeeper.service.keytab',
     owner: 'zookeeper',
+    group: 'hadoop',
     princhost: '_HOST',
-    perms: '0600',
+    perms: '0440',
     spnego_keytab: 'zookeeper.service.keytab'
   },
   hbase: {
     principal: 'hbase',
     keytab: 'hbase.service.keytab',
     owner: 'hbase',
+    group: 'hadoop',
     princhost: '_HOST',
-    perms: '0600',
+    perms: '0440',
     spnego_keytab: 'hbase.service.keytab'
   },
   httpfs: {
     principal: 'httpfs',
     keytab: 'httpfs.service.keytab',
     owner: 'httpfs',
+    group: 'hadoop',
     princhost: '_HOST',
-    perms: '0600',
+    perms: '0440',
     spnego_keytab: 'httpfs.service.keytab'
   },
   hive: {
     principal: 'hive',
     keytab: 'hive.service.keytab',
     owner: 'hive',
+    group: 'hadoop',
     princhost: '_HOST',
-    perms: '0600',
+    perms: '0440',
     spnego_keytab: 'hive.service.keytab'
   },
   oozie: {
     principal: 'oozie',
     keytab: 'oozie.service.keytab',
     owner: 'oozie',
+    group: 'hadoop',
     princhost: '_HOST',
-    perms: '0600',
+    perms: '0440',
     spnego_keytab: 'oozie.service.keytab'
   },
   flume: {
     principal: 'flume',
     keytab: 'flume.service.keytab',
     owner: 'flume',
+    group: 'hadoop',
     princhost: '_HOST',
-    perms: '0600',
+    perms: '0440',
     spnego_keytab: 'flume.service.keytab'
   }
 }

--- a/cookbooks/bcpc-hadoop/definitions/configure_kerberos.rb
+++ b/cookbooks/bcpc-hadoop/definitions/configure_kerberos.rb
@@ -27,7 +27,7 @@ define :configure_kerberos do
     # Create the keytab file
     file "#{keytab_dir}/#{keytab_file}" do
       owner "#{srvdat['owner']}"
-      group "root"
+      group "#{srvdat['group']}"
       mode "#{srvdat['perms']}"
       action :create_if_missing
       content lazy { Base64.decode64(get_config!("#{config_host}-#{srvc}")) }


### PR DESCRIPTION
Adding this PR to do few things:

1. Restructure`Kerberos` data structure and make it readable and easy to manage
2. Match `Kerberos` data structure with wrapper cookbook to avoid any mismatch between wrapper and upstream. Flume is one example that was missing from wrapper.
3. Add correct `Group` and grant permissions while creating `Keytabs`
