### PR TITLE
Deterministic heap for namenode

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -72,7 +72,8 @@ default["bcpc"]["hadoop"]["namenode"]["gc_opts"] =
 
 default["bcpc"]["hadoop"]["mapreduce"]["framework"]["name"] = "yarn"
 default["bcpc"]["hadoop"]["namenode"]["handler"]["count"] = 100
-default["bcpc"]["hadoop"]["namenode"]["xmx"]["max_size"] = 16384
+default["bcpc"]["hadoop"]["namenode"]["xmx"]["max_size"] = 1024
+default["bcpc"]["hadoop"]["namenode"]["xmn"]["max_size"] = 128
 default["bcpc"]["hadoop"]["namenode"]["xmx"]["max_ratio"] = 0.25
 default["bcpc"]["hadoop"]["namenode"]["jmx"]["port"] = 10111
 default["bcpc"]["hadoop"]["namenode"]["rpc"]["port"] = 8020

--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -72,7 +72,9 @@ default["bcpc"]["hadoop"]["namenode"]["gc_opts"] =
 
 default["bcpc"]["hadoop"]["mapreduce"]["framework"]["name"] = "yarn"
 default["bcpc"]["hadoop"]["namenode"]["handler"]["count"] = 100
+# set to nil to calculate dynamically based on available memory
 default["bcpc"]["hadoop"]["namenode"]["xmx"]["max_size"] = 1024
+# set to nil to calculate dynamically based on available memory
 default["bcpc"]["hadoop"]["namenode"]["xmn"]["max_size"] = 128
 default["bcpc"]["hadoop"]["namenode"]["xmx"]["max_ratio"] = 0.25
 default["bcpc"]["hadoop"]["namenode"]["jmx"]["port"] = 10111

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_hadoop-env.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_hadoop-env.sh.erb
@@ -52,8 +52,8 @@ export HADOOP_SECURE_DN_USER=<%= node["bcpc"]["hadoop"]["hadoop_secure_dn_user"]
    datanode_heap = [node["bcpc"]["hadoop"]["datanode"]["xmx"]["max_size"], (node["memory"]["total"].to_i * node["bcpc"]["hadoop"]["datanode"]["xmx"]["max_ratio"]/1024).floor].min
    datanode_newsize = [(0.125*datanode_heap).ceil, 3072].min
 
-   namenode_heap = [node["bcpc"]["hadoop"]["namenode"]["xmx"]["max_size"], (node["memory"]["total"].to_i * node["bcpc"]["hadoop"]["namenode"]["xmx"]["max_ratio"]/1024).floor].min
-   namenode_newsize = [(0.125*namenode_heap).ceil, 3072].min 
+   namenode_heap = [node["bcpc"]["hadoop"]["namenode"]["xmx"]["max_size"], (node["memory"]["total"].to_i * node["bcpc"]["hadoop"]["namenode"]["xmx"]["max_ratio"]/1024).floor].max
+   namenode_newsize = [node["bcpc"]["hadoop"]["namenode"]["xmn"]["max_size"], (0.125 * namenode_heap).ceil].max 
 
    maxpermsize = [(node["memory"]["total"].to_i * 0.021).floor, 256].min
 -%>

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_hadoop-env.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_hadoop-env.sh.erb
@@ -52,13 +52,13 @@ export HADOOP_SECURE_DN_USER=<%= node["bcpc"]["hadoop"]["hadoop_secure_dn_user"]
    datanode_heap = [node["bcpc"]["hadoop"]["datanode"]["xmx"]["max_size"], (node["memory"]["total"].to_i * node["bcpc"]["hadoop"]["datanode"]["xmx"]["max_ratio"]/1024).floor].min
    datanode_newsize = [(0.125*datanode_heap).ceil, 3072].min
 
-   namenode_heap = [node["bcpc"]["hadoop"]["namenode"]["xmx"]["max_size"], (node["memory"]["total"].to_i * node["bcpc"]["hadoop"]["namenode"]["xmx"]["max_ratio"]/1024).floor].max
-   namenode_newsize = [node["bcpc"]["hadoop"]["namenode"]["xmn"]["max_size"], (0.125 * namenode_heap).ceil].max 
+   namenode_heap = node["bcpc"]["hadoop"]["namenode"]["xmx"]["max_size"] 
+   namenode_newsize = node["bcpc"]["hadoop"]["namenode"]["xmn"]["max_size"] 
 
    maxpermsize = [(node["memory"]["total"].to_i * 0.021).floor, 256].min
 -%>
 export HADOOP_DATANODE_OPTS="$HADOOP_DATANODE_OPTS -Xms<%= datanode_heap %>m -Xmx<%= datanode_heap %>m -Xmn<%= datanode_newsize %>m -XX:PermSize=<%= (0.5*maxpermsize).floor %>m -XX:MaxPermSize=<%= maxpermsize %>m <%= node["bcpc"]["hadoop"]["datanode"]["gc_opts"] %>"
-export HADOOP_NAMENODE_OPTS="$HADOOP_NAMENODE_OPTS -Xms<%= namenode_heap %>m -Xmx<%= namenode_heap %>m -Xmn<%= namenode_newsize %>m -XX:PermSize=<%= (0.5*maxpermsize).floor %>m -XX:MaxPermSize=<%= maxpermsize %>m <%= node["bcpc"]["hadoop"]["namenode"]["gc_opts"] %>"
+export HADOOP_NAMENODE_OPTS="$HADOOP_NAMENODE_OPTS -Xms<%= namenode_heap %>m -Xmx<%= namenode_heap %>m -XX:NewSize=<%= namenode_newsize %>m -XX:MaxNewSize=<%= namenode_newsize %>m -XX:PermSize=<%= (0.5*maxpermsize).floor %>m -XX:MaxPermSize=<%= maxpermsize %>m <%= node["bcpc"]["hadoop"]["namenode"]["gc_opts"] %>"
 
 <% if node[:bcpc][:hadoop].attribute?(:jmx_enabled) and node[:bcpc][:hadoop][:jmx_enabled] %>
 JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_hadoop-env.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_hadoop-env.sh.erb
@@ -52,8 +52,11 @@ export HADOOP_SECURE_DN_USER=<%= node["bcpc"]["hadoop"]["hadoop_secure_dn_user"]
    datanode_heap = [node["bcpc"]["hadoop"]["datanode"]["xmx"]["max_size"], (node["memory"]["total"].to_i * node["bcpc"]["hadoop"]["datanode"]["xmx"]["max_ratio"]/1024).floor].min
    datanode_newsize = [(0.125*datanode_heap).ceil, 3072].min
 
-   namenode_heap = node["bcpc"]["hadoop"]["namenode"]["xmx"]["max_size"] 
-   namenode_newsize = node["bcpc"]["hadoop"]["namenode"]["xmn"]["max_size"] 
+   namenode_heap = node["bcpc"]["hadoop"]["namenode"]["xmx"]["max_size"] || \
+    (node["memory"]["total"].to_i * \
+    node["bcpc"]["hadoop"]["namenode"]["xmx"]["max_ratio"]/1024).floor
+   namenode_newsize = node["bcpc"]["hadoop"]["namenode"]["xmn"]["max_size"] || \
+    (0.125 * namenode_heap).ceil
 
    maxpermsize = [(node["memory"]["total"].to_i * 0.021).floor, 256].min
 -%>


### PR DESCRIPTION
The current calculation was setup in such a way that NameNode heap would either be 16GB or some fraction of system memory, whichever is the minimum.  This was designed so that we are able to support real systems and along side this VM cluster.  This is not deterministic so lets just set to Xmx to 1GB and NewSize to 128m which is what is recommended for 1,000,000 files per http://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.3.6/bk_installing_manually_book/content/ref-80953924-1cbf-4655-9953-1e744290a6c3.1.html, and is probably too much for a toy VM cluster anyway.

BONUS: All the confusing logic is removed (at least for the NameNode)
BREAKING: This will restart a NameNode since we are making configuration chnages