### PR TITLE
Revert the mysql jar install target

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/mysql_connector.rb
+++ b/cookbooks/bcpc-hadoop/recipes/mysql_connector.rb
@@ -40,7 +40,7 @@ end
 maven 'mysql-connector-java' do
   group_id 'mysql'
   version  '5.1.43'
-  dest '/usr/share/java/mysql-connector-java.jar'
+  dest '/usr/share/java'
   action :put
   timeout 1800
 end


### PR DESCRIPTION
Prior to #960, the mysql-connector.jar is being installed in
/usr/share/java/mysql-connector.jar instead of
/usr/share/java/mysql-connector.jar/mysql-connector.jar. This new
location causes Oozie and Hive to no find the jar.

Fixes #970 and #971