### PR TITLE
cluster_assign_roles.rb never runs install_bootstrap

### DIFF
--- a/cluster_assign_roles.rb
+++ b/cluster_assign_roles.rb
@@ -222,6 +222,9 @@ class ClusterAssignRoles
     target_head_nodes = target_nodes & all_hadoop_head_nodes
     target_worker_nodes = target_nodes - all_hadoop_head_nodes
 
+    # first prepare commonly used services
+    install_bootstrap(all_hadoop_head_nodes)
+
     #
     # Many bcpc recipes expect to be able to search for nodes based on
     # their configured roles.  This means we have to pre-populate the


### PR DESCRIPTION
This is intended to fix #880 however we may need extra logic and fixes before this can be merged

 - `target_x_nodes` vs `all_hadoop_x_nodes` and also does
 - we probbaly should not run `install_bootstrap` every time `install_hadoop` is invoked