### PR TITLE
Change to make HBase master heap memory configurable through attribute

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
@@ -14,9 +14,6 @@ common_opts =
   ' -XX:+PrintGCDateStamps' \
   ' -XX:+UseParNewGC' \
   ' -Xloggc:${HBASE_LOG_DIR}/gc/gc-pid-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log' \
-  ' -Xmn' + node['bcpc']['hadoop']['hbase_rs']['xmn']['size'].to_s + 'm' \
-  ' -Xms' + node['bcpc']['hadoop']['hbase_rs']['xms']['size'].to_s + 'm' \
-  ' -Xmx' + node['bcpc']['hadoop']['hbase_rs']['xmx']['size'].to_s + 'm' \
   ' -XX:+ExplicitGCInvokesConcurrent' \
   ' -XX:+PrintTenuringDistribution' \
   ' -XX:+UseNUMA' \
@@ -41,12 +38,18 @@ node.default['bcpc']['hadoop']['hbase']['env'].tap do |hbase_env|
 
   hbase_env['HBASE_MASTER_OPTS'] =
     '$HBASE_MASTER_OPTS' + common_opts +
+    ' -Xmn' + node['bcpc']['hadoop']['hbase_master']['xmn']['size'].to_s + 'm' +
+    ' -Xms' + node['bcpc']['hadoop']['hbase_master']['xms']['size'].to_s + 'm' +
+    ' -Xmx' + node['bcpc']['hadoop']['hbase_master']['xmx']['size'].to_s + 'm' +
     ' -XX:CMSInitiatingOccupancyFraction=' + node['bcpc']['hadoop']['hbase_master']['cmsinitiatingoccupancyfraction'].to_s +
     ' -XX:HeapDumpPath=${HBASE_LOG_DIR}/heap-dump-hm-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof' \
     ' -XX:PretenureSizeThreshold=' + node['bcpc']['hadoop']['hbase_master']['PretenureSizeThreshold'].to_s
 
   hbase_env['HBASE_REGIONSERVER_OPTS'] =
     '$HBASE_REGION_SERVER_OPTS' + common_opts +
+    ' -Xmn' + node['bcpc']['hadoop']['hbase_rs']['xmn']['size'].to_s + 'm' +
+    ' -Xms' + node['bcpc']['hadoop']['hbase_rs']['xms']['size'].to_s + 'm' +
+    ' -Xmx' + node['bcpc']['hadoop']['hbase_rs']['xmx']['size'].to_s + 'm' +
     ' -XX:CMSInitiatingOccupancyFraction=' + node['bcpc']['hadoop']['hbase_rs']['cmsinitiatingoccupancyfraction'].to_s +
     ' -XX:HeapDumpPath=${HBASE_LOG_DIR}/heap-dump-rs-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').hprof' \
     ' -XX:PretenureSizeThreshold=' + node['bcpc']['hadoop']['hbase_rs']['PretenureSizeThreshold'].to_s


### PR DESCRIPTION
Currently there is a bug which prevents HBase master JVM heap size takes the value set for region servers. This change will make the configuration of master heap non dependent on region server memory setting.

**Note:** This may require change to wrapper cookbooks if HBase memory values are overwritten through wrapper.