### PR TITLE
Correctly handle a fixnum FD from sysopen

### DIFF
--- a/cookbooks/bcpc/libraries/disk_helpers.rb
+++ b/cookbooks/bcpc/libraries/disk_helpers.rb
@@ -81,9 +81,9 @@ def bcpc_unused_disks
     begin
       require 'fcntl'
       fd = IO::sysopen("/dev/#{dd}", Fcntl::O_RDONLY | Fcntl::O_EXCL)
-      fd.close
+      IO.new(fd).close
       true
-    rescue Exception => ee
+    rescue Errno::EBUSY => ee
       Chef::Log.debug("Unable to open #{dd} with O_EXCL: #{ee}")
       nil
     end


### PR DESCRIPTION
sysopen returns a fixnum, not an FD object, so we must create an FD object from the integer in order to close it successfully.

This has been breaking new VM builds