### PR TITLE
Correct issues for Java cookbook's handling of Java filenames

### DIFF
--- a/cookbooks/bach_repository/recipes/oracle_java.rb
+++ b/cookbooks/bach_repository/recipes/oracle_java.rb
@@ -2,6 +2,7 @@
 # Cookbook Name:: bach_repository
 # Recipe:: oracle_java
 #
+require 'pathname'
 include_recipe 'bach_repository::directory'
 bins_dir = node['bach']['repository']['bins_directory']
 
@@ -29,7 +30,10 @@ remote_file "#{bins_dir}/jce_policy-8.zip" do
   checksum node['bach']['repository']['java']['jce_checksum']
 end
 
-remote_file "#{bins_dir}/jdk-linux-x64.tar.gz" do
+java_tgz_name = Pathname.new(node['bach']['repository']['java']['jdk_url'])\
+                        .basename.to_s
+
+remote_file "#{bins_dir}/#{java_tgz_name}" do
   source node['bach']['repository']['java']['jdk_url']
   user 'root'
   group 'root'

--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -3,6 +3,7 @@
 #  Hadoop specific configs
 #
 #############################################
+require 'pathname'
 
 default["bcpc"]["hadoop"] = {}
 default["bcpc"]["hadoop"]["distribution"]["release"] = '2.3.6.2-3'
@@ -190,8 +191,11 @@ default['java']['jdk_version'] = 8
 default['java']['install_flavor'] = 'oracle'
 default['java']['accept_license_agreement'] = true
 
+java_url = node['java']['jdk']['8']['x86_64']['url']
+java_tgz_name = Pathname.new(java_url).basename.to_s
+
 default['java']['jdk']['8']['x86_64']['url'] =
-  get_binary_server_url + 'jdk-linux-x64.tar.gz'
+  get_binary_server_url + java_tgz_name
 
 default['java']['jdk']['8']['x86_64']['checksum'] =
   node['java']['jdk']['8']['x86_64']['checksum']


### PR DESCRIPTION
This should correct the issue which we are having with a generic Java tarball name. However, I am getting an issue with my bootstrap trying to install Chef from itself (apt-key issue) with master so I can not get far enough to test this at the moment. This should fix #877 if all goes well.