### PR TITLE
Enable wide viewing of YARN logs

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/yarn.rb
+++ b/cookbooks/bcpc-hadoop/attributes/yarn.rb
@@ -131,6 +131,7 @@ default['bcpc']['hadoop']['yarn']['site_xml'].tap do |site_xml|
 
   site_xml['yarn.scheduler.maximum-allocation-mb'] = yarn_max_memory.call
   site_xml['yarn.acl.enable'] = 'true'
+  site_xml['mapred.job.acl-view-job'] = '*'
 
   site_xml['yarn.timeline-service.client.max-retries'] = 0
   site_xml['yarn.nodemanager.disk-health-checker.min-free-space-per-disk-mb'] = node['bcpc']['hadoop']['yarn']['min-free-space-per-disk-mb']


### PR DESCRIPTION
Reference: https://hadoop.apache.org/docs/r2.7.2/hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xml

To be cherry-picked in the release-3.0 branch