### PR TITLE
Additional disk fixes

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/disks.rb
+++ b/cookbooks/bcpc-hadoop/recipes/disks.rb
@@ -155,7 +155,13 @@ ruby_block 'format-disks' do
         end
       end
 
-      mount_device = bcpc_uuid_for_device(dev_name) || dev_name
+      uuid_candidate = bcpc_uuid_for_device(dev_name)
+
+      mount_device = if uuid_candidate
+                       "UUID=#{uuid_candidate}"
+                     else
+                       dev_name
+                     end
 
       Chef::Resource::Mount.new(mount_target,
                                 node.run_context).tap do |mm|

--- a/cookbooks/bcpc/libraries/disk_helpers.rb
+++ b/cookbooks/bcpc/libraries/disk_helpers.rb
@@ -81,9 +81,9 @@ def bcpc_unused_disks
     begin
       require 'fcntl'
       fd = IO::sysopen("/dev/#{dd}", Fcntl::O_RDONLY | Fcntl::O_EXCL)
-      fd.close
+      IO.new(fd).close
       true
-    rescue Exception => ee
+    rescue Errno::EBUSY => ee
       Chef::Log.debug("Unable to open #{dd} with O_EXCL: #{ee}")
       nil
     end


### PR DESCRIPTION
- Correctly derive UUID= line for mounts by UUID
- Wrap the fixnum FD with an IO object in order to close it