### PR TITLE
Select root disk based on disk controller driver in preseed

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -29,8 +29,24 @@ default['bcpc']['bootstrap']['preseed'].tap do |preseed|
     'touch /target/etc/udev/rules.d/75-persistent-net-generator.rules'
 
   #
+  # This is an ordered array of preferred disk controller kernel
+  # drivers.  The first enumerated disk found from the earliest driver
+  # in the list will be chosen by the preseed for use as a root device.
+  #
+  # If none of the drivers are in use, the first available /dev/sd*
+  # device will be used.
+  #
+  # See select_bach_root_disk.erb for details.
+  #
+  preseed['preferred_disk_drivers'] = ['ahci']
+
+  #
   # All these lines get concatenated, hence the semicolons and
   # backslashes.
+  #
+  # Despite the name "preseed," this is run during the partman stage.
+  # udevadm and friends are already available in the install
+  # environment.
   #
   preseed['early_command'] = <<-EOM.gsub(/^ {4}/, '')
       udevadm trigger; udevadm settle --timeout=30 ; \\

--- a/cookbooks/bcpc/recipes/cobbler.rb
+++ b/cookbooks/bcpc/recipes/cobbler.rb
@@ -214,6 +214,11 @@ template '/etc/cobbler/dhcp.template' do
   notifies :run, 'bash[cobbler-sync]', :delayed
 end
 
+template '/var/lib/cobbler/scripts/select_bach_root_disk' do
+  source 'cobbler/select_bach_root_disk.erb'
+  mode 0644
+end
+
 cookbook_file '/var/lib/cobbler/loaders/ipxe-x86_64.efi' do
   source 'ipxe-x86_64.efi'
   mode 0644

--- a/cookbooks/bcpc/templates/default/cobbler/select_bach_root_disk.erb
+++ b/cookbooks/bcpc/templates/default/cobbler/select_bach_root_disk.erb
@@ -1,0 +1,67 @@
+## -*- mode: shell-script -*-
+##
+## This script uses the ordered list of disk drivers from the bcpc
+## cookbook to preferentially select a root disk.  By default, the
+## first disk found attached to earliest disk driver in the list will
+## be used for the root disk.
+##
+## If no disks are attached to preferred disk drivers, all /dev/sd*
+## devices are included at the end of the glob, so we will fall back to
+## whatever is found first.
+##
+## This file starts out as an erb file, which chef renders to a
+## cheetah template.  Cobbler, in turn, renders the cheetah template
+## to a finished script.  The Cheetah format requires the unusual
+## comment and escape syntax.
+##
+mkdir -p /etc/udev/rules.d
+echo '' > /etc/udev/rules.d/99-bach.rules
+
+##
+## These udev rules create symlinks named by disk driver for block
+## devices attached to our preferred drivers.
+##
+<% preferred_drivers =
+    node['bcpc']['bootstrap']['preseed']['preferred_disk_drivers'] %>
+<% preferred_drivers.each do |module_name| %>
+echo 'KERNEL=="sd[a-z]", DRIVERS=="<%= module_name %>",'\
+     'SYMLINK+="<%= module_name %>/%k"' >> \
+     /etc/udev/rules.d/99-bach.rules
+<% end %>
+
+udevadm control --reload
+udevadm trigger
+udevadm settle --timeout=30
+
+<%
+  driver_globs = preferred_drivers.map do |module_name|
+    "/dev/#{module_name}/*"
+  end
+
+  candidate_disks_glob = driver_globs.join(' ') +
+    '/dev/sd[a-z] /dev/sd[a-z][a-z]'
+%>
+##
+## After creating the symlinks with udev, we create a glob that places
+## block devices attached to preferred disk controllers at the
+## beginning of the expanded string.
+##
+## The first item in the space-separated string, whether it is a
+## preferred disk controller device or a fallback, will be our root
+## disk.
+##
+## In bash this would be more easily written with arrays, but the
+## debian-installer environment only has 'ash,' a primitive Almquist
+## shell.  This degenerate example of the 'for' loop will leave the
+## first value in the $candidate_disk variable.
+##
+for candidate_disk in <%= candidate_disks_glob %>
+do break; done
+
+##
+## All candidate disk filenames are the original kernel name (the %k
+## substitution), so we can fulfill the contract with partman-auto by
+## taking the basename and pre-pending "/dev/" to the front.
+##
+devname=/dev/`basename \$candidate_disk`
+debconf-set partman-auto/disk \$devname

--- a/cookbooks/bcpc/templates/default/cobbler/trusty.preseed.erb
+++ b/cookbooks/bcpc/templates/default/cobbler/trusty.preseed.erb
@@ -59,14 +59,26 @@ d-i clock-setup/ntp boolean true
 d-i clock-setup/ntp-server string <%= @node[:ntp][:servers].first %>
 
 ### Partitioning
+
+#
+# This script selects a root disk based on node[:bcpc][:cobbler][:disk_drivers].
+#
+# After the root disk selection script, the early_command script from
+# node[:bcpc][:bootstrap][:preseed][:early_command] is run.  (This is
+# typically used to erase the data disks.)
+#
 d-i partman/early_command string \
+  wget -O - -q "http://$http_server:$http_port/cblr/svc/op/script/system/$system_name/?script=select_bach_root_disk" > /tmp/select_bach_root_disk.sh; ash -x /tmp/select_bach_root_disk.sh 2> /tmp/select_bach_root_disk.out; \
 <%=
   # The gsub calls are here to escape the early_command for use in a 
   # Cheetah template.
   shell_script = @node[:bcpc][:bootstrap][:preseed][:early_command]
   shell_script.gsub(/\$/, '\$')
 %>
-d-i partman-auto/disk string /dev/sda
+
+## # This is commented out because it will be configured by select_bach_root
+## d-i partman-auto/disk string /dev/sda
+
 d-i partman-auto/method string lvm
 d-i partman-lvm/confirm boolean true
 d-i partman-lvm/confirm_nooverwrite boolean true


### PR DESCRIPTION
This pull request updates our Ubuntu 14.04 preseed with a shell script to preferentially select a root disk based on the driver used for the disk controller.

This allows us to prefer AHCI volumes over RAID volumes on hardware in which we are using an SSD for root.

The root disk selection script will fall back to a simple shell glob if no preferred disk driver is set or no disks are attached to that driver. 