### PR TITLE
Jvmkill

### DIFF
--- a/cookbooks/bach_repository/recipes/default.rb
+++ b/cookbooks/bach_repository/recipes/default.rb
@@ -30,8 +30,8 @@ include_recipe 'bach_repository::python'
 include_recipe 'bach_repository::apt'
 
 # Install Java
-include_recipe "java::default"
-include_recipe "java::oracle_jce"
+include_recipe 'java::default'
+include_recipe 'java::oracle_jce'
 
 # build jvmkill lib
 include_recipe 'bach_repository::jvmkill'

--- a/cookbooks/bach_repository/recipes/default.rb
+++ b/cookbooks/bach_repository/recipes/default.rb
@@ -33,5 +33,8 @@ include_recipe 'bach_repository::apt'
 include_recipe "java::default"
 include_recipe "java::oracle_jce"
 
+# build jvmkill lib
+include_recipe 'bach_repository::jvmkill'
+
 # Run after everything to fix perms.
 include_recipe 'bach_repository::permissions'

--- a/cookbooks/bach_repository/recipes/jvmkill.rb
+++ b/cookbooks/bach_repository/recipes/jvmkill.rb
@@ -1,0 +1,51 @@
+#
+# Cookbook Name:: bach_repository
+# Recipe:: jvmkill
+#
+# Copyright 2013, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# This recipe will download and compile jvmkill library
+# and save the libjvmkill.so in the bins directory
+
+require 'tmpdir'
+
+include_recipe 'bach_repository::directory'
+
+bins_dir = node['bach']['repository']['bins_directory']
+src_dir = node['bach']['repository']['src_directory']
+build_dir = src_dir + '/jvmkill'
+lib_file = build_dir + '/libjvmkill.so'
+target_file = bins_dir + '/libjvmkill.so'
+
+# checkout
+git build_dir do
+   repository 'https://github.com/airlift/jvmkill.git'
+   action :sync
+   not_if { File.exists?target_file }
+end
+
+# compile
+execute 'jvmkill-make' do
+  command "make JAVA_HOME=#{node['bcpc']['hadoop']['java']}"
+  cwd build_dir
+  not_if { File.exists?(target_file) }
+end
+
+# deploy
+remote_file target_file do
+  source "file://#{lib_file}"
+  mode 0444
+end

--- a/cookbooks/bach_repository/recipes/jvmkill.rb
+++ b/cookbooks/bach_repository/recipes/jvmkill.rb
@@ -32,20 +32,20 @@ target_file = bins_dir + '/libjvmkill.so'
 
 # checkout
 git build_dir do
-   repository 'https://github.com/airlift/jvmkill.git'
-   action :sync
-   not_if { File.exists?target_file }
+  repository 'https://github.com/airlift/jvmkill.git'
+  action :sync
+  not_if { File.exist?target_file }
 end
 
 # compile
 execute 'jvmkill-make' do
   command "make JAVA_HOME=#{node['bcpc']['hadoop']['java']}"
   cwd build_dir
-  not_if { File.exists?(target_file) }
+  not_if { File.exist?(target_file) }
 end
 
 # deploy
 remote_file target_file do
   source "file://#{lib_file}"
-  mode 0444
+  mode 0o0444
 end

--- a/cookbooks/bach_repository/test/integration/bach_repository/serverspec/localhost/java_spec.rb
+++ b/cookbooks/bach_repository/test/integration/bach_repository/serverspec/localhost/java_spec.rb
@@ -15,8 +15,7 @@ describe file(jce_file) do
   it { should be_file }
 end
 
-describe command("/usr/lib/jvm/java-8-oracle-amd64/bin/java -version") do
+describe command('/usr/lib/jvm/java-8-oracle-amd64/bin/java -version') do
   its(:exit_status) { should eq 0 }
   its(:stderr) { should match(/java version.*1\.8/) }
 end
-

--- a/cookbooks/bach_repository/test/integration/bach_repository/serverspec/localhost/java_spec.rb
+++ b/cookbooks/bach_repository/test/integration/bach_repository/serverspec/localhost/java_spec.rb
@@ -15,13 +15,8 @@ describe file(jce_file) do
   it { should be_file }
 end
 
-describe command("env | grep JAVA_HOME") do
+describe command("/usr/lib/jvm/java-8-oracle-amd64/bin/java -version") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should contain('/usr/lib/jvm/java-8-oracle-amd64') }
-u
-end
-
-describe command("java -version") do
-  its(:exit_status) { should eq 0 }
+  its(:stderr) { should match(/java version.*1\.8/) }
 end
 

--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -5,104 +5,104 @@
 #############################################
 require 'pathname'
 
-default["bcpc"]["hadoop"] = {}
-default["bcpc"]["hadoop"]["distribution"]["release"] = '2.3.6.2-3'
-default["bcpc"]["hadoop"]["distribution"]["active_release"] = node["bcpc"]["hadoop"]["distribution"]["release"]
-default["bcpc"]["hadoop"]["decommission"]["hosts"] = []
+default['bcpc']['hadoop'] = {}
+default['bcpc']['hadoop']['distribution']['release'] = '2.3.6.2-3'
+default['bcpc']['hadoop']['distribution']['active_release'] = node['bcpc']['hadoop']['distribution']['release']
+default['bcpc']['hadoop']['decommission']['hosts'] = []
 # disks to use for Hadoop activities (expected to be an environment or role set variable)
-default["bcpc"]["hadoop"]["hadoop_home_warn_suppress"] = 1
-default["bcpc"]["hadoop"]["hadoop_log_dir"] = "/var/log/hadoop-hdfs"
-default["bcpc"]["hadoop"]["hadoop_mapred_ident_string"] = "mapred"
-default["bcpc"]["hadoop"]["hadoop_mapred_log_dir"] = "/var/log/hadoop-mapreduce"
-default["bcpc"]["hadoop"]["hadoop_secure_dn_log_dir"] = "/var/log/hadoop-hdfs"
-default["bcpc"]["hadoop"]["hadoop_pid_dir"] = "/var/run/hadoop-hdfs"
-default["bcpc"]["hadoop"]["hadoop_secure_dn_pid_dir"] = "/var/run/hadoop-hdfs"
-default["bcpc"]["hadoop"]["hadoop_mapred_pid_dir"] = "/var/run/hadoop-mapreduce"
-default["bcpc"]["hadoop"]["hadoop_secure_dn_user"] = "hdfs"
-default["bcpc"]["hadoop"]["hadoop"]["bin"]["path"] = "/usr/bin/hadoop"
-default["bcpc"]["hadoop"]["hadoop"]["config"]["dir"] = "/etc/hadoop/conf"
-# Flag to control whether automatic restarts due to config changes need to be skipped 
+default['bcpc']['hadoop']['hadoop_home_warn_suppress'] = 1
+default['bcpc']['hadoop']['hadoop_log_dir'] = '/var/log/hadoop-hdfs'
+default['bcpc']['hadoop']['hadoop_mapred_ident_string'] = 'mapred'
+default['bcpc']['hadoop']['hadoop_mapred_log_dir'] = '/var/log/hadoop-mapreduce'
+default['bcpc']['hadoop']['hadoop_secure_dn_log_dir'] = '/var/log/hadoop-hdfs'
+default['bcpc']['hadoop']['hadoop_pid_dir'] = '/var/run/hadoop-hdfs'
+default['bcpc']['hadoop']['hadoop_secure_dn_pid_dir'] = '/var/run/hadoop-hdfs'
+default['bcpc']['hadoop']['hadoop_mapred_pid_dir'] = '/var/run/hadoop-mapreduce'
+default['bcpc']['hadoop']['hadoop_secure_dn_user'] = 'hdfs'
+default['bcpc']['hadoop']['hadoop']['bin']['path'] = '/usr/bin/hadoop'
+default['bcpc']['hadoop']['hadoop']['config']['dir'] = '/etc/hadoop/conf'
+# Flag to control whether automatic restarts due to config changes need to be skipped
 # for e.g. if ZK quorum is down or if the recipes need to be run in a non ZK env
-default["bcpc"]["hadoop"]["skip_restart_coordination"] = false
-default["bcpc"]["hadoop"]["hdfs"]["site_xml"]["dfs.datanode.sync.behind.writes"] = true
-default["bcpc"]["hadoop"]["hdfs"]["site_xml"]["dfs.datanode.synconclose"] = true
-default["bcpc"]["hadoop"]["hdfs"]["site_xml"]["dfs.namenode.stale.datanode.interval"] = 30000
-default["bcpc"]["hadoop"]["hdfs"]["HA"] = true
-default["bcpc"]["hadoop"]["hdfs"]["failed_volumes_tolerated"] = 1
-default["bcpc"]["hadoop"]["hdfs"]["dfs_replication_factor"] = 3
-default["bcpc"]["hadoop"]["hdfs"]["dfs_blocksize"] = "128m"
-default['bcpc']['hadoop']['hdfs_url']="hdfs://#{node.chef_environment}"
-default["bcpc"]["hadoop"]["jmx_enabled"] = true
-default[:bcpc][:hadoop][:jute][:maxbuffer] = 6291456
-default["bcpc"]["hadoop"]["datanode"]["xmx"]["max_size"] = 4096
-default["bcpc"]["hadoop"]["datanode"]["xmx"]["max_ratio"] = 0.25
-default["bcpc"]["hadoop"]["datanode"]["max"]["xferthreads"] = 16384
-default["bcpc"]["hadoop"]["datanode"]["jmx"]["port"] = 10112
+default['bcpc']['hadoop']['skip_restart_coordination'] = false
+default['bcpc']['hadoop']['hdfs']['site_xml']['dfs.datanode.sync.behind.writes'] = true
+default['bcpc']['hadoop']['hdfs']['site_xml']['dfs.datanode.synconclose'] = true
+default['bcpc']['hadoop']['hdfs']['site_xml']['dfs.namenode.stale.datanode.interval'] = 30_000
+default['bcpc']['hadoop']['hdfs']['HA'] = true
+default['bcpc']['hadoop']['hdfs']['failed_volumes_tolerated'] = 1
+default['bcpc']['hadoop']['hdfs']['dfs_replication_factor'] = 3
+default['bcpc']['hadoop']['hdfs']['dfs_blocksize'] = '128m'
+default['bcpc']['hadoop']['hdfs_url'] = "hdfs://#{node.chef_environment}"
+default['bcpc']['hadoop']['jmx_enabled'] = true
+default[:bcpc][:hadoop][:jute][:maxbuffer] = 6_291_456
+default['bcpc']['hadoop']['datanode']['xmx']['max_size'] = 4_096
+default['bcpc']['hadoop']['datanode']['xmx']['max_ratio'] = 0.25
+default['bcpc']['hadoop']['datanode']['max']['xferthreads'] = 16_384
+default['bcpc']['hadoop']['datanode']['jmx']['port'] = 10112
 
 # for jvmkill library
 default['bcpc-hadoop']['jvmkill']['lib_file'] = '/var/lib/jvmkill/libjvmkill.so'
 
 common_opts =
-  '-XX:+UseParNewGC ' +
-  '-XX:+UseConcMarkSweepGC ' +  
-  '-verbose:gc -XX:+PrintHeapAtGC ' +
-  '-XX:+PrintGCDetails ' +
-  '-XX:+PrintGCTimeStamps ' + 
-  '-XX:+PrintGCDateStamps ' + 
-  '-XX:+UseNUMA ' +
-  '-XX:+PrintGCApplicationStoppedTime ' +
-  '-XX:+UseCompressedOops ' +
-  '-XX:+PrintClassHistogram ' + 
-  '-XX:+PrintGCApplicationConcurrentTime ' + 
-  '-XX:+UseCMSInitiatingOccupancyOnly ' + 
-  '-XX:CMSInitiatingOccupancyFraction=70 ' + 
-  '-XX:+HeapDumpOnOutOfMemoryError ' + 
-  '-XX:+PrintTenuringDistribution ' +
-  '-XX:+ExitOnOutOfMemoryError ' +
+  '-XX:+UseParNewGC ' \
+  '-XX:+UseConcMarkSweepGC ' \
+  '-verbose:gc -XX:+PrintHeapAtGC ' \
+  '-XX:+PrintGCDetails ' \
+  '-XX:+PrintGCTimeStamps ' \
+  '-XX:+PrintGCDateStamps ' \
+  '-XX:+UseNUMA ' \
+  '-XX:+PrintGCApplicationStoppedTime ' \
+  '-XX:+UseCompressedOops ' \
+  '-XX:+PrintClassHistogram ' \
+  '-XX:+PrintGCApplicationConcurrentTime ' \
+  '-XX:+UseCMSInitiatingOccupancyOnly ' \
+  '-XX:CMSInitiatingOccupancyFraction=70 ' \
+  '-XX:+HeapDumpOnOutOfMemoryError ' \
+  '-XX:+PrintTenuringDistribution ' \
+  '-XX:+ExitOnOutOfMemoryError ' \
   "-agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
 
 # GC Options for DataNode
-default["bcpc"]["hadoop"]["datanode"]["gc_opts"] =  
-  '-server -XX:ParallelGCThreads=4 ' + 
-  '-Xloggc:/var/log/hadoop-hdfs/gc/gc.log-dn-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log ' + 
+default['bcpc']['hadoop']['datanode']['gc_opts'] =
+  '-server -XX:ParallelGCThreads=4 ' \
+  '-Xloggc:/var/log/hadoop-hdfs/gc/gc.log-dn-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log ' \
   '-XX:HeapDumpPath=/var/log/hadoop-hdfs/heap-dump-dn-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof ' +
   common_opts
 
 # GC Options for NameNode
-default["bcpc"]["hadoop"]["namenode"]["gc_opts"] = 
-  '-server -XX:ParallelGCThreads=14 ' + 
-  '-Xloggc:/var/log/hadoop-hdfs/gc/gc.log-nn-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log ' + 
+default['bcpc']['hadoop']['namenode']['gc_opts'] =
+  '-server -XX:ParallelGCThreads=14 ' \
+  '-Xloggc:/var/log/hadoop-hdfs/gc/gc.log-nn-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log ' \
   '-XX:HeapDumpPath=/var/log/hadoop-hdfs/heap-dump-nn-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof ' +
   common_opts
 
-default["bcpc"]["hadoop"]["mapreduce"]["framework"]["name"] = "yarn"
-default["bcpc"]["hadoop"]["namenode"]["handler"]["count"] = 100
+default['bcpc']['hadoop']['mapreduce']['framework']['name'] = 'yarn'
+default['bcpc']['hadoop']['namenode']['handler']['count'] = 100
 # set to nil to calculate dynamically based on available memory
-default["bcpc"]["hadoop"]["namenode"]["xmx"]["max_size"] = 1024
+default['bcpc']['hadoop']['namenode']['xmx']['max_size'] = 1024
 # set to nil to calculate dynamically based on available memory
-default["bcpc"]["hadoop"]["namenode"]["xmn"]["max_size"] = 128
-default["bcpc"]["hadoop"]["namenode"]["xmx"]["max_ratio"] = 0.25
-default["bcpc"]["hadoop"]["namenode"]["jmx"]["port"] = 10111
-default["bcpc"]["hadoop"]["namenode"]["rpc"]["port"] = 8020
-default["bcpc"]["hadoop"]["namenode"]["http"]["port"] = 50070 
-default["bcpc"]["hadoop"]["namenode"]["https"]["port"] = 50470
-default["bcpc"]["hadoop"]["kafka"]["jmx"]["port"] = 9995
-default["bcpc"]["hadoop"]["topology"]["script"] = "topology"
-default["bcpc"]["hadoop"]["topology"]["cookbook"] = "bcpc-hadoop"
-default["bcpc"]["hadoop"]["yarn"]["scheduler"]["minimum-allocation-mb"] = 256
+default['bcpc']['hadoop']['namenode']['xmn']['max_size'] = 128
+default['bcpc']['hadoop']['namenode']['xmx']['max_ratio'] = 0.25
+default['bcpc']['hadoop']['namenode']['jmx']['port'] = 10111
+default['bcpc']['hadoop']['namenode']['rpc']['port'] = 8020
+default['bcpc']['hadoop']['namenode']['http']['port'] = 50070
+default['bcpc']['hadoop']['namenode']['https']['port'] = 50470
+default['bcpc']['hadoop']['kafka']['jmx']['port'] = 9995
+default['bcpc']['hadoop']['topology']['script'] = 'topology'
+default['bcpc']['hadoop']['topology']['cookbook'] = 'bcpc-hadoop'
+default['bcpc']['hadoop']['yarn']['scheduler']['minimum-allocation-mb'] = 256
 
 #
 # Attributes for service rolling restart process
 #
 # Number of tries to acquire the lock required to restart the process
-default["bcpc"]["hadoop"]["restart_lock_acquire"]["max_tries"] = 5
+default['bcpc']['hadoop']['restart_lock_acquire']['max_tries'] = 5
 # The path in ZK where the restart locks (znodes)  need to be created
-# The path should exist in ZooKeeper e.g. "/lock" and the default is "/"
-default["bcpc"]["hadoop"]["restart_lock"]["root"] = "/"
+# The path should exist in ZooKeeper e.g. '/lock' and the default is '/'
+default['bcpc']['hadoop']['restart_lock']['root'] = '/'
 # Sleep time in seconds between tries to acquire the lock for restart
-default["bcpc"]["hadoop"]["restart_lock_acquire"]["sleep_time"] = 2
+default['bcpc']['hadoop']['restart_lock_acquire']['sleep_time'] = 2
 # Flag to set whether the restart process was successful or not
-default["bcpc"]["hadoop"]["datanode"]["restart_failed"] = false
+default['bcpc']['hadoop']['datanode']['restart_failed'] = false
 
 # These are to cache Chef search results and
 # allow hardcoding nodes performing various roles
@@ -119,35 +119,35 @@ default[:bcpc][:hadoop][:httpfs_hosts] = []
 default[:bcpc][:hadoop][:rs_hosts] = []
 default[:bcpc][:hadoop][:mysql_hosts] = []
 
-default["bcpc"]["keepalived"]["config_template"] = "keepalived.conf_hadoop"
+default['bcpc']['keepalived']['config_template'] = 'keepalived.conf_hadoop'
 
-default["bcpc"]["revelytix"]["loom_username"] = "loom"
-default["bcpc"]["revelytix"]["activescan_hdfs_user"] = "activescan-user"
-default["bcpc"]["revelytix"]["activescan_hdfs_enabled"] = "true"
-default["bcpc"]["revelytix"]["activescan_table_enabled"] = "true"
-default["bcpc"]["revelytix"]["hdfs_scan_interval"] = 60
-default["bcpc"]["revelytix"]["hdfs_parse_lines"] = 50
-default["bcpc"]["revelytix"]["hdfs_score_threshold"] = 0.25
-default["bcpc"]["revelytix"]["hdfs_max_buffer_size"] = 8388608
-default["bcpc"]["revelytix"]["persist_mode"] = "hive"
-default["bcpc"]["revelytix"]["dataset_persist_dir"] = "loom-datasets"
-default["bcpc"]["revelytix"]["temporary_file_dir"] = "hdfs-default:loom-temp"
-default["bcpc"]["revelytix"]["job_service_thread_pool_size"] = 10
-default["bcpc"]["revelytix"]["security_authentication"] = "loom"
-default["bcpc"]["revelytix"]["security_enabled"] = "true"
-default["bcpc"]["revelytix"]["ssl_enabled"] = "true"
-default["bcpc"]["revelytix"]["ssl_port"] = 8443
-default["bcpc"]["revelytix"]["ssl_keystore"] = "config/keystore"
-default["bcpc"]["revelytix"]["ssl_key_password"] = ""
-default["bcpc"]["revelytix"]["ssl_trust_store"] = "config/truststore"
-default["bcpc"]["revelytix"]["ssl_trust_password"] = ""
-default["bcpc"]["revelytix"]["loom_dist_cache"] = "loom-dist-cache"
-default["bcpc"]["revelytix"]["hive_classloader_blacklist_jars"] = "slf4j,log4j,commons-logging"
-default["bcpc"]["revelytix"]["port"] = 8080
+default['bcpc']['revelytix']['loom_username'] = 'loom'
+default['bcpc']['revelytix']['activescan_hdfs_user'] = 'activescan-user'
+default['bcpc']['revelytix']['activescan_hdfs_enabled'] = 'true'
+default['bcpc']['revelytix']['activescan_table_enabled'] = 'true'
+default['bcpc']['revelytix']['hdfs_scan_interval'] = 60
+default['bcpc']['revelytix']['hdfs_parse_lines'] = 50
+default['bcpc']['revelytix']['hdfs_score_threshold'] = 0.25
+default['bcpc']['revelytix']['hdfs_max_buffer_size'] = 8_388_608
+default['bcpc']['revelytix']['persist_mode'] = 'hive'
+default['bcpc']['revelytix']['dataset_persist_dir'] = 'loom-datasets'
+default['bcpc']['revelytix']['temporary_file_dir'] = 'hdfs-default:loom-temp'
+default['bcpc']['revelytix']['job_service_thread_pool_size'] = 10
+default['bcpc']['revelytix']['security_authentication'] = 'loom'
+default['bcpc']['revelytix']['security_enabled'] = 'true'
+default['bcpc']['revelytix']['ssl_enabled'] = 'true'
+default['bcpc']['revelytix']['ssl_port'] = 8443
+default['bcpc']['revelytix']['ssl_keystore'] = 'config/keystore'
+default['bcpc']['revelytix']['ssl_key_password'] = ''
+default['bcpc']['revelytix']['ssl_trust_store'] = 'config/truststore'
+default['bcpc']['revelytix']['ssl_trust_password'] = ''
+default['bcpc']['revelytix']['loom_dist_cache'] = 'loom-dist-cache'
+default['bcpc']['revelytix']['hive_classloader_blacklist_jars'] = 'slf4j,log4j,commons-logging'
+default['bcpc']['revelytix']['port'] = 8080
 
 # Attributes to store details about (log) files from nodes to be copied
 # into a centralized location (currently HDFS).
-# E.g. value {'hbase_rs' =>  { 'logfile' => "/path/file_name_of_log_file",
+# E.g. value {'hbase_rs' =>  { 'logfile' => '/path/file_name_of_log_file',
 #                              'docopy' => true (or false)
 #                             },...
 #            }
@@ -158,40 +158,39 @@ default['bcpc']['hadoop']['copylog_enable'] = true
 # HDFS quotas for copylogs files
 default['bcpc']['hadoop']['copylog_quota'] = {
   'space' => '10G',
-  'files' => '10000'
+  'files' => 10_000
 }
 # File rollup interval in secs for log data copied into HDFS through Flume
-default['bcpc']['hadoop']['copylog_rollup_interval'] = 86400
+default['bcpc']['hadoop']['copylog_rollup_interval'] = 86_400
 # Ensure copylogs can read Chef's client.log
-default['chef_client']['log_perm'] = '00644'
+default['chef_client']['log_perm'] = 0o644
 
-default['bcpc']['hadoop']['copylog']['syslog'] = { 
-    'logfile' => '/var/log/syslog',
-    'docopy' => true
+default['bcpc']['hadoop']['copylog']['syslog'] = {
+  'logfile' => '/var/log/syslog',
+  'docopy' => true
 }
 
 default['bcpc']['hadoop']['copylog']['authlog'] = {
-    'logfile' => '/var/log/auth.log',
-    'docopy' => true
+  'logfile' => '/var/log/auth.log',
+  'docopy' => true
 }
 
-
 # Ensure the following group mappings in the group database
-default[:bcpc][:hadoop][:os][:group][:hadoop][:members] = [
- "hdfs",
- "yarn",
- "hbase",
- "oozie",
- "hive",
- "zookeeper",
- "mapred",
- "httpfs"
-]
-default[:bcpc][:hadoop][:os][:group][:hdfs][:members]=["hdfs"]
-default[:bcpc][:hadoop][:os][:group][:mapred][:members]=["yarn"]
+default[:bcpc][:hadoop][:os][:group][:hadoop][:members] = %w(
+  hdfs
+  yarn
+  hbase
+  oozie
+  hive
+  zookeeper
+  mapred
+  httpfs
+)
 
+default[:bcpc][:hadoop][:os][:group][:hdfs][:members] = ['hdfs']
+default[:bcpc][:hadoop][:os][:group][:mapred][:members] = ['yarn']
 
-# Override attributes to install Java 
+# Override attributes to install Java
 # use java cookbook (https://github.com/agileorbit-cookbooks/java)
 default['java']['jdk_version'] = 8
 default['java']['install_flavor'] = 'oracle'
@@ -209,6 +208,6 @@ default['java']['jdk']['8']['x86_64']['url'] = get_binary_server_url + jdk_tgz_n
 default['java']['oracle']['jce']['8']['url'] = get_binary_server_url + jce_tgz_name
 
 # Set the JAVA_HOME for Hadoop components
-default['bcpc']['hadoop']['java'] = "/usr/lib/jvm/java-8-oracle-amd64"
+default['bcpc']['hadoop']['java'] = '/usr/lib/jvm/java-8-oracle-amd64'
 
 default['bcpc']['cluster']['file_path'] = '/home/vagrant/chef-bcpc/cluster.txt'

--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -39,6 +39,9 @@ default["bcpc"]["hadoop"]["datanode"]["xmx"]["max_ratio"] = 0.25
 default["bcpc"]["hadoop"]["datanode"]["max"]["xferthreads"] = 16384
 default["bcpc"]["hadoop"]["datanode"]["jmx"]["port"] = 10112
 
+# for jvmkill library
+default['bcpc-hadoop']['jvmkill']['lib_file'] = '/var/lib/jvmkill/libjvmkill.so'
+
 common_opts =
   '-XX:+UseParNewGC ' +
   '-XX:+UseConcMarkSweepGC ' +  
@@ -55,7 +58,8 @@ common_opts =
   '-XX:CMSInitiatingOccupancyFraction=70 ' + 
   '-XX:+HeapDumpOnOutOfMemoryError ' + 
   '-XX:+PrintTenuringDistribution ' +
-  '-XX:+ExitOnOutOfMemoryError'
+  '-XX:+ExitOnOutOfMemoryError ' +
+  "-agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
 
 # GC Options for DataNode
 default["bcpc"]["hadoop"]["datanode"]["gc_opts"] =  
@@ -194,7 +198,7 @@ default['java']['install_flavor'] = 'oracle'
 default['java']['accept_license_agreement'] = true
 default['java']['oracle']['jce']['enabled'] = true
 
-# redirect the installation urls to the bootstrap node
+# redirect the installation URLs to the bootstrap node
 jdk_url = node['java']['jdk']['8']['x86_64']['url']
 jce_url = node['java']['oracle']['jce']['8']['url']
 
@@ -207,5 +211,4 @@ default['java']['oracle']['jce']['8']['url'] = get_binary_server_url + jce_tgz_n
 # Set the JAVA_HOME for Hadoop components
 default['bcpc']['hadoop']['java'] = "/usr/lib/jvm/java-8-oracle-amd64"
 
-default['bcpc']['cluster']['file_path'] =
-  '/home/vagrant/chef-bcpc/cluster.txt'
+default['bcpc']['cluster']['file_path'] = '/home/vagrant/chef-bcpc/cluster.txt'

--- a/cookbooks/bcpc-hadoop/attributes/hive.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hive.rb
@@ -1,24 +1,24 @@
-default["bcpc"]["hadoop"]["hive"]["hive_table_stats_db"] =
+default['bcpc']['hadoop']['hive']['hive_table_stats_db'] =
   'hive_table_stats'
-default["bcpc"]["hadoop"]["hive"]["hive_table_stats_db_user"] =
+default['bcpc']['hadoop']['hive']['hive_table_stats_db_user'] =
   'hive_table_stats'
-default["bcpc"]["hadoop"]["hive"]["server2"]["authentication"] =
+default['bcpc']['hadoop']['hive']['server2']['authentication'] =
   'KERBEROS'
-default["bcpc"]["hadoop"]["hive"]["server2"]["ldap_url"] =
+default['bcpc']['hadoop']['hive']['server2']['ldap_url'] =
   'ldap://bcpc.example.com'
-default["bcpc"]["hadoop"]["hive"]["server2"]["ldap_domain"] =
+default['bcpc']['hadoop']['hive']['server2']['ldap_domain'] =
   'bcpc.example.com'
-default["bcpc"]["hadoop"]["hive"]["server2"]["port"] = '10000'
-default["bcpc"]["hadoop"]["hive"]["warehouse"]["dir"] = \
+default['bcpc']['hadoop']['hive']['server2']['port'] = '10000'
+default['bcpc']['hadoop']['hive']['warehouse']['dir'] = \
   ::File.join(node[:bcpc][:hadoop][:hdfs_url], '/user/hive/warehouse')
-default["bcpc"]["hadoop"]["hive"]["scratch"]["dir"] = \
+default['bcpc']['hadoop']['hive']['scratch']['dir'] = \
   ::File.join(node[:bcpc][:hadoop][:hdfs_url], '/tmp/hive-scratch/')
 
 # These will become key/value pairs in 'hive_site.xml'
 default[:bcpc][:hadoop][:hive][:site_xml].tap do |site_xml|
   # hive.* options
   site_xml['hive.aux.jars.path'] =
-    'file:///usr/share/java/mysql-connector-java.jar,' + 
+    'file:///usr/share/java/mysql-connector-java.jar,' \
     'file:///usr/hdp/current/hive-webhcat/share/hcatalog/hive-hcatalog-core.jar'
   site_xml['hive.exec.scratchdir'] = \
     ::File.join(node[:bcpc][:hadoop][:hive][:scratch][:dir], '${user.name}')
@@ -42,7 +42,7 @@ default[:bcpc][:hadoop][:hive][:site_xml].tap do |site_xml|
   site_xml['datanucleus.autoCreateSchema'] = false
   site_xml['datanucleus.fixedDatastore'] = true
   site_xml['javax.jdo.option.ConnectionDriverName'] = 'com.mysql.jdbc.Driver'
-  site_xml['javax.jdo.option.ConnectionUserName'] = "hive"
+  site_xml['javax.jdo.option.ConnectionUserName'] = 'hive'
 end
 
 # These will become key/value pairs in 'hive-env.sh'
@@ -50,28 +50,28 @@ default[:bcpc][:hadoop][:hive][:env_sh].tap do |env_sh|
   env_sh[:HIVE_CONF_DIR] = '/etc/hive/conf.' + node.chef_environment
   env_sh[:JAVA_HOME] = node[:bcpc][:hadoop][:java]
   env_sh[:HADOOP_HEAPSIZE] = 1024
-  env_sh[:HADOOP_OPTS] = 
-    '-verbose:gc ' +
-    '-XX:+PrintHeapAtGC ' +
-    '-XX:+PrintGCDetails ' +
-    '-XX:+PrintGCTimeStamps ' +
-    '-XX:+PrintGCDateStamps ' +
-    '-Xloggc:/var/log/hive/gc/' +
-      'gc.log-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log ' +
-    '-XX:+PrintTenuringDistribution ' +
-    '-XX:+PrintGCApplicationStoppedTime ' +
-    '-XX:+PrintGCApplicationConcurrentTime ' +
-    '-XX:+UseConcMarkSweepGC ' +
-    '-XX:+UseCMSInitiatingOccupancyOnly ' +
-    '-XX:CMSInitiatingOccupancyFraction=70 ' +
-    '-XX:+HeapDumpOnOutOfMemoryError ' +
-    '-XX:HeapDumpPath=/var/log/hive/heap-dump-hive-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof ' +
-    '-XX:+CMSClassUnloadingEnabled ' +
-    '-XX:+UseParNewGC ' + 
-    '-XX:+ExitOnOutOfMemoryError ' +
+  env_sh[:HADOOP_OPTS] =
+    '-verbose:gc ' \
+    '-XX:+PrintHeapAtGC ' \
+    '-XX:+PrintGCDetails ' \
+    '-XX:+PrintGCTimeStamps ' \
+    '-XX:+PrintGCDateStamps ' \
+    '-Xloggc:/var/log/hive/gc/' \
+    'gc.log-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log ' \
+    '-XX:+PrintTenuringDistribution ' \
+    '-XX:+PrintGCApplicationStoppedTime ' \
+    '-XX:+PrintGCApplicationConcurrentTime ' \
+    '-XX:+UseConcMarkSweepGC ' \
+    '-XX:+UseCMSInitiatingOccupancyOnly ' \
+    '-XX:CMSInitiatingOccupancyFraction=70 ' \
+    '-XX:+HeapDumpOnOutOfMemoryError ' \
+    '-XX:HeapDumpPath=/var/log/hive/heap-dump-hive-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof ' \
+    '-XX:+CMSClassUnloadingEnabled ' \
+    '-XX:+UseParNewGC ' \
+    '-XX:+ExitOnOutOfMemoryError ' \
     "-agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
 
-  env_sh[:HIVE_LOG_DIR] = "/var/log/hive"
-  env_sh[:HIVE_PID_DIR] = "/var/run/hive"
-  env_sh[:HIVE_IDENT_STRING] = "hive"
+  env_sh[:HIVE_LOG_DIR] = '/var/log/hive'
+  env_sh[:HIVE_PID_DIR] = '/var/run/hive'
+  env_sh[:HIVE_IDENT_STRING] = 'hive'
 end

--- a/cookbooks/bcpc-hadoop/attributes/hive.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hive.rb
@@ -68,7 +68,8 @@ default[:bcpc][:hadoop][:hive][:env_sh].tap do |env_sh|
     '-XX:HeapDumpPath=/var/log/hive/heap-dump-hive-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof ' +
     '-XX:+CMSClassUnloadingEnabled ' +
     '-XX:+UseParNewGC ' + 
-    '-XX:+ExitOnOutOfMemoryError' 
+    '-XX:+ExitOnOutOfMemoryError ' +
+    "-agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
 
   env_sh[:HIVE_LOG_DIR] = "/var/log/hive"
   env_sh[:HIVE_PID_DIR] = "/var/run/hive"

--- a/cookbooks/bcpc-hadoop/attributes/oozie.rb
+++ b/cookbooks/bcpc-hadoop/attributes/oozie.rb
@@ -5,7 +5,8 @@ default["bcpc"]["hadoop"]["oozie"]["memory_opts"] =
   " -XX:MaxPermSize=256m" +
   " -XX:+HeapDumpOnOutOfMemoryError " +
   " -XX:HeapDumpPath=/var/log/oozie/heap-dump-oozie-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof" +
-  " -XX:+ExitOnOutOfMemoryError"
+  " -XX:+ExitOnOutOfMemoryError" +
+  " -agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
 default["bcpc"]["hadoop"]["oozie"]["sharelib_checksum"] = nil
 default["bcpc"]["hadoop"]["oozie_config"] = "/etc/oozie/conf"
 default["bcpc"]["hadoop"]["oozie_data"] = "/var/lib/oozie"

--- a/cookbooks/bcpc-hadoop/attributes/oozie.rb
+++ b/cookbooks/bcpc-hadoop/attributes/oozie.rb
@@ -1,34 +1,38 @@
-default["bcpc"]["hadoop"]["oozie"]["admins"] = []
-default["bcpc"]["hadoop"]["oozie"]["memory_opts"] = 
-  "$CATALINA_OPTS" +
-  " -Xmx2048m" +
-  " -XX:MaxPermSize=256m" +
-  " -XX:+HeapDumpOnOutOfMemoryError " +
-  " -XX:HeapDumpPath=/var/log/oozie/heap-dump-oozie-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof" +
-  " -XX:+ExitOnOutOfMemoryError" +
+default['bcpc']['hadoop']['oozie']['admins'] = []
+default['bcpc']['hadoop']['oozie']['memory_opts'] =
+  '$CATALINA_OPTS' \
+  ' -Xmx2048m' \
+  ' -XX:MaxPermSize=256m' \
+  ' -XX:+HeapDumpOnOutOfMemoryError ' \
+  ' -XX:HeapDumpPath=/var/log/oozie/heap-dump-oozie-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof' \
+  ' -XX:+ExitOnOutOfMemoryError' \
   " -agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
-default["bcpc"]["hadoop"]["oozie"]["sharelib_checksum"] = nil
-default["bcpc"]["hadoop"]["oozie_config"] = "/etc/oozie/conf"
-default["bcpc"]["hadoop"]["oozie_data"] = "/var/lib/oozie"
-default["bcpc"]["hadoop"]["oozie_log"] = "/var/log/oozie"
-default["bcpc"]["hadoop"]["oozie_log_dir"] = "/var/log/oozie"
-default["bcpc"]["hadoop"]["oozie_pid_dir"] = "/var/run/oozie"
-default["bcpc"]["hadoop"]["oozie_catalina_home"] = "/usr/lib/bigtop-tomcat"
-default["bcpc"]["hadoop"]["cataline_tmpdir"] = "/tmp"
-default["bcpc"]["hadoop"]["catalina_pid"] = "/var/run/oozie/oozie.pid"
-default["bcpc"]["hadoop"]["oozie_https_port"] = 11443
-default["bcpc"]["hadoop"]["oozie_port"] = 11000
-default["bcpc"]["hadoop"]["oozie"]["systemmode"] = "NORMAL"
-default["bcpc"]["hadoop"]["oozie"]["service"]["AuthorizationService"]["security"]["enabled"] = false
-default["bcpc"]["hadoop"]["oozie"]["service"]["PurgeService"]["older"]["than"] = 30
-default["bcpc"]["hadoop"]["oozie"]["service"]["PurgeService"]["purge"]["interval"] = 3600
-default["bcpc"]["hadoop"]["oozie"]["service"]["CallableQueueService"]["queue"]["size"] = 10000
-default["bcpc"]["hadoop"]["oozie"]["service"]["CallableQueueService"]["threads"] = 10
-default["bcpc"]["hadoop"]["oozie"]["service"]["CallableQueueService"]["callable"]["concurrency"] = 3
-default["bcpc"]["hadoop"]["oozie"]["service"]["coord"]["normal"]["default"]["timeout"] = 120
-default["bcpc"]["hadoop"]["oozie"]["db"]["schema"]["name"] = "oozie"
-default["bcpc"]["hadoop"]["oozie"]["service"]["JPAService"]["create"]["db"]["schema"] = false
-default["bcpc"]["hadoop"]["oozie"]["service"]["JPAService"]["pool"]["max"]["active"]["conn"] = 100
-default["bcpc"]["hadoop"]["oozie"]["authentication"]["token"]["validity"] = 36000
-default["bcpc"]["hadoop"]["oozie"]["service"]["ext"] = "org.apache.oozie.service.ZKLocksService,org.apache.oozie.service.ZKXLogStreamingService,org.apache.oozie.service.ZKJobsConcurrencyService,org.apache.oozie.service.ZKUUIDService"
+default['bcpc']['hadoop']['oozie']['sharelib_checksum'] = nil
+default['bcpc']['hadoop']['oozie_config'] = '/etc/oozie/conf'
+default['bcpc']['hadoop']['oozie_data'] = '/var/lib/oozie'
+default['bcpc']['hadoop']['oozie_log'] = '/var/log/oozie'
+default['bcpc']['hadoop']['oozie_log_dir'] = '/var/log/oozie'
+default['bcpc']['hadoop']['oozie_pid_dir'] = '/var/run/oozie'
+default['bcpc']['hadoop']['oozie_catalina_home'] = '/usr/lib/bigtop-tomcat'
+default['bcpc']['hadoop']['cataline_tmpdir'] = '/tmp'
+default['bcpc']['hadoop']['catalina_pid'] = '/var/run/oozie/oozie.pid'
+default['bcpc']['hadoop']['oozie_https_port'] = 11443
+default['bcpc']['hadoop']['oozie_port'] = 11000
+default['bcpc']['hadoop']['oozie']['systemmode'] = 'NORMAL'
+default['bcpc']['hadoop']['oozie']['service']['AuthorizationService']['security']['enabled'] = false
+default['bcpc']['hadoop']['oozie']['service']['PurgeService']['older']['than'] = 30
+default['bcpc']['hadoop']['oozie']['service']['PurgeService']['purge']['interval'] = 3_600
+default['bcpc']['hadoop']['oozie']['service']['CallableQueueService']['queue']['size'] = 10_000
+default['bcpc']['hadoop']['oozie']['service']['CallableQueueService']['threads'] = 10
+default['bcpc']['hadoop']['oozie']['service']['CallableQueueService']['callable']['concurrency'] = 3
+default['bcpc']['hadoop']['oozie']['service']['coord']['normal']['default']['timeout'] = 120
+default['bcpc']['hadoop']['oozie']['db']['schema']['name'] = 'oozie'
+default['bcpc']['hadoop']['oozie']['service']['JPAService']['create']['db']['schema'] = false
+default['bcpc']['hadoop']['oozie']['service']['JPAService']['pool']['max']['active']['conn'] = 100
+default['bcpc']['hadoop']['oozie']['authentication']['token']['validity'] = 36_000
+default['bcpc']['hadoop']['oozie']['service']['ext'] =
+  'org.apache.oozie.service.ZKLocksService,' \
+  'org.apache.oozie.service.ZKXLogStreamingService,' \
+  'org.apache.oozie.service.ZKJobsConcurrencyService,' \
+  'org.apache.oozie.service.ZKUUIDService'
 default['bcpc']['hadoop']['oozie']['check_action_delay'] = 90

--- a/cookbooks/bcpc-hadoop/attributes/yarn.rb
+++ b/cookbooks/bcpc-hadoop/attributes/yarn.rb
@@ -57,7 +57,8 @@ default[:bcpc][:hadoop][:yarn][:env_sh].tap do |env_sh|
    ' -XX:+UseParNewGC' +
    ' -XX:+UseConcMarkSweepGC ' +
    ' -Dcom.sun.management.jmxremote.ssl=false' +
-   ' -Dcom.sun.management.jmxremote.authenticate=false'
+   ' -Dcom.sun.management.jmxremote.authenticate=false' +
+   " -agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
 
   env_sh[:YARN_RESOURCEMANAGER_OPTS] =
     ' -Dcom.sun.management.jmxremote.port=' +
@@ -70,7 +71,8 @@ default[:bcpc][:hadoop][:yarn][:env_sh].tap do |env_sh|
     ' -XX:+UseParNewGC' +
     ' -XX:+UseConcMarkSweepGC ' +
     ' -Dcom.sun.management.jmxremote.ssl=false' +
-    ' -Dcom.sun.management.jmxremote.authenticate=false'
+    ' -Dcom.sun.management.jmxremote.authenticate=false' +
+    " -agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
 end
 
 default[:bcpc][:hadoop][:yarn][:site_xml].tap do |site_xml|

--- a/cookbooks/bcpc-hadoop/attributes/yarn.rb
+++ b/cookbooks/bcpc-hadoop/attributes/yarn.rb
@@ -1,17 +1,17 @@
-default["bcpc"]["hadoop"]["yarn"]["fairsharepreemptiontimeout"] = 150
-default['bcpc']['hadoop']['yarn']['historyserver']['heap']["size"] = 128
-default['bcpc']['hadoop']['yarn']['historyserver']['heap']["ratio"] = 0
+default['bcpc']['hadoop']['yarn']['fairsharepreemptiontimeout'] = 150
+default['bcpc']['hadoop']['yarn']['historyserver']['heap']['size'] = 128
+default['bcpc']['hadoop']['yarn']['historyserver']['heap']['ratio'] = 0
 default['bcpc']['hadoop']['yarn']['yarn.log-aggregation.retain-days'] = 10
-default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["avail_memory"]["ratio"] = 0.5
-default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["avail_memory"]["size"] = nil
-default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["avail_vcpu"]["ratio"] = 0.5
-default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["avail_vcpu"]["count"] = nil
-default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["port"] = 45454
-default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["jmx"]["port"] = 3131
-default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["port"] = 8032
-default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["jmx"]["port"] = 3131
-default["bcpc"]["hadoop"]["yarn"]["scheduler"]["fair"]["min-vcores"] = 2
-default["bcpc"]["hadoop"]["yarn"]["min-free-space-per-disk-mb"] = 100
+default['bcpc']['hadoop']['yarn']['nodemanager']['avail_memory']['ratio'] = 0.5
+default['bcpc']['hadoop']['yarn']['nodemanager']['avail_memory']['size'] = nil
+default['bcpc']['hadoop']['yarn']['nodemanager']['avail_vcpu']['ratio'] = 0.5
+default['bcpc']['hadoop']['yarn']['nodemanager']['avail_vcpu']['count'] = nil
+default['bcpc']['hadoop']['yarn']['nodemanager']['port'] = 45454
+default['bcpc']['hadoop']['yarn']['nodemanager']['jmx']['port'] = 3131
+default['bcpc']['hadoop']['yarn']['resourcemanager']['port'] = 8032
+default['bcpc']['hadoop']['yarn']['resourcemanager']['jmx']['port'] = 3131
+default['bcpc']['hadoop']['yarn']['scheduler']['fair']['min-vcores'] = 2
+default['bcpc']['hadoop']['yarn']['min-free-space-per-disk-mb'] = 100
 default['bcpc']['hadoop']['yarn']['min_user_id'] = 1000
 
 yarn_log_dir = '/var/log/hadoop-yarn'
@@ -21,80 +21,75 @@ yarn_conf_dir = '/etc/hadoop/conf'
 yarn_logfile = 'yarn-$(hostname).log'
 yarn_policyfile = 'hadoop-policy.xml'
 
-default[:bcpc][:hadoop][:yarn][:env_sh].tap do |env_sh|
-  env_sh[:YARN_LOG_DIR] = yarn_log_dir
-  env_sh[:YARN_PID_DIR] = yarn_pid_dir
-  env_sh[:YARN_IDENT_STRING] = yarn_user
-  env_sh[:HADOOP_YARN_USER] = yarn_user
-  env_sh[:YARN_CONF_DIR] = yarn_conf_dir
-  env_sh[:JAVA_HOME] = node[:bcpc][:hadoop][:java]
-  env_sh[:JAVA] = File.join(env_sh[:JAVA_HOME], 'bin', 'java')
-  env_sh[:YARN_HEAPSIZE] = '1000' # megabytes
-  env_sh[:JAVA_HEAP_MAX] = '1000' # megabytes
-  env_sh[:YARN_LOGFILE] = yarn_logfile
-  env_sh[:YARN_POLICYFILE] = yarn_policyfile
+default['bcpc']['hadoop']['yarn']['env_sh'].tap do |env_sh|
+  env_sh['YARN_LOG_DIR'] = yarn_log_dir
+  env_sh['YARN_PID_DIR'] = yarn_pid_dir
+  env_sh['YARN_IDENT_STRING'] = yarn_user
+  env_sh['HADOOP_YARN_USER'] = yarn_user
+  env_sh['YARN_CONF_DIR'] = yarn_conf_dir
+  env_sh['JAVA_HOME'] = node['bcpc']['hadoop']['java']
+  env_sh['JAVA'] = File.join(env_sh['JAVA_HOME'], 'bin', 'java')
+  env_sh['YARN_HEAPSIZE'] = '1000' # megabytes
+  env_sh['JAVA_HEAP_MAX'] = '1000' # megabytes
+  env_sh['YARN_LOGFILE'] = yarn_logfile
+  env_sh['YARN_POLICYFILE'] = yarn_policyfile
 
-  env_sh[:YARN_OPTS] =
+  env_sh['YARN_OPTS'] =
     ' -Dhadoop.log.dir=' + yarn_log_dir +
     ' -Dyarn.log.dir=' + yarn_log_dir +
-    ' -Dhadoop.log.file=' + yarn_logfile  +
+    ' -Dhadoop.log.file=' + yarn_logfile +
     ' -Dyarn.log.dir=' + yarn_logfile +
     ' -Dyarn.id.str=' + yarn_user +
-    ' -Dhadoop.root.logger=INFO,CONSOLE ' +
-    ' -Dyarn.root.logger=INFO,CONSOLE ' +
+    ' -Dhadoop.root.logger=INFO,CONSOLE ' \
+    ' -Dyarn.root.logger=INFO,CONSOLE ' \
     ' -Dyarn.policy.file=' + yarn_policyfile +
-    ' -Djute.maxbuffer=' + node[:bcpc][:hadoop][:jute][:maxbuffer].to_s
+    ' -Djute.maxbuffer=' + node['bcpc']['hadoop']['jute']['maxbuffer'].to_s
 
+  env_sh['YARN_NODEMANAGER_OPTS'] =
+    ' -Dcom.sun.management.jmxremote.port=' + node['bcpc']['hadoop']['yarn']['nodemanager']['jmx']['port'].to_s +
+    ' -XX:HeapDumpPath=/var/log/hadoop-yarn/heap-dump-nm-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof ' \
+    ' -XX:+UseCMSInitiatingOccupancyOnly' \
+    ' -XX:CMSInitiatingOccupancyFraction=70' \
+    ' -XX:+HeapDumpOnOutOfMemoryError' \
+    ' -XX:+ExitOnOutOfMemoryError' \
+    ' -XX:+UseParNewGC' \
+    ' -XX:+UseConcMarkSweepGC ' \
+    ' -Dcom.sun.management.jmxremote.ssl=false' \
+    ' -Dcom.sun.management.jmxremote.authenticate=false' \
+    " -agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
 
-  env_sh[:YARN_NODEMANAGER_OPTS] =
-   ' -Dcom.sun.management.jmxremote.port=' +
-    node[:bcpc][:hadoop][:yarn][:nodemanager][:jmx][:port].to_s +
-   ' -XX:HeapDumpPath=/var/log/hadoop-yarn/heap-dump-nm-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof ' +
-   ' -XX:+UseCMSInitiatingOccupancyOnly' +
-   ' -XX:CMSInitiatingOccupancyFraction=70' +
-   ' -XX:+HeapDumpOnOutOfMemoryError' +
-   ' -XX:+ExitOnOutOfMemoryError' +
-   ' -XX:+UseParNewGC' +
-   ' -XX:+UseConcMarkSweepGC ' +
-   ' -Dcom.sun.management.jmxremote.ssl=false' +
-   ' -Dcom.sun.management.jmxremote.authenticate=false' +
-   " -agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
-
-  env_sh[:YARN_RESOURCEMANAGER_OPTS] =
+  env_sh['YARN_RESOURCEMANAGER_OPTS'] =
     ' -Dcom.sun.management.jmxremote.port=' +
-    node[:bcpc][:hadoop][:yarn][:resourcemanager][:jmx][:port].to_s +
-    ' -XX:HeapDumpPath=/var/log/hadoop-yarn/heap-dump-rm-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof' +
-    ' -XX:+UseCMSInitiatingOccupancyOnly' +
-    ' -XX:CMSInitiatingOccupancyFraction=70' +
-    ' -XX:+HeapDumpOnOutOfMemoryError' +
-    ' -XX:+ExitOnOutOfMemoryError' +
-    ' -XX:+UseParNewGC' +
-    ' -XX:+UseConcMarkSweepGC ' +
-    ' -Dcom.sun.management.jmxremote.ssl=false' +
-    ' -Dcom.sun.management.jmxremote.authenticate=false' +
+    node['bcpc']['hadoop']['yarn']['resourcemanager']['jmx']['port'].to_s +
+    ' -XX:HeapDumpPath=/var/log/hadoop-yarn/heap-dump-rm-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof' \
+    ' -XX:+UseCMSInitiatingOccupancyOnly' \
+    ' -XX:CMSInitiatingOccupancyFraction=70' \
+    ' -XX:+HeapDumpOnOutOfMemoryError' \
+    ' -XX:+ExitOnOutOfMemoryError' \
+    ' -XX:+UseParNewGC' \
+    ' -XX:+UseConcMarkSweepGC ' \
+    ' -Dcom.sun.management.jmxremote.ssl=false' \
+    ' -Dcom.sun.management.jmxremote.authenticate=false' \
     " -agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
 end
 
-default[:bcpc][:hadoop][:yarn][:site_xml].tap do |site_xml|
+default['bcpc']['hadoop']['yarn']['site_xml'].tap do |site_xml|
   site_xml['yarn.application.classpath'] =
     [
-     '/etc/hadoop/conf',
-     '/usr/hdp/current/hadoop-client/*',
-     '/usr/hdp/current/hadoop-client/lib/*',
-     '/usr/hdp/current/hadoop-hdfs-client/*',
-     '/usr/hdp/current/hadoop-hdfs-client/lib/*',
-     '/usr/hdp/current/hadoop-yarn-client/*',
-     '/usr/hdp/current/hadoop-yarn-client/lib/*'
+      '/etc/hadoop/conf',
+      '/usr/hdp/current/hadoop-client/*',
+      '/usr/hdp/current/hadoop-client/lib/*',
+      '/usr/hdp/current/hadoop-hdfs-client/*',
+      '/usr/hdp/current/hadoop-hdfs-client/lib/*',
+      '/usr/hdp/current/hadoop-yarn-client/*',
+      '/usr/hdp/current/hadoop-yarn-client/lib/*'
     ].join(',')
 
   site_xml['yarn.log-aggregation-enable'] = true
-
   ynla = 'yarn.nodemanager.log-aggregation'
   site_xml["#{ynla}.roll-monitoring-interval-seconds"] = 1800
   site_xml["#{ynla}.compression-type"] = 'gz'
-
-
-  site_xml["yarn.nodemanager.container-executor.class"] =
+  site_xml['yarn.nodemanager.container-executor.class'] =
     'org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor'
 
   lce = 'yarn.nodemanager.linux-container-executor'
@@ -111,7 +106,7 @@ default[:bcpc][:hadoop][:yarn][:site_xml].tap do |site_xml|
       node['bcpc']['hadoop']['yarn']['nodemanager']['avail_memory']
 
     avail_memory['size'] ||
-      [1024, (node['memory']['total'].to_i * avail_memory['ratio']/1024).floor].max
+      [1024, (node['memory']['total'].to_i * avail_memory['ratio'] / 1024).floor].max
   end
 
   site_xml['yarn.nodemanager.resource.memory-mb'] = yarn_max_memory.call
@@ -138,7 +133,7 @@ default[:bcpc][:hadoop][:yarn][:site_xml].tap do |site_xml|
   site_xml['yarn.acl.enable'] = 'true'
 
   site_xml['yarn.timeline-service.client.max-retries'] = 0
-  site_xml['yarn.nodemanager.disk-health-checker.min-free-space-per-disk-mb'] = node["bcpc"]["hadoop"]["yarn"]["min-free-space-per-disk-mb"]
+  site_xml['yarn.nodemanager.disk-health-checker.min-free-space-per-disk-mb'] = node['bcpc']['hadoop']['yarn']['min-free-space-per-disk-mb']
 end
 
 ### Delete these. (start) ###
@@ -147,42 +142,44 @@ end
 # These properties are used exactly once in generated values, so they've been
 # replaced by constants in yarn_config.rb
 #
-default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["yarn.client.failover-sleep-base-ms"] = 150
-default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["recovery"]["enabled"] = true
-default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["store"]["class"] = "org.apache.hadoop.yarn.server.resourcemanager.recovery.ZKRMStateStore"
-default["bcpc"]["hadoop"]["yarn"]["client"]["failover-proxy-provider"] = "org.apache.hadoop.yarn.client.ConfiguredRMFailoverProxyProvider"
+default['bcpc']['hadoop']['yarn']['resourcemanager']['yarn.client.failover-sleep-base-ms'] = 150
+default['bcpc']['hadoop']['yarn']['resourcemanager']['recovery']['enabled'] = true
+default['bcpc']['hadoop']['yarn']['resourcemanager']['store']['class'] = 'org.apache.hadoop.yarn.server.resourcemanager.recovery.ZKRMStateStore'
+default['bcpc']['hadoop']['yarn']['client']['failover-proxy-provider'] = 'org.apache.hadoop.yarn.client.ConfiguredRMFailoverProxyProvider'
 
 #
 # All of these properties are used exactly once, but can be replaced
-# by defaults in [:bcpc][:hadoop][:yarn][:site_xml]
+# by defaults in ['bcpc']['hadoop']['yarn']['site_xml']
 #
-default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["remote-app-log-dir"] = "/var/log/hadoop-yarn/apps"
-default["bcpc"]["hadoop"]["yarn"]["log-aggregation-enable"] = true
-default["bcpc"]["hadoop"]["yarn"]["log-aggregation_retain-seconds"] = 60*60*24*31
-default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["log-aggregation"]["roll-monitoring-interval-seconds"] = 1800
-default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["log-aggregation"]["compression-type"] = "gz"
-default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["container-executor"]["class"] = "org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor"
-default["bcpc"]["hadoop"]["yarn.nodemanager.linux-container-executor.group"] = "yarn"
-default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["linux-container-executor"]["nonsecure-mode"]["limit-users"] = false
-default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["linux-container-executor"]["resources-handler"]["class"] = "org.apache.hadoop.yarn.server.nodemanager.util.CgroupsLCEResourcesHandler"
-default["bcpc"]["hadoop"]["yarn"]["nodemanager"]["linux-container-executor"]["cgroups"]["mount-path"] = "/sys/fs/cgroup/"
+default['bcpc']['hadoop']['yarn']['nodemanager']['remote-app-log-dir'] = '/var/log/hadoop-yarn/apps'
+default['bcpc']['hadoop']['yarn']['log-aggregation-enable'] = true
+default['bcpc']['hadoop']['yarn']['log-aggregation_retain-seconds'] = 60 * 60 * 24 * 31
+default['bcpc']['hadoop']['yarn']['nodemanager']['log-aggregation']['roll-monitoring-interval-seconds'] = 1800
+default['bcpc']['hadoop']['yarn']['nodemanager']['log-aggregation']['compression-type'] = 'gz'
+default['bcpc']['hadoop']['yarn']['nodemanager']['container-executor']['class'] =
+  'org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor'
+default['bcpc']['hadoop']['yarn.nodemanager.linux-container-executor.group'] = 'yarn'
+default['bcpc']['hadoop']['yarn']['nodemanager']['linux-container-executor']['nonsecure-mode']['limit-users'] = false
+default['bcpc']['hadoop']['yarn']['nodemanager']['linux-container-executor']['resources-handler']['class'] =
+  'org.apache.hadoop.yarn.server.nodemanager.util.CgroupsLCEResourcesHandler'
+default['bcpc']['hadoop']['yarn']['nodemanager']['linux-container-executor']['cgroups']['mount-path'] = '/sys/fs/cgroup/'
 default['bcpc']['hadoop']['yarn']['nodemanager']['vmem-check-enabled'] = false
-default["bcpc"]["hadoop"]["yarn"]["resourcemanager"]["nodes"]["exclude-path"] = "/etc/hadoop/conf/yarn.exclude"
-default["bcpc"]["hadoop"]["yarn"]["scheduler"]["class"] = "org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler"
-default["bcpc"]["hadoop"]["yarn"]["scheduler"]["fair"]["preemption"] = true
+default['bcpc']['hadoop']['yarn']['resourcemanager']['nodes']['exclude-path'] = '/etc/hadoop/conf/yarn.exclude'
+default['bcpc']['hadoop']['yarn']['scheduler']['class'] = 'org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler'
+default['bcpc']['hadoop']['yarn']['scheduler']['fair']['preemption'] = true
 default['bcpc']['hadoop']['yarn']['timeline-service']['client']['max-retries'] = 0
 
-default[:bcpc][:hadoop][:yarn][:fairSchedulerOpts] = {
+default['bcpc']['hadoop']['yarn']['fairSchedulerOpts'] = {
   'defaultFairSharePreemptionTimeout' => 120,
   'defaultMinSharePreemptionTimeout' => 10,
   'queueMaxAMShareDefault' => 0.5,
   'defaultQueueSchedulingPolicy' => 'DRF'
 }
 
-default[:bcpc][:hadoop][:yarn][:queuePlacementPolicy] = [
-  {'nestedUserQueue' =>
-    {'secondaryGroupExistingQueue' => {'create' => 'false'}}},
-  {'nestedUserQueue' =>
-    {'default' => {'queue' => 'default'}}},
-  {'reject' => nil}
+default['bcpc']['hadoop']['yarn']['queuePlacementPolicy'] = [
+  { 'nestedUserQueue' =>
+    { 'secondaryGroupExistingQueue' => { 'create' => 'false' } } },
+  { 'nestedUserQueue' =>
+    { 'default' => { 'queue' => 'default' } } },
+  { 'reject' => nil }
 ]

--- a/cookbooks/bcpc-hadoop/recipes/configs.rb
+++ b/cookbooks/bcpc-hadoop/recipes/configs.rb
@@ -71,6 +71,9 @@ end
 include_recipe "java::default"
 include_recipe "java::oracle_jce"
 
+# jvmkill
+include_recipe "bcpc-hadoop::jvmkill"
+
 %w{zookeeper}.each do |pkg|
   package hwx_pkg_str(pkg, node[:bcpc][:hadoop][:distribution][:release]) do
     action :upgrade

--- a/cookbooks/bcpc-hadoop/recipes/configs.rb
+++ b/cookbooks/bcpc-hadoop/recipes/configs.rb
@@ -4,36 +4,30 @@ require 'base64'
 include_recipe 'bcpc-hadoop::default'
 
 # disable IPv6 (e.g. for HADOOP-8568)
-case node["platform_family"]
-  when "debian"
-    %w{net.ipv6.conf.all.disable_ipv6
-       net.ipv6.conf.default.disable_ipv6
-       net.ipv6.conf.lo.disable_ipv6}.each do |param|
-      sysctl_param param do
-        value 1
-      end
+case node['platform_family']
+when 'debian'
+  %w(net.ipv6.conf.all.disable_ipv6
+     net.ipv6.conf.default.disable_ipv6
+     net.ipv6.conf.lo.disable_ipv6).each do |param|
+    sysctl_param param do
+      value 1
     end
-  else
-  Chef::Log.warn "============ Unable to disable IPv6 for non-Debian systems"
+  end
+else
+  Chef::Log.warn '============ Unable to disable IPv6 for non-Debian systems'
 end
 
 # ensure we use /etc/security/limits.d to allow ulimit overriding
-if not node.has_key?('pam_d') or not node['pam_d'].has_key?('services') or not node['pam_d']['services'].has_key?('common-session')
+if !node.key?('pam_d') || !node['pam_d'].key?('services') || !node['pam_d']['services'].key?('common-session')
   node.default['pam_d']['services'] = {
     'common-session' => {
       'main' => {
-        'pam_permit_default' => {
-          'interface' => 'session', 'control_flag' => '[default=1]', 'name' => 'pam_permit.so' },
-        'pam_deny' => {
-          'interface' => 'session', 'control_flag' => 'requisite', 'name' => 'pam_deny.so' },
-        'pam_permit_required' => {
-          'interface' => 'session', 'control_flag' => 'required', 'name' => 'pam_permit.so' },
-        'pam_limits' => {
-          'interface' => 'session', 'control_flag' => 'required', 'name' => 'pam_limits.so' },
-        'pam_umask' => {
-          'interface' => 'session', 'control_flag' => 'optional', 'name' => 'pam_umask.so' },
-        'pam_unix' => {
-          'interface' => 'session', 'control_flag' => 'required', 'name' => 'pam_unix.so' }
+        'pam_permit_default' => { 'interface' => 'session', 'control_flag' => '[default=1]', 'name' => 'pam_permit.so' },
+        'pam_deny' => { 'interface' => 'session', 'control_flag' => 'requisite', 'name' => 'pam_deny.so' },
+        'pam_permit_required' => { 'interface' => 'session', 'control_flag' => 'required', 'name' => 'pam_permit.so' },
+        'pam_limits' => { 'interface' => 'session', 'control_flag' => 'required', 'name' => 'pam_limits.so' },
+        'pam_umask' => { 'interface' => 'session', 'control_flag' => 'optional', 'name' => 'pam_umask.so' },
+        'pam_unix' => { 'interface' => 'session', 'control_flag' => 'required', 'name' => 'pam_unix.so' }
       },
       'includes' => []
     }
@@ -53,28 +47,28 @@ node.override['locking_resource']['zookeeper_servers'] = \
     [float_host(server['hostname']), node[:bcpc][:hadoop][:zookeeper][:port]].join(':')
   end
 
-package "bigtop-jsvc"
+package 'bigtop-jsvc'
 
-template "hadoop-detect-javahome" do
-  path "/usr/lib/bigtop-utils/bigtop-detect-javahome"
-  source "hdp_bigtop-detect-javahome.erb"
-  owner "root"
-  group "root"
-  mode "0755"
+template 'hadoop-detect-javahome' do
+  path '/usr/lib/bigtop-utils/bigtop-detect-javahome'
+  source 'hdp_bigtop-detect-javahome.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
 end
 
-package "hdp-select" do
+package 'hdp-select' do
   action :upgrade
 end
 
 # Install Java
-include_recipe "java::default"
-include_recipe "java::oracle_jce"
+include_recipe 'java::default'
+include_recipe 'java::oracle_jce'
 
 # jvmkill
-include_recipe "bcpc-hadoop::jvmkill"
+include_recipe 'bcpc-hadoop::jvmkill'
 
-%w{zookeeper}.each do |pkg|
+%w(zookeeper).each do |pkg|
   package hwx_pkg_str(pkg, node[:bcpc][:hadoop][:distribution][:release]) do
     action :upgrade
   end

--- a/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
@@ -4,29 +4,27 @@ node.default['bcpc']['hadoop']['hbase']['env'] = {}
 cpu_total = node['cpu']['total']
 cpu_ratio = node['bcpc']['hadoop']['hbase_rs']['gc_thread']['cpu_ratio']
 common_opts =
-  ' -server -XX:ParallelGCThreads=' +
-      [1, (cpu_total * cpu_ratio).ceil].max.to_s +
-  ' -XX:+UseCMSInitiatingOccupancyOnly' +
-  ' -XX:+HeapDumpOnOutOfMemoryError' +
-  ' -verbose:gc' +
-  ' -XX:+PrintHeapAtGC' +
-  ' -XX:+PrintGCDetails' +
-  ' -XX:+PrintGCTimeStamps' +
-  ' -XX:+PrintGCDateStamps' +
-  ' -XX:+UseParNewGC' +
-  ' -Xloggc:${HBASE_LOG_DIR}/gc/gc-pid-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log' +
-  ' -Xmn' + node['bcpc']['hadoop']['hbase_rs']['xmn']['size'].to_s + 'm' +
-  ' -Xms' + node['bcpc']['hadoop']['hbase_rs']['xms']['size'].to_s + 'm' +
-  ' -Xmx' + node['bcpc']['hadoop']['hbase_rs']['xmx']['size'].to_s + 'm' +
-  ' -XX:+ExplicitGCInvokesConcurrent' +
-  ' -XX:+PrintTenuringDistribution' +
-  ' -XX:+UseNUMA' +
-
-  ' -XX:+PrintGCApplicationStoppedTime' +
-  ' -XX:+UseCompressedOops' +
-  ' -XX:+PrintClassHistogram' +
-  ' -XX:+PrintGCApplicationConcurrentTime' +
-  ' -XX:+ExitOnOutOfMemoryError' +
+  ' -server -XX:ParallelGCThreads=' + [1, (cpu_total * cpu_ratio).ceil].max.to_s +
+  ' -XX:+UseCMSInitiatingOccupancyOnly' \
+  ' -XX:+HeapDumpOnOutOfMemoryError' \
+  ' -verbose:gc' \
+  ' -XX:+PrintHeapAtGC' \
+  ' -XX:+PrintGCDetails' \
+  ' -XX:+PrintGCTimeStamps' \
+  ' -XX:+PrintGCDateStamps' \
+  ' -XX:+UseParNewGC' \
+  ' -Xloggc:${HBASE_LOG_DIR}/gc/gc-pid-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log' \
+  ' -Xmn' + node['bcpc']['hadoop']['hbase_rs']['xmn']['size'].to_s + 'm' \
+  ' -Xms' + node['bcpc']['hadoop']['hbase_rs']['xms']['size'].to_s + 'm' \
+  ' -Xmx' + node['bcpc']['hadoop']['hbase_rs']['xmx']['size'].to_s + 'm' \
+  ' -XX:+ExplicitGCInvokesConcurrent' \
+  ' -XX:+PrintTenuringDistribution' \
+  ' -XX:+UseNUMA' \
+  ' -XX:+PrintGCApplicationStoppedTime' \
+  ' -XX:+UseCompressedOops' \
+  ' -XX:+PrintClassHistogram' \
+  ' -XX:+PrintGCApplicationConcurrentTime' \
+  ' -XX:+ExitOnOutOfMemoryError' \
   " -agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
 
 node.default['bcpc']['hadoop']['hbase']['env'].tap do |hbase_env|
@@ -35,72 +33,62 @@ node.default['bcpc']['hadoop']['hbase']['env'].tap do |hbase_env|
   hbase_env['HBASE_LOG_DIR'] = '/var/log/hbase'
   hbase_env['HBASE_MANAGES_ZK'] = 'false'
 
-  hbase_env['HBASE_JMX_BASE'] = '-Dcom.sun.management.jmxremote.ssl=false' +
+  hbase_env['HBASE_JMX_BASE'] = '-Dcom.sun.management.jmxremote.ssl=false' \
     ' -Dcom.sun.management.jmxremote.authenticate=false'
 
-  hbase_env['HBASE_OPTS'] = '$HBASE_OPTS -Djava.net.preferIPv4Stack=true' +
+  hbase_env['HBASE_OPTS'] = '$HBASE_OPTS -Djava.net.preferIPv4Stack=true' \
     ' -XX:+UseConcMarkSweepGC'
 
   hbase_env['HBASE_MASTER_OPTS'] =
-    '$HBASE_MASTER_OPTS' +
-     common_opts +
-    ' -XX:CMSInitiatingOccupancyFraction=' +
-      node['bcpc']['hadoop']['hbase_master']['cmsinitiatingoccupancyfraction'].to_s +
-    ' -XX:HeapDumpPath=${HBASE_LOG_DIR}/heap-dump-hm-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof' +
-    ' -XX:PretenureSizeThreshold=' +
-      node['bcpc']['hadoop']['hbase_master']['PretenureSizeThreshold'].to_s
+    '$HBASE_MASTER_OPTS' + common_opts +
+    ' -XX:CMSInitiatingOccupancyFraction=' + node['bcpc']['hadoop']['hbase_master']['cmsinitiatingoccupancyfraction'].to_s +
+    ' -XX:HeapDumpPath=${HBASE_LOG_DIR}/heap-dump-hm-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof' \
+    ' -XX:PretenureSizeThreshold=' + node['bcpc']['hadoop']['hbase_master']['PretenureSizeThreshold'].to_s
 
   hbase_env['HBASE_REGIONSERVER_OPTS'] =
-    '$HBASE_REGION_SERVER_OPTS' +
-    common_opts +
-    ' -XX:CMSInitiatingOccupancyFraction=' +
-      node['bcpc']['hadoop']['hbase_rs']['cmsinitiatingoccupancyfraction'].to_s +
-    ' -XX:HeapDumpPath=${HBASE_LOG_DIR}/heap-dump-rs-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof' +
-    ' -XX:PretenureSizeThreshold=' +
-      node['bcpc']['hadoop']['hbase_rs']['PretenureSizeThreshold'].to_s
+    '$HBASE_REGION_SERVER_OPTS' + common_opts +
+    ' -XX:CMSInitiatingOccupancyFraction=' + node['bcpc']['hadoop']['hbase_rs']['cmsinitiatingoccupancyfraction'].to_s +
+    ' -XX:HeapDumpPath=${HBASE_LOG_DIR}/heap-dump-rs-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof' \
+    ' -XX:PretenureSizeThreshold=' + node['bcpc']['hadoop']['hbase_rs']['PretenureSizeThreshold'].to_s
 end
 
-if node["bcpc"]["hadoop"]["hbase"]["bucketcache"]["enabled"] == true then
+if node['bcpc']['hadoop']['hbase']['bucketcache']['enabled'] == true
   node.default['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] =
-   node['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] +
-   ' -XX:MaxDirectMemorySize=' +
-     node['bcpc']['hadoop']['hbase_rs']['mx_dir_mem']['size'].to_s + 'm'
+    node['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] +
+    ' -XX:MaxDirectMemorySize=' + node['bcpc']['hadoop']['hbase_rs']['mx_dir_mem']['size'].to_s + 'm'
+
   node.default['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] =
-   node['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] +
-   ' -XX:MaxDirectMemorySize=' +
-     node['bcpc']['hadoop']['hbase_master']['mx_dir_mem']['size'].to_s + 'm'
+    node['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] +
+    ' -XX:MaxDirectMemorySize=' + node['bcpc']['hadoop']['hbase_master']['mx_dir_mem']['size'].to_s + 'm'
 end
 
-if node[:bcpc][:hadoop][:kerberos][:enable] == true then
-    node.default['bcpc']['hadoop']['hbase']['env']['HBASE_OPTS'] =
-      node['bcpc']['hadoop']['hbase']['env']['HBASE_OPTS'] +
-      ' -Djava.security.auth.login.config=/etc/hbase/conf/hbase-client.jaas'
-    node.default['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] =
-      node['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] +
-      ' -Djava.security.auth.login.config=/etc/hbase/conf/hbase-server.jaas'
-    node.default['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] =
-      node['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] +
-      ' -Djava.security.auth.login.config=/etc/hbase/conf/regionserver.jaas'
+if node[:bcpc][:hadoop][:kerberos][:enable] == true
+  node.default['bcpc']['hadoop']['hbase']['env']['HBASE_OPTS'] =
+    node['bcpc']['hadoop']['hbase']['env']['HBASE_OPTS'] +
+    ' -Djava.security.auth.login.config=/etc/hbase/conf/hbase-client.jaas'
+  node.default['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] =
+    node['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] +
+    ' -Djava.security.auth.login.config=/etc/hbase/conf/hbase-server.jaas'
+  node.default['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] =
+    node['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] +
+    ' -Djava.security.auth.login.config=/etc/hbase/conf/regionserver.jaas'
 end
 
 #
 # HBASE Master and RegionServer env.sh variables are updated with JMX related options when JMX is enabled
 #
-if node[:bcpc][:hadoop].attribute?(:jmx_enabled) and node[:bcpc][:hadoop][:jmx_enabled] then
+if node[:bcpc][:hadoop].attribute?(:jmx_enabled) && node[:bcpc][:hadoop][:jmx_enabled]
   node.default['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] =
-    node['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] +
-    ' $HBASE_JMX_BASE ' +
-    ' -Dcom.sun.management.jmxremote.port=' +
-      node[:bcpc][:hadoop][:hbase_master][:jmx][:port].to_s
-   node.default['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] =
-    node['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] +
-    ' $HBASE_JMX_BASE ' +
-    ' -Dcom.sun.management.jmxremote.port=' +
-      node[:bcpc][:hadoop][:hbase_rs][:jmx][:port].to_s
+    node['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] + ' $HBASE_JMX_BASE ' \
+    ' -Dcom.sun.management.jmxremote.port=' + node[:bcpc][:hadoop][:hbase_master][:jmx][:port].to_s
+
+  node.default['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] =
+    node['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] + ' $HBASE_JMX_BASE ' \
+    ' -Dcom.sun.management.jmxremote.port=' + node[:bcpc][:hadoop][:hbase_rs][:jmx][:port].to_s
 end
 
 template '/etc/hbase/conf/hbase-env.sh' do
   source 'generic_env.sh.erb'
-  mode 0644
-  variables(:options => node['bcpc']['hadoop']['hbase']['env'])
+  mode 0o0644
+  variables(options: node['bcpc']['hadoop']['hbase']['env'])
 end

--- a/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
@@ -26,7 +26,8 @@ common_opts =
   ' -XX:+UseCompressedOops' +
   ' -XX:+PrintClassHistogram' +
   ' -XX:+PrintGCApplicationConcurrentTime' +
-  ' -XX:+ExitOnOutOfMemoryError'
+  ' -XX:+ExitOnOutOfMemoryError' +
+  " -agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
 
 node.default['bcpc']['hadoop']['hbase']['env'].tap do |hbase_env|
   hbase_env['JAVA_HOME'] = node[:bcpc][:hadoop][:java]

--- a/cookbooks/bcpc-hadoop/recipes/jvmkill.rb
+++ b/cookbooks/bcpc-hadoop/recipes/jvmkill.rb
@@ -41,4 +41,3 @@ remote_file lib_file.to_s do
   group 'ubuntu'
   mode '0755'
 end
-

--- a/cookbooks/bcpc-hadoop/recipes/jvmkill.rb
+++ b/cookbooks/bcpc-hadoop/recipes/jvmkill.rb
@@ -1,0 +1,44 @@
+#
+# Cookbook Name:: bcpc-hadoop
+# Recipe:: jvmkill
+#
+# Copyright 2013, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This recipe deploys libjvmkill.so to the following location
+# node['bcpc-hadoop']['jvmkill']['lib_file']
+#
+require 'pathname'
+
+lib_file = node['bcpc-hadoop']['jvmkill']['lib_file']
+lib_file_name = Pathname.new(lib_file).basename.to_s
+lib_file_path = Pathname.new(lib_file).dirname.to_s
+src_file_url = File.join(get_binary_server_url, lib_file_name)
+
+directory lib_file_path do
+  owner 'ubuntu'
+  group 'ubuntu'
+  mode '0755'
+  recursive true
+end
+
+remote_file lib_file.to_s do
+  source src_file_url
+  owner 'ubuntu'
+  group 'ubuntu'
+  mode '0755'
+end
+


### PR DESCRIPTION
Add libjvmkill.so to hadoop java processes.
```

ubuntu@dnj2-bach-r3n16:~/chef-bcpc/cookbooks$ grep -R "agentpath" .
./bcpc-hadoop/recipes/hbase_env.rb:  " -agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
./bcpc-hadoop/attributes/default.rb:  "-agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
./bcpc-hadoop/attributes/oozie.rb:  " -agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
./bcpc-hadoop/attributes/hive.rb:    "-agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
./bcpc-hadoop/attributes/yarn.rb:    " -agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
./bcpc-hadoop/attributes/yarn.rb:    " -agentpath:#{node['bcpc-hadoop']['jvmkill']['lib_file']}"
```

Please review and give comments.

Tested on VM cluster. Was able to build a fresh VM cluster, and confirmed hadoop processes have "-agentpath" attached, e.g. 
```
[sudo] password for ubuntu: vagrant@for h in 11 12 13; do echo ----${h}----; ./nodessh.sh Test-Laptop 10.0.100.${h} 'ps -ef|grep hbase-regionserver|grep -v
 grep |egrep -o libjvmkill.so' sudo; done                                                                                                                  
----11----
[sudo] password for ubuntu: ----12----
[sudo] password for ubuntu: ----13----
[sudo] password for ubuntu: libjvmkill.so
```
