### PR TITLE
Adjust bootstrap chef client config symlink for both locations

### DIFF
--- a/cookbooks/bcpc/recipes/bootstrap.rb
+++ b/cookbooks/bcpc/recipes/bootstrap.rb
@@ -164,6 +164,12 @@ end
 
 package 'sshpass'
 
-link '/etc/chef/client.d/knife.rb' do
-  to '/home/vagrant/chef-bcpc/.chef/knife.rb'
+# Symlink configuration for chef-client AND for chef-shell
+vagrantchefconf = '/home/vagrant/chef-bcpc/.chef/knife.rb'
+chefconflinks = ['/etc/chef/client.d/knife.rb', '/etc/chef/client.rb']
+
+chefconflinks.each do |chefconflink|
+  link chefconflink do
+    to vagrantchefconf
+  end
 end


### PR DESCRIPTION
@amithkanand found that we've forgotten to symlink the regular configuration in `/etc/chef/client.rb` to the one we store in vagrant's home directory, though the symlink already existed for the configuration `chef-client` uses (`/etc/chef/client.d/knife.rb`). This PR fixes that issue and makes it possible to add additional config files in the future with relative ease. Should it have an attribute? Probably, but there's currently no value to an attribute for any of these configs outside of this recipe, so I hardcoded it. SORRY.