### PR TITLE
Initial Journalnode JMX

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -37,7 +37,6 @@ default[:bcpc][:hadoop][:jute][:maxbuffer] = 6_291_456
 default['bcpc']['hadoop']['datanode']['xmx']['max_size'] = 4_096
 default['bcpc']['hadoop']['datanode']['xmx']['max_ratio'] = 0.25
 default['bcpc']['hadoop']['datanode']['max']['xferthreads'] = 16_384
-default['bcpc']['hadoop']['datanode']['jmx']['port'] = 10112
 
 # for jvmkill library
 default['bcpc-hadoop']['jvmkill']['lib_file'] = '/var/lib/jvmkill/libjvmkill.so'
@@ -82,7 +81,6 @@ default['bcpc']['hadoop']['namenode']['xmx']['max_size'] = 1024
 # set to nil to calculate dynamically based on available memory
 default['bcpc']['hadoop']['namenode']['xmn']['max_size'] = 128
 default['bcpc']['hadoop']['namenode']['xmx']['max_ratio'] = 0.25
-default['bcpc']['hadoop']['namenode']['jmx']['port'] = 10111
 default['bcpc']['hadoop']['namenode']['rpc']['port'] = 8020
 default['bcpc']['hadoop']['namenode']['http']['port'] = 50070
 default['bcpc']['hadoop']['namenode']['https']['port'] = 50470

--- a/cookbooks/bcpc-hadoop/attributes/hdfs.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hdfs.rb
@@ -4,6 +4,13 @@ default["hadoop"]["hdfs"]["balancer"]["bandwidth"] = 1048576
 # balancer thread multiplier constant
 default["hadoop"]["hdfs"]["balancer"]["max_concurrent_moves_multiplier"] = 10
 
+# JMX port mappings
+default['bcpc']['hadoop'].tap do |jmx|
+  jmx['journalnode']['jmx']['port'] = 10110
+  jmx['datanode']['jmx']['port'] = 10112
+  jmx['namenode']['jmx']['port'] = 10111
+end
+
 default[:bcpc][:hadoop][:hdfs][:dfs].tap do |dfs|
   dfs[:namenode][:audit][:log][:async] = true
   dfs[:webhdfs][:enabled] = true

--- a/cookbooks/bcpc-hadoop/recipes/hadoop_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hadoop_config.rb
@@ -66,8 +66,9 @@ template "/etc/hadoop/conf/hadoop-env.sh" do
   source "hdp_hadoop-env.sh.erb"
   mode 0555
   variables(
-    :nn_jmx_port => node[:bcpc][:hadoop][:namenode][:jmx][:port],
-    :dn_jmx_port => node[:bcpc][:hadoop][:datanode][:jmx][:port]
+    :nn_jmx_port => node['bcpc']['hadoop']['namenode']['jmx']['port'],
+    :dn_jmx_port => node['bcpc']['hadoop']['datanode']['jmx']['port'],
+    :jn_jmx_port => node['bcpc']['hadoop']['journalnode']['jmx']['port']
   )
 end
 

--- a/cookbooks/bcpc-hadoop/recipes/journalnode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/journalnode.rb
@@ -6,6 +6,41 @@ include_recipe 'bcpc-hadoop::hadoop_config'
 hdprel=node[:bcpc][:hadoop][:distribution][:active_release]
 hdppath="/usr/hdp/#{hdprel}"
 
+# Setup JMXTrans information
+node.default['jmxtrans'].tap do |jmxtrans|
+  jmxtrans['servers'] = [
+                          {
+                          'type': 'journalnode',
+                          'service': 'hadoop-hdfs-journalnode',
+                          'service_cmd': 'org.apache.hadoop.hdfs.qjournal.server.JournalNode'
+                          }
+                        ]
+  jmxtrans['default_queries']['journalnode'] =
+    [
+      {
+        'obj': 'Hadoop:service=JournalNode,name=RpcDetailedActivityForPort*',
+        'result_alias': 'DetailedRPCActivity',
+        'attr': []
+      },
+      {
+        'obj': 'Hadoop:service=JournalNode,name=RpcActivityForPort8485',
+        'result_alias': 'RPCActivity',
+        'attr': []
+      },
+      {
+        'obj': 'Hadoop:service=JournalNode,name=UgiMetrics',
+        'result_alias': 'UgiMetrics',
+        'attr': []
+      },
+      {
+        'obj': 'Hadoop:service=JournalNode,name=Journal-*',
+        'result_alias': 'JNActivity',
+        'attr': []
+      }
+    ]
+    
+end
+
 %w{hadoop-hdfs-namenode hadoop-hdfs-journalnode}.each do |pkg|
   package hwx_pkg_str(pkg, hdprel) do
     action :install

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_hadoop-env.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_hadoop-env.sh.erb
@@ -67,6 +67,7 @@ export HADOOP_NAMENODE_OPTS="$HADOOP_NAMENODE_OPTS -Xms<%= namenode_heap %>m -Xm
 JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
 export HADOOP_NAMENODE_OPTS="$HADOOP_NAMENODE_OPTS $JMX_OPTS -Dcom.sun.management.jmxremote.port=<%= @nn_jmx_port %>"
 export HADOOP_DATANODE_OPTS="$HADOOP_DATANODE_OPTS $JMX_OPTS -Dcom.sun.management.jmxremote.port=<%= @dn_jmx_port %>"
+export HADOOP_JOURNALNODE_OPTS="$HADOOP_JOURNALNODE_OPTS $JMX_OPTS -Dcom.sun.management.jmxremote.port=<%= @jn_jmx_port %>"
 <% end %>
 
 export HADOOP_NAMENODE_OPTS="$HADOOP_NAMENODE_OPTS -Dhadoop.security.logger=INFO,RFAS -Dhdfs.audit.logger=INFO,RFAAUDIT"


### PR DESCRIPTION
This provides JMX metrics for our Journal Nodes.

Useful metrics are things like:
* `LastWriterEpoch` - to make sure your QJM's have not split brained
* Various `*NumOps` metrics - to ensure things are working smoothly
* A series of histogram style metrics for sync times - to ensure your QJM is not slowing your HDFS down
* Authentication metrics - to ensure your kerberos is working happily