### PR TITLE
no need to set special ownership for dfs.exclude, just make it readable

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hadoop_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hadoop_config.rb
@@ -74,8 +74,6 @@ end
 file "/etc/hadoop/conf/dfs.exclude" do
   content node["bcpc"]["hadoop"]["decommission"]["hosts"].join("\n")
   mode 0644
-  owner 'yarn'
-  group 'hdfs'
   only_if { !node["bcpc"]["hadoop"]["decommission"]["hosts"].nil? }
 end
 


### PR DESCRIPTION
Fixes issues #966 