### PR TITLE
Update Gem file handling to not explode on Gem 'clamp' or 'chefish'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,10 @@ if File.exist?('/opt/chefdk/Gemfile')
     # strip off a Gem from a Git repo as it seems to confuse things
     opscode_gem_data.gsub!(/^gem.*opscode-pushy-client.*\n/,'')
     instance_eval(opscode_gem_data, "/opt/chefdk/Gemfile")
+elsif File.exist?('/opt/chef/Gemfile')
+  # overload the path so we do not re-cache these gems
+    opscode_gem_data = IO.read("/opt/chef/Gemfile")
+    instance_eval(opscode_gem_data, "/opt/chef/Gemfile")
 else
   source 'https://rubygems.org' do
     gem 'parallel'
@@ -25,7 +29,7 @@ else
   end
 end
 
-gem 'fpm', :git => 'https://github.com/cbaenziger/fpm' # workaround fpm #1197
+gem 'fpm'
 
 source 'https://rubygems.org' do
   gem 'faker'

--- a/cookbooks/bach_repository/Gemfile
+++ b/cookbooks/bach_repository/Gemfile
@@ -1,4 +1,5 @@
 # -*- mode: enh-ruby -*-
+ruby RUBY_VERSION
 source 'https://rubygems.org' do
 
   gem 'berkshelf'
@@ -7,4 +8,4 @@ source 'https://rubygems.org' do
   gem 'test-kitchen'
   gem 'builder'
 end
-gem 'fpm', :git => 'https://github.com/cbaenziger/fpm' # workaround fpm #1197
+gem 'fpm'


### PR DESCRIPTION
This fixes Ruby issues whereby we don't pin our Gemfile to the version of Ruby we are using and further do not use the `/opt/chef` versions of Ruby for the `bach_repository` test-kitchen VM. And we can stop using a temporary for of `fpm` now as the issues between `minit-tar` Gem seems to have resolved from fatal to only a warning.