### PR TITLE
remove ntop

### DIFF
--- a/cookbooks/bcpc/recipes/networking.rb
+++ b/cookbooks/bcpc/recipes/networking.rb
@@ -44,7 +44,6 @@ package 'vlan'
   iftop
   nmap
   ngrep
-  ntop
 ).each do |p|
   package p do
     action :upgrade


### PR DESCRIPTION
In ubuntu 12.04 and 14.04 ntop is not configured properly in the post-install and the service fails to start, aborting chef-client run