### PR TITLE
Disable ForkJoin validation in Oozie

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-site.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-site.xml.erb
@@ -11,6 +11,10 @@
         Refer to the oozie-default.xml file for the complete list of
         Oozie configuration properties and their default values.
     -->
+    <property>
+      <name>oozie.validate.ForkJoin</name>
+      <value>false</value>
+    </property>
 
     <property>
       <name>oozie.service.ActionService.executor.ext.classes</name>


### PR DESCRIPTION
Set as a workaround until the next HDP 2.6 maintenance release.