### PR TITLE
Fixes to make master work in a disconnected environment Version 2

### DIFF
--- a/cookbooks/bcpc/recipes/chef_gems.rb
+++ b/cookbooks/bcpc/recipes/chef_gems.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook Name:: bcpc
+# Recipe:: chef_gems
+#
+# Copyright 2017, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This recipe configures the chef gems required to begin a chef-bach
+# run on a node.  It solves the chicken/egg problem of being unable to
+# load the full cookbook set until after installing chef gems.
+#
+# This recipe is typically run during the "install_stubs" phase of
+# cluster_assign_roles.
+#
+include_recipe 'bcpc::chef_poise_install'
+include_recipe 'bcpc::chef_vault_install'

--- a/cookbooks/bcpc/recipes/ssh.rb
+++ b/cookbooks/bcpc/recipes/ssh.rb
@@ -24,7 +24,8 @@
 # It has to be done in a data bag because we commonly delete the node
 # and client objects when a host is reinstalled.
 #
-include_recipe 'bcpc::chef_vault_install'
+
+include_recipe 'bcpc::chef_gems'
 
 package 'openssh-client' do
   action :upgrade


### PR DESCRIPTION
Resubmit #861 without Java as it has been already fixed and without the commits that were added later on top

- Force ruby-augeas onto the uniform bcpc_chef_gem definition
- Use the --deployment flag for bundler install when applicable
- Add poise to the recipe for install_stub in C-A-R

**DROPPED** from #861 
- Update java 8 to b131, which is actually available on Oracle internet mirrors -- already addressed in #865 
- Add a chef-bach version string to the message of the day -- already addressed in #857 

**OBSOLETES**
#867 #861 

