### PR TITLE
Better kerberos deployment

### DIFF
--- a/cookbooks/bach_krb5/recipes/keytabs.rb
+++ b/cookbooks/bach_krb5/recipes/keytabs.rb
@@ -54,11 +54,10 @@ get_cluster_nodes().each do |h|
     keytab_file = va['keytab']
     keytab_path = ::File.join(keytab_dir, host_fqdn, keytab_file)
     regular_principal = "#{service_principal}/#{host_fqdn}@#{realm}"
-    http_principal = "HTTP/#{host_fqdn}@#{realm}"
     vip_principal = "#{service_principal}/#{viphost}@#{realm}"
 
     # Variable to hold all principals for a single keytab
-    keytab_principals = "#{regular_principal} #{http_principal} #{vip_principal}"
+    keytab_principals = "#{regular_principal} #{vip_principal}"
     
     # Create the keytab file
     execute "creating-keytab-for-#{ke}" do
@@ -68,7 +67,7 @@ get_cluster_nodes().each do |h|
       not_if {
         # Don't run if all principals are found in an existing keytab file.
         require 'mixlib/shellout'
-        [regular_principal, http_principal, vip_principal].map do |princ|
+        [regular_principal, vip_principal].map do |princ|
           cc = Mixlib::ShellOut.new("klist -k #{keytab_path} | grep #{princ}")
           cc.run_command
           cc.status.success?
@@ -77,7 +76,7 @@ get_cluster_nodes().each do |h|
     end
 
     # Verify the keytab file, because kadmin.local does not return errors.
-    [regular_principal, http_principal, vip_principal].each do |princ|
+    [regular_principal, vip_principal].each do |princ|
       execute "verifying-#{princ}-keytab" do
         command "klist -k #{keytab_path} | grep #{princ}"
       end

--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -169,7 +169,16 @@ default['bcpc']['hadoop']['copylog']['authlog'] = {
 
 
 # Ensure the following group mappings in the group database
-default[:bcpc][:hadoop][:os][:group][:hadoop][:members]=["hdfs","yarn"]
+default[:bcpc][:hadoop][:os][:group][:hadoop][:members] = [
+ "hdfs",
+ "yarn",
+ "hbase",
+ "oozie",
+ "hive",
+ "zookeeper",
+ "mapred",
+ "httpfs"
+]
 default[:bcpc][:hadoop][:os][:group][:hdfs][:members]=["hdfs"]
 default[:bcpc][:hadoop][:os][:group][:mapred][:members]=["yarn"]
 

--- a/cookbooks/bcpc-hadoop/attributes/kerberos.rb
+++ b/cookbooks/bcpc-hadoop/attributes/kerberos.rb
@@ -33,7 +33,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     principal: 'yarn',
     keytab: 'yarn.service.keytab',
     owner: 'yarn',
-    group: 'hadoop',
+    group: 'yarn',
     princhost: '_HOST',
     perms: '0440',
     spnego_keytab: 'spnego.service.keytab'
@@ -42,7 +42,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     principal: 'yarn',
     keytab: 'yarn.service.keytab',
     owner: 'yarn',
-    group: 'hadoop',
+    group: 'yarn',
     princhost: '_HOST',
     perms: '0440',
     spnego_keytab: 'spnego.service.keytab'
@@ -69,7 +69,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     principal: 'zookeeper',
     keytab: 'zookeeper.service.keytab',
     owner: 'zookeeper',
-    group: 'hadoop',
+    group: 'zookeeper',
     princhost: '_HOST',
     perms: '0440',
     spnego_keytab: 'spnego.service.keytab'
@@ -78,7 +78,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     principal: 'hbase',
     keytab: 'hbase.service.keytab',
     owner: 'hbase',
-    group: 'hadoop',
+    group: 'hbase',
     princhost: '_HOST',
     perms: '0440',
     spnego_keytab: 'spnego.service.keytab'
@@ -96,7 +96,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     principal: 'hive',
     keytab: 'hive.service.keytab',
     owner: 'hive',
-    group: 'hadoop',
+    group: 'hive',
     princhost: '_HOST',
     perms: '0440',
     spnego_keytab: 'spnego.service.keytab'
@@ -105,7 +105,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     principal: 'oozie',
     keytab: 'oozie.service.keytab',
     owner: 'oozie',
-    group: 'hadoop',
+    group: 'oozie',
     princhost: '_HOST',
     perms: '0440',
     spnego_keytab: 'spnego.service.keytab'
@@ -114,7 +114,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     principal: 'flume',
     keytab: 'flume.service.keytab',
     owner: 'flume',
-    group: 'hadoop',
+    group: 'flume',
     princhost: '_HOST',
     perms: '0440',
     spnego_keytab: 'spnego.service.keytab'

--- a/cookbooks/bcpc-hadoop/attributes/kerberos.rb
+++ b/cookbooks/bcpc-hadoop/attributes/kerberos.rb
@@ -9,7 +9,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     group: 'hadoop',
     princhost: '_HOST',
     perms: '0440',
-    spnego_keytab: 'hdfs.service.keytab'
+    spnego_keytab: 'spnego.service.keytab'
   },
   datanode: {
     principal: 'hdfs',
@@ -18,7 +18,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     group: 'hadoop',
     princhost: '_HOST',
     perms: '0440',
-    spnego_keytab: 'hdfs.service.keytab'
+    spnego_keytab: 'spnego.service.keytab'
   },
   journalnode: {
     principal: 'hdfs',
@@ -27,7 +27,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     group: 'hadoop',
     princhost: '_HOST',
     perms: '0440',
-    spnego_keytab: 'hdfs.service.keytab'
+    spnego_keytab: 'spnego.service.keytab'
   },
   resourcemanager: {
     principal: 'yarn',
@@ -36,7 +36,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     group: 'hadoop',
     princhost: '_HOST',
     perms: '0440',
-    spnego_keytab: 'yarn.service.keytab'
+    spnego_keytab: 'spnego.service.keytab'
   },
   nodemanager: {
     principal: 'yarn',
@@ -45,7 +45,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     group: 'hadoop',
     princhost: '_HOST',
     perms: '0440',
-    spnego_keytab: 'yarn.service.keytab'
+    spnego_keytab: 'spnego.service.keytab'
   },
   historyserver: {
     principal: 'mapred',
@@ -54,7 +54,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     group: 'hadoop',
     princhost: '_HOST',
     perms: '0440',
-    spnego_keytab: 'mapred.service.keytab'
+    spnego_keytab: 'spnego.service.keytab'
   },
   spnego: {
     principal: 'HTTP',
@@ -72,7 +72,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     group: 'hadoop',
     princhost: '_HOST',
     perms: '0440',
-    spnego_keytab: 'zookeeper.service.keytab'
+    spnego_keytab: 'spnego.service.keytab'
   },
   hbase: {
     principal: 'hbase',
@@ -81,7 +81,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     group: 'hadoop',
     princhost: '_HOST',
     perms: '0440',
-    spnego_keytab: 'hbase.service.keytab'
+    spnego_keytab: 'spnego.service.keytab'
   },
   httpfs: {
     principal: 'httpfs',
@@ -90,7 +90,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     group: 'hadoop',
     princhost: '_HOST',
     perms: '0440',
-    spnego_keytab: 'httpfs.service.keytab'
+    spnego_keytab: 'spnego.service.keytab'
   },
   hive: {
     principal: 'hive',
@@ -99,7 +99,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     group: 'hadoop',
     princhost: '_HOST',
     perms: '0440',
-    spnego_keytab: 'hive.service.keytab'
+    spnego_keytab: 'spnego.service.keytab'
   },
   oozie: {
     principal: 'oozie',
@@ -108,7 +108,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     group: 'hadoop',
     princhost: '_HOST',
     perms: '0440',
-    spnego_keytab: 'oozie.service.keytab'
+    spnego_keytab: 'spnego.service.keytab'
   },
   flume: {
     principal: 'flume',
@@ -117,7 +117,7 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     group: 'hadoop',
     princhost: '_HOST',
     perms: '0440',
-    spnego_keytab: 'flume.service.keytab'
+    spnego_keytab: 'spnego.service.keytab'
   }
 }
 default[:bcpc][:hadoop][:kerberos][:keytab][:dir] = "/etc/security/keytabs"

--- a/cookbooks/bcpc-hadoop/definitions/configure_kerberos.rb
+++ b/cookbooks/bcpc-hadoop/definitions/configure_kerberos.rb
@@ -35,19 +35,21 @@ define :configure_kerberos do
     end
 
     princ_host = srvdat['princhost'] == "_HOST" ? float_host(node[:fqdn]) : srvdat['princhost']
+    
+    if srvdat['principal'] != "HTTP"
+      execute "kdestroy-for-#{srvdat['owner']}" do
+        command "kdestroy"
+        user "#{srvdat['owner']}"
+        action :run
+        only_if { user_exists?("#{srvdat['owner']}") }
+      end
 
-    execute "kdestroy-for-#{srvdat['owner']}" do
-      command "kdestroy"
-      user "#{srvdat['owner']}"
-      action :run
-      only_if { user_exists?("#{srvdat['owner']}") }
-    end
-
-    execute "kinit-for-#{srvdat['owner']}" do
-      command "kinit -kt #{keytab_dir}/#{keytab_file} #{srvdat['principal']}/#{princ_host}"
-      action :run
-      user "#{srvdat['owner']}"
-      only_if { user_exists?("#{srvdat['owner']}") }
+      execute "kinit-for-#{srvdat['owner']}" do
+        command "kinit -kt #{keytab_dir}/#{keytab_file} #{srvdat['principal']}/#{princ_host}"
+        action :run
+        user "#{srvdat['owner']}"
+        only_if { user_exists?("#{srvdat['owner']}") }
+      end
     end
   end
 end

--- a/cookbooks/bcpc-hadoop/recipes/copylog.rb
+++ b/cookbooks/bcpc-hadoop/recipes/copylog.rb
@@ -30,7 +30,11 @@ link "/etc/init.d/flume-agent-multi" do
   notifies :run, "bash[kill flume-java]", :immediate
 end
 
-configure_kerberos 'flume_kerb' do
+configure_kerberob  'flume_spnego' do
+  service_name 'spnego'
+end
+
+flume_kerb' do
   service_name 'flume'
 end
 

--- a/cookbooks/bcpc-hadoop/recipes/copylog.rb
+++ b/cookbooks/bcpc-hadoop/recipes/copylog.rb
@@ -30,7 +30,7 @@ link "/etc/init.d/flume-agent-multi" do
   notifies :run, "bash[kill flume-java]", :immediate
 end
 
-configure_kerberob  'flume_spnego' do
+configure_kerberos  'flume_spnego' do
   service_name 'spnego'
 end
 

--- a/cookbooks/bcpc-hadoop/recipes/copylog.rb
+++ b/cookbooks/bcpc-hadoop/recipes/copylog.rb
@@ -34,7 +34,7 @@ configure_kerberob  'flume_spnego' do
   service_name 'spnego'
 end
 
-flume_kerb' do
+configure_kerberos 'flume_kerb' do
   service_name 'flume'
 end
 

--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -59,12 +59,24 @@ user_ulimit "yarn" do
   process_limit 65536
 end
 
+configure_kerberos 'datanode_spnego' do
+  service_name 'spnego'
+end
+
 configure_kerberos 'datanode_kerb' do
   service_name 'datanode'
 end
 
+configure_kerberos 'nodemanager_spnego' do
+  service_name 'spnego'
+end
+
 configure_kerberos 'nodemanager_kerb' do
   service_name 'nodemanager'
+end
+
+configure_kerberos 'mapred_spnego' do
+  service_name 'spnego'
 end
 
 configure_kerberos 'mapred_kerb' do

--- a/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_master.rb
@@ -31,6 +31,10 @@ phoenix-client
   hdp_select(p, node[:bcpc][:hadoop][:distribution][:active_release])
 end
 
+configure_kerberos 'hbase_spnego' do
+  service_name 'spnego'
+end
+
 configure_kerberos 'hbase_kerb' do
   service_name 'hbase'
 end

--- a/cookbooks/bcpc-hadoop/recipes/historyserver.rb
+++ b/cookbooks/bcpc-hadoop/recipes/historyserver.rb
@@ -33,6 +33,10 @@ end
   end
 end
 
+configure_kerberos 'historyserver_spnego' do
+  service_name 'spnego'
+end
+
 configure_kerberos 'historyserver_kerb' do
   service_name 'historyserver'
 end

--- a/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
@@ -27,6 +27,10 @@ user_ulimit "hive" do
   process_limit 65536
 end
 
+configure_kerberos 'hive_spnego' do
+  service_name 'spnego'
+end
+
 configure_kerberos 'hive_kerb' do
   service_name 'hive'
 end

--- a/cookbooks/bcpc-hadoop/recipes/httpfs.rb
+++ b/cookbooks/bcpc-hadoop/recipes/httpfs.rb
@@ -24,6 +24,10 @@ bash "kill hdfs-httpfs" do
   returns [0, 1]
 end
 
+configure_kerberos 'httpfs_spnego' do
+  service_name 'spnego'
+end
+
 configure_kerberos 'httpfs_kerb' do
   service_name 'httpfs'
 end

--- a/cookbooks/bcpc-hadoop/recipes/journalnode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/journalnode.rb
@@ -132,6 +132,10 @@ link "/etc/init.d/hadoop-hdfs-journalnode" do
   notifies :run, 'bash[kill hdfs-journalnode]', :immediate
 end
 
+configure_kerberos 'journalnode_spnego' do
+  service_name 'spnego'
+end
+
 configure_kerberos 'namenode_kerb' do
   service_name 'namenode'
 end

--- a/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
@@ -101,6 +101,10 @@ ruby_block 'create-nn-directories' do
   end
 end
 
+configure_kerberos 'namenode_spnego' do
+  service_name 'spnego'
+end
+
 configure_kerberos 'namenode_kerb' do
   service_name 'namenode'
 end

--- a/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
@@ -99,6 +99,10 @@ ruby_block 'create-nn-directories' do
   end
 end
 
+configure_kerberos 'namenode_spnego' do
+  service_name 'spnego'
+end
+
 configure_kerberos 'namenode_kerb' do
   service_name 'namenode'
 end

--- a/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
@@ -95,6 +95,10 @@ ruby_block 'create-namenode-directories' do
   end
 end
 
+configure_kerberos 'namenode_spnego' do
+  service_name 'spnego'
+end
+
 configure_kerberos 'namenode_kerb' do
   service_name 'namenode'
 end

--- a/cookbooks/bcpc-hadoop/recipes/oozie.rb
+++ b/cookbooks/bcpc-hadoop/recipes/oozie.rb
@@ -56,6 +56,10 @@ end
   hdp_select(pkg, node[:bcpc][:hadoop][:distribution][:active_release])
 end
 
+configure_kerberos 'oozie_spnego' do
+  service_name 'spnego'
+end
+
 configure_kerberos 'oozie_kerb' do
   service_name 'oozie'
 end

--- a/cookbooks/bcpc-hadoop/recipes/region_server.rb
+++ b/cookbooks/bcpc-hadoop/recipes/region_server.rb
@@ -42,6 +42,10 @@ template "/etc/default/hbase" do
   variables(:hbrs_jmx_port => node[:bcpc][:hadoop][:hbase_rs][:jmx][:port])
 end
 
+configure_kerberos 'region_server_spnego' do
+  service_name 'spnego'
+end
+
 configure_kerberos 'hbasers_kerb' do
   service_name 'hbase'
 end

--- a/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
@@ -100,6 +100,10 @@ bash "kill yarn-timelineserver" do
   returns [0, 1]
 end
 
+configure_kerberos 'rm_spnego' do
+  service_name 'spnego'
+end
+
 configure_kerberos 'rm_kerb' do
   service_name 'resourcemanager'
 end

--- a/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
+++ b/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
@@ -14,6 +14,10 @@ user_ulimit "zookeeper" do
   filehandle_limit 65536
 end
 
+configure_kerberos 'zookeeper_spnego' do
+  service_name 'spnego'
+end
+
 configure_kerberos 'zookeeper_kerb' do
   service_name 'zookeeper'
 end

--- a/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
+++ b/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
@@ -14,10 +14,6 @@ user_ulimit "zookeeper" do
   filehandle_limit 65536
 end
 
-configure_kerberos 'zookeeper_spnego' do
-  service_name 'spnego'
-end
-
 configure_kerberos 'zookeeper_kerb' do
   service_name 'zookeeper'
 end


### PR DESCRIPTION
Creating this PR to:

- Remove merging of `SPNEGO` principal into service keytab
- Create `SPENGO` keytab on each host (so far we were relying on merged keytab for `spnego` principal)
- Configure `Hadoop` services to read `SPNEGO` keytab instead of merged keytab
- Fix group memebership for all `Hadoop` service accounts

Breaking:

- All service accounts must belong to `Hadoop` group
- Service account from KDC are being used on all the clusters