### PR TITLE
Set :vault_mode to save on typing

### DIFF
--- a/setup_chef_cookbooks.sh
+++ b/setup_chef_cookbooks.sh
@@ -38,6 +38,7 @@ cookbook_path '$(pwd)/vendor/cookbooks'
 ssl_verify_mode :verify_none
 verify_api_cert false
 
+knife[:vault_mode] = 'client'
 File.umask(0007)
 EOF
 


### PR DESCRIPTION
Doing this should no longer be needed `knife vault show -m client`.

Reference: <https://github.com/chef/chef-vault#kniferb>

Some bits in #896 should probably be synced up