### PR TITLE
Support rolling upgrade and determine installed HDP version

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/mapred.rb
+++ b/cookbooks/bcpc-hadoop/attributes/mapred.rb
@@ -10,15 +10,17 @@ default["bcpc"]["hadoop"]["yarn"]["app"]["mapreduce"]["am"]["staging-dir"] = "/u
 default[:bcpc][:hadoop][:mapreduce][:site_xml].tap do |site_xml|
   site_xml['mapreduce.admin.map.child.java.opts'] =
     '-server -Djava.net.preferIPv4Stack=true -Dhdp.version=' +
-    node[:bcpc][:hadoop][:distribution][:release].to_s
+    '${hdp.version}'
+
+  site_xml['mapreduce.admin.reduce.child.java.opts'] =
+    '-server -Djava.net.preferIPv4Stack=true -Dhdp.version=' +
+    '${hdp.version}'
 
   hdp_path =
-    File.join('/usr/hdp',
-              node[:bcpc][:hadoop][:distribution][:active_release])
+    File.join('/usr/hdp', '${hdp.version}')
 
   hdp_apps_path =
-    File.join('/hdp/apps',
-              node[:bcpc][:hadoop][:distribution][:active_release])
+    File.join('/hdp/apps', '${hdp.version}')
   
   site_xml['mapreduce.admin.user.env'] =
     'LD_LIBRARY_PATH=' +
@@ -41,7 +43,7 @@ default[:bcpc][:hadoop][:mapreduce][:site_xml].tap do |site_xml|
      '$PWD/mr-framework/hadoop/share/hadoop/hdfs/*',
      '$PWD/mr-framework/hadoop/share/hadoop/hdfs/lib/*',
      "#{hdp_path}/hadoop/lib/hadoop-lzo-0.6.0." +
-       "#{node[:bcpc][:hadoop][:distribution][:active_release]}.jar",
+       "${hdp.version}",
      "#{hdp_path}/phoenix/phoenix-server.jar",
      '$HADOOP_CONF_DIR',
     ].join(',')
@@ -50,6 +52,9 @@ default[:bcpc][:hadoop][:mapreduce][:site_xml].tap do |site_xml|
     File.join(hdp_apps_path, 'mapreduce', 'mapreduce.tar.gz#mr-framework')
 
   site_xml['mapreduce.map.output.compress'] = true
+
+  site_xml['yarn.app.mapreduce.am.admin-command-opts'] = 
+    '-Dhdp.version=${hdp.version}'
 
   site_xml['mapred.map.output.compress.codec'] =
     "org.apache.hadoop.io.compress.SnappyCodec"

--- a/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-env.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/ooz_oozie-env.sh.erb
@@ -17,13 +17,13 @@ export OOZIE_PID_DIR=/var/run/oozie
 export OOZIE_CATALINA_HOME=/usr/lib/bigtop-tomcat
 export CATALINA_TMPDIR=/tmp
 export CATALINA_PID=/var/run/oozie/oozie.pid
-export CATALINA_BASE=/usr/hdp/<%= node[:bcpc][:hadoop][:distribution][:active_release] %>/oozie/oozie-server/
+export CATALINA_BASE=/usr/hdp/current/oozie-server/
 export CATALINA_OPTS="<%= node["bcpc"]["hadoop"]["oozie"]["memory_opts"] %>"
 export OOZIE_HTTPS_PORT="11443"
 export OOZIE_HTTPS_KEYSTORE_PASS="<%=get_config("oozie-keystore-password") %>"
 export CATALINA_OPTS="$CATALINA_OPTS -Doozie.https.port=${OOZIE_HTTPS_PORT}"
 export CATALINA_OPTS="$CATALINA_OPTS -Doozie.https.keystore.pass=${OOZIE_HTTPS_KEYSTORE_PASS}"
 export JAVA_HOME=<%= node["bcpc"]["hadoop"]["java"] %>
-export JAVA_LIBRARY_PATH=/usr/hdp/<%= node[:bcpc][:hadoop][:distribution][:active_release] %>/hadoop/lib/native:/usr/hdp/<%= node[:bcpc][:hadoop][:distribution][:active_release] %>/hadoop/lib/native/Linux-amd64-64
+export JAVA_LIBRARY_PATH=/usr/hdp/current/hadoop-client/lib/native/Linux-amd64-64
 export OOZIE_HTTP_HOSTNAME=<%= float_host(node[:fqdn]) %>
 export OOZIE_BASE_URL=http://<%= float_host(node[:bcpc][:management][:viphost]) %>:11000/oozie


### PR DESCRIPTION
This PR replaces use of hard coded `HDP` release number with a special variable `${hdp.version}` that is parsed by `Hadoop/Mapreduce` framework to determine installed `HDP` version on the node. This is required to support rolling upgrade of the cluster. 