### PR TITLE
single mechanism for node decommissions

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hadoop_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hadoop_config.rb
@@ -44,7 +44,6 @@ hadoop_non_templates =
    log4j.properties
    ssl-client.xml
    ssl-server.xml
-   dfs.exclude
   }
 
 hadoop_non_templates.each do |t|
@@ -69,6 +68,14 @@ template "/etc/hadoop/conf/hadoop-env.sh" do
     :nn_jmx_port => node[:bcpc][:hadoop][:namenode][:jmx][:port],
     :dn_jmx_port => node[:bcpc][:hadoop][:datanode][:jmx][:port]
   )
+end
+
+file "/etc/hadoop/conf/dfs.exclude" do
+  content node["bcpc"]["hadoop"]["decommission"]["hosts"].join("\n")
+  mode 0644
+  owner 'yarn'
+  group 'hdfs'
+  only_if { !node["bcpc"]["hadoop"]["decommission"]["hosts"].nil? }
 end
 
 include_recipe 'bcpc-hadoop::core_site'

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_dfs.exclude.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_dfs.exclude.erb
@@ -1,0 +1,1 @@
+  1 This file is no longer used, dfs.exclude is now populated from default['bcpc']['hadoop']['decommission']['hosts']

--- a/cookbooks/bcpc-hadoop/templates/default/hdp_yarn.exclude.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/hdp_yarn.exclude.erb
@@ -1,0 +1,1 @@
+This file is no longer used, yarn.exclude is now populated from default['bcpc']['hadoop']['decommission']['hosts']


### PR DESCRIPTION
Use bcpc.hadoop.decommission.hosts for both yarn and hdfs decommission.