### PR TITLE
bootstrap-gpg issue

### DIFF
--- a/setup_chef_bootstrap_node.sh
+++ b/setup_chef_bootstrap_node.sh
@@ -46,6 +46,17 @@ sudo chef-client \
      -c .chef/knife.rb \
      -o 'recipe[bcpc::chef_poise_install]'
 
+
+#
+# For some reason that I don't understand,we need to do this before
+# BCPC-Bootstrap so that we have os in the chef vault to allow bootstrap-gpg
+# to be properly put inside the configs/Test-Laptop data bag as we aren't even installing the chef vault until after the first apt run
+sudo -E chef-client \
+     -c .chef/knife.rb \
+     -o 'recipe[bach_repository::apt]'
+
+
+
 #
 # With chef-vault installed and the repo configured, it's safe to save
 # and converge the complete runlist.


### PR DESCRIPTION
Repeating my comment: 
For some reason that I don't understand. My hypothesis is that  we need to do this before BCPC-Bootstrap so that we have os in the chef vault to allow bootstrap-gpg to be properly put inside the configs/Test-Laptop data bag as we aren't even installing the chef vault until after the first apt run.