### PR TITLE
Unset the sticky bit on the scratch directory

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
@@ -56,7 +56,7 @@ end
 bash 'create-hive-scratch' do
   code <<-EOH
   hdfs dfs -mkdir -p #{node['bcpc']['hadoop']['hive']['scratch']['dir']}
-  hdfs dfs -chmod -R 1777 #{node['bcpc']['hadoop']['hive']['scratch']['dir']}
+  hdfs dfs -chmod -R 0777 #{node['bcpc']['hadoop']['hive']['scratch']['dir']}
   hdfs dfs -chown -R hive:hdfs #{node['bcpc']['hadoop']['hive']['scratch']['dir']}
   EOH
   user 'hdfs'


### PR DESCRIPTION
Tested running the command manually in my own directories

I'll backport the PR to master after deployment