### PR TITLE
Add missing MaxDirectMemorySize param for master

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hbase.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hbase.rb
@@ -47,6 +47,7 @@ default["bcpc"]["hadoop"]["hbase_master"]["PretenureSizeThreshold"] = "1m"
 default["bcpc"]["hadoop"]["hbase_master"]["xmn"]["size"] = 256
 default["bcpc"]["hadoop"]["hbase_master"]["xms"]["size"] = 1024
 default["bcpc"]["hadoop"]["hbase_master"]["xmx"]["size"] = 1024
+default["bcpc"]["hadoop"]["hbase_master"]["mx_dir_mem"]["size"] = 256
 default["bcpc"]["hadoop"]["hbase_rs"]["jmx"]["port"] = 10102
 default["bcpc"]["hadoop"]["hbase_rs"]["xmn"]["size"] = 256
 default["bcpc"]["hadoop"]["hbase_rs"]["xms"]["size"] = 1024

--- a/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
@@ -64,6 +64,10 @@ if node["bcpc"]["hadoop"]["hbase"]["bucketcache"]["enabled"] == true then
    node['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] +
    ' -XX:MaxDirectMemorySize=' +
      node['bcpc']['hadoop']['hbase_rs']['mx_dir_mem']['size'].to_s + 'm'
+  node.default['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] =
+   node['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] +
+   ' -XX:MaxDirectMemorySize=' +
+     node['bcpc']['hadoop']['hbase_master']['mx_dir_mem']['size'].to_s + 'm'
 end
 
 if node[:bcpc][:hadoop][:kerberos][:enable] == true then


### PR DESCRIPTION
After performing an HDP version upgrade and enabling the off-heap cache, I noticed that the master will now fail with the same OOM as a RegionServer would when the bucketcache config value is set to `true`, since our current recipe will not explicitly set a `MaxDirectMemorySize` for the master. This simple change resolves that issue and allows separating the value between RS and master.

In the interest of time, I have not done my usual cleanup on the modified files, as much as it hurts me to ignore all the squiggly lines in my editor.