### PR TITLE
Prevent exposing hive warehouse directories

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hive.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hive.rb
@@ -32,7 +32,7 @@ default[:bcpc][:hadoop][:hive][:site_xml].tap do |site_xml|
   site_xml['hive.stats.dbclass'] = 'fs'
   site_xml['hive.stats.jdbcdriver'] = 'com.mysql.jdbc.Driver'
   site_xml['hive.support.concurrency'] = true
-  site_xml['hive.warehouse.subdir.inherit.perms'] = true
+  site_xml['hive.warehouse.subdir.inherit.perms'] = false
   site_xml['hive.cluster.delegation.token.store.class'] =
     'org.apache.hadoop.hive.thrift.ZooKeeperTokenStore'
   site_xml['hive.cluster.delegation.token.store.zookeeper.connectString'] =

--- a/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
@@ -47,8 +47,8 @@ end
 bash 'create-hive-warehouse' do
   code <<-EOH
   hdfs dfs -mkdir -p #{node['bcpc']['hadoop']['hive']['warehouse']['dir']}
-  hdfs dfs -chmod -R 775 #{node['bcpc']['hadoop']['hive']['warehouse']['dir']}
-  hdfs dfs -chown -R hive:hdfs #{node['bcpc']['hadoop']['hive']['warehouse']['dir']}
+  hdfs dfs -chmod 777 #{node['bcpc']['hadoop']['hive']['warehouse']['dir']}
+  hdfs dfs -chown hive:hdfs #{node['bcpc']['hadoop']['hive']['warehouse']['dir']}
   EOH
   user 'hdfs'
 end


### PR DESCRIPTION
Also prevents chef runs in hive from putting too much load on the
namenode.

Tested on a VM cluster build from scratch.