### PR TITLE
Allow disks to have arbitrary names in bcpc-hadoop::disks

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/disks.rb
+++ b/cookbooks/bcpc-hadoop/recipes/disks.rb
@@ -47,9 +47,9 @@ ruby_block 'enumerate-disks' do
       # What disks will bcpc and bcpc-hadoop feel free to blank?
       # By default, all sd* devices (excluding sda) and all md* devices.
       #
-      # On our EFI-based VM builds, it's very important to the 32 MB
+      # On our EFI-based VM builds, it's very important to omit the 32 MB
       # image containing iPXE.  (It's relatively harmless to overwrite
-      # it, but it will cause graphite to fail when /disk/0 fills up.)
+      # the image, but it will cause graphite to fail when /disk/0 fills up.)
       #
       # We also reject any block device we are unable to open with O_EXCL,
       # because that means it is already in use by the kernel.

--- a/cookbooks/bcpc-hadoop/recipes/disks.rb
+++ b/cookbooks/bcpc-hadoop/recipes/disks.rb
@@ -47,17 +47,28 @@ ruby_block 'enumerate-disks' do
       # What disks will bcpc and bcpc-hadoop feel free to blank?
       # By default, all sd* devices (excluding sda) and all md* devices.
       #
-      # On our EFI-based VM builds, it's very important to omit sdb, as
-      # that is the 32 MB image containing iPXE.  (It's relatively
-      # harmless to overwrite it, but it will cause graphite to fail when
-      # /disk/0 fills up.)
+      # On our EFI-based VM builds, it's very important to the 32 MB
+      # image containing iPXE.  (It's relatively harmless to overwrite
+      # it, but it will cause graphite to fail when /disk/0 fills up.)
+      #
+      # We also reject any block device we are unable to open with O_EXCL,
+      # because that means it is already in use by the kernel.
       #
       all_drives = node[:block_device].keys.select do |dd|
-        dd =~ /sd[a-i]?[b-z]/ ||
-        dd =~ /md\d+/
+        dd =~ /sd[a-i]?[a-z]/ || dd =~ /md\d+/
+      end.select do |dd|
+        begin
+          require 'fcntl'
+          fd = IO::sysopen("/dev/#{dd}", Fcntl::O_RDONLY | Fcntl::O_EXCL)
+          fd.close
+          true
+        rescue Exception => ee
+          Chef::Log.debug("Unable to open #{dd} with O_EXCL: #{ee}")
+          nil
+        end
       end
 
-      disks[:available_disks] =
+      disks[:unformatted_disks] =
         if node[:dmi][:system][:product_name] == 'VirtualBox'
 
           # Reject all disks with fewer than a million blocks, so that we
@@ -89,113 +100,127 @@ ruby_block 'format-disks' do
     reservation_requests =
       node[:bcpc][:hadoop][:disks][:reservation_requests]
 
-    role_min_disk =
-      node[:bcpc][:hadoop][:disks][:role_min_disk]
-
     #
     # The available disks list is generated dynamically, at converge time.
     #
-    available_disks =
-      node.run_state[:bcpc_hadoop_disks][:available_disks]
+    unformatted_disks =
+      node.run_state[:bcpc_hadoop_disks][:unformatted_disks]
 
-    if available_disks.any?
-      available_disks.each_index do |i|
-        Chef::Resource::Directory.new("/disk/#{i}",
-                                      node.run_context).tap do |dd|
-          dd.owner 'root'
-          dd.group 'root'
-          dd.mode 00755
-          dd.recursive true
-          dd.run_action(:create)
-        end
+    unformatted_disks.each_index do |i|
+      Chef::Resource::Directory.new("/disk/#{i}",
+                                    node.run_context).tap do |dd|
+        dd.owner 'root'
+        dd.group 'root'
+        dd.mode 00755
+        dd.recursive true
+        dd.run_action(:create)
+      end
 
-        base_name = available_disks[i]
+      base_name = available_disks[i]
 
-        #
-        # If the raw disk has already been formatted with an FS, no
-        # partition table is necessary.
-        #
-        # Otherwise, create a partition and format that.
-        #
-        require 'mixlib/shellout'
+      #
+      # If the raw disk has already been formatted with an FS, no
+      # partition table is necessary.
+      #
+      # Otherwise, create a partition and format that.
+      #
+      require 'mixlib/shellout'
 
-        fs_check =
-          Mixlib::ShellOut.new('file', '-s', "/dev/#{base_name}")
-        fs_check.run_command
+      fs_check =
+        Mixlib::ShellOut.new('file', '-s', "/dev/#{base_name}")
+      fs_check.run_command
 
-        dev_name = if fs_check.status.success? &&
-                       fs_check.stdout.include?('SGI XFS filesystem')
-                     "/dev/#{base_name}"
-                   else
-                     "/dev/#{base_name}1"
-                   end
+      dev_name = if fs_check.status.success? &&
+                     fs_check.stdout.include?('SGI XFS filesystem')
+                   "/dev/#{base_name}"
+                 else
+                   "/dev/#{base_name}1"
+                 end
 
-        if dev_name.end_with?('1')
-          unless ::File.exist?(dev_name)
-            Chef::Resource::Execute.new("mklabel-#{base_name}",
-                                        node.run_context).tap do |ee|
-              ee.command "parted -s /dev/#{base_name} mklabel gpt"
-              ee.run_action(:run)
-            end
-
-            Chef::Resource::Execute.new("mkpart-#{base_name}",
-                                        node.run_context).tap do |ee|
-              ee.command "parted -s /dev/#{base_name} " \
-                'mkpart bach_data ext4 0% 100%'
-              ee.run_action(:run)
-            end
+      if dev_name.end_with?('1')
+        unless ::File.exist?(dev_name)
+          Chef::Resource::Execute.new("mklabel-#{base_name}",
+                                      node.run_context).tap do |ee|
+            ee.command "parted -s /dev/#{base_name} mklabel gpt"
+            ee.run_action(:run)
           end
 
-        end
-
-        check_command =
-          Mixlib::ShellOut.new("file -s #{dev_name} | " \
-                               "grep -q 'SGI XFS filesystem'")
-        check_command.run_command
-
-        unless check_command.status.success?
-          Chef::Resource::Execute.new("mkfs-#{dev_name}",
+          Chef::Resource::Execute.new("mkpart-#{base_name}",
                                       node.run_context).tap do |ee|
-            ee.command "mkfs -t xfs -f #{dev_name}"
+            ee.command "parted -s /dev/#{base_name} " \
+              'mkpart bach_data ext4 0% 100%'
             ee.run_action(:run)
           end
         end
+      end
 
-        Chef::Resource::Mount.new("/disk/#{i}",
-                                  node.run_context).tap do |mm|
-          mm.device dev_name
-          mm.fstype 'xfs'
-          mm.options 'noatime,nodiratime,inode64'
-          mm.run_action(:enable)
-          mm.run_action(:mount)
+      check_command =
+        Mixlib::ShellOut.new("file -s #{dev_name} | " \
+                             "grep -q 'SGI XFS filesystem'")
+      check_command.run_command
+
+      unless check_command.status.success?
+        Chef::Resource::Execute.new("mkfs-#{dev_name}",
+                                    node.run_context).tap do |ee|
+          ee.command "mkfs -t xfs -f #{dev_name}"
+          ee.run_action(:run)
         end
       end
 
-      # is our role included in the list
-      if (node[:bcpc][:hadoop][:disks][:disk_reserve_roles] &
-          node.roles).any?
-
-        # make sure we have enough disks to fulfill reservations and
-        # also normal opration of the DN and NN
-        if reservation_requests.length > available_disks.length
-          Chef::Application.fatal!('Reservations exceeds available disks')
-        end
-
-        if available_disks.length - reservation_requests.length < role_min_disk
-          Chef::Application.fatal!('Minimum disk requirement not met')
-        end
-
-        mount_indexes =
-          (0..(available_disks.length - 1)).to_a -
-          reservation_requests.each_index.to_a
-
-        node.run_state[:bcpc_hadoop_disks][:mounts] = mount_indexes
-      else
-        node.run_state[:bcpc_hadoop_disks][:mounts] =
-          (0..(available_disks.length - 1)).to_a
+      Chef::Resource::Mount.new("/disk/#{i}",
+                                node.run_context).tap do |mm|
+        mm.device dev_name
+        mm.fstype 'xfs'
+        mm.options 'noatime,nodiratime,inode64'
+        mm.run_action(:enable)
+        mm.run_action(:mount)
       end
+    end
+  end
+end
+
+ruby_block 'hadoop-disk-reservations' do
+  block do
+    #
+    # Reload Ohai filesystem plugin, in order to pick up any newly
+    # formatted filesystems.
+    #
+    ohai = ::Ohai::System.new
+    ohai.all_plugins('filesystem')
+    node.automatic_attrs.merge! ohai.data
+    Chef::Log.info('ohai[filesystem] reloaded')
+
+    available_disks = node[:filesystem].select do |device, mount_point|
+      # All disks formatted by this recipe were mounted at /disk/NN.
+      mount_point =~ /\/disk\/\d+/
+    end.keys
+
+    # is our role included in the list
+    if (node[:bcpc][:hadoop][:disks][:disk_reserve_roles] &
+        node.roles).any?
+      #
+      # Make sure we have enough disks to fulfill reservations and
+      # also normal operations of the DN and NN.
+      #
+      if reservation_requests.length > available_disks.length
+        raise 'Reservations exceeds available disks'
+      end
+
+      role_min_disk =
+        node[:bcpc][:hadoop][:disks][:role_min_disk]
+
+      if available_disks.length - reservation_requests.length < role_min_disk
+        raise 'Minimum disk requirement not met'
+      end
+
+      mount_indexes =
+        (0..(available_disks.length - 1)).to_a -
+        reservation_requests.each_index.to_a
+
+      node.run_state[:bcpc_hadoop_disks][:mounts] = mount_indexes
     else
-      Chef::Application.fatal!('No available disks found!')
+      node.run_state[:bcpc_hadoop_disks][:mounts] =
+        (0..(available_disks.length - 1)).to_a
     end
   end
 end


### PR DESCRIPTION
This PR follows on the install-time work in PR #861 and PR #875 to format disks correctly regardless of device enumeration order.

Instead of blindly formating sdb, sdc, sdd, sde in order, unformatted disks are detected by attempting to open() with O_EXCL.  Block devices that are already in use by the kernel cannot be opened with that flag, and fail.