### PR TITLE
Suppress Hashie warnings once and for all

### DIFF
--- a/lib/cluster_data.rb
+++ b/lib/cluster_data.rb
@@ -6,12 +6,18 @@
 # will attempt to contact the chef server.  These should probably be
 # separated from each other.
 #
+
+# Suppress Hashie warnings by loading it early.
+require 'hashie/logger'
+Hashie.logger.level = Logger.const_get 'ERROR'
+
 require 'chef'
 require 'chef-vault'
 require 'json'
 require 'ohai'
 require 'pry'
 require 'ridley'
+
 Ridley::Logging.logger.level = Logger.const_get 'ERROR'
 
 module BACH


### PR DESCRIPTION
Hashie, a transitive dependency buried inside Chef, added a feature that warns the user each and every time a stdlib method might be overridden by a generated accessor method.  This fills our C-A-R logs with useless/trivial garbage:

```
W, [2017-09-07T20:16:20.484655 #18995]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#size defined in Hash. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.
W, [2017-09-07T20:16:20.486006 #18995]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#size defined in Hash. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.
W, [2017-09-07T20:16:20.487087 #18995]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#size defined in Hash. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.
W, [2017-09-07T20:16:20.488035 #18995]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#size defined in Hash. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.
W, [2017-09-07T20:16:20.489211 #18995]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#size defined in Hash. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.
```

This PR loads Hashie early, then suppresses the warnings.