### PR TITLE
Fix wait_for_hosts.rb by initializing Hashie

### DIFF
--- a/lib/cluster_data.rb
+++ b/lib/cluster_data.rb
@@ -8,6 +8,7 @@
 #
 
 # Suppress Hashie warnings by loading it early.
+require 'hashie'
 require 'hashie/logger'
 Hashie.logger.level = Logger.const_get 'ERROR'
 


### PR DESCRIPTION
Depending on the order Chef libraries are loaded, Hashie may or may not be initialised when we attempt to disable warning messages in its logger.

You will know you have been hit by this issue when you get an uninitialised constant exception:
```
bundler: failed to load command: ./wait_for_hosts.rb (./wait_for_hosts.rb)
NameError: uninitialized constant Hashie::Logger
  /home/vagrant/chef-bcpc/vendor/bundle/ruby/2.3.0/gems/hashie-3.5.1/lib/hashie/logger.rb:6:in `logger'
  /home/vagrant/chef-bcpc/lib/cluster_data.rb:12:in `<top (required)>'
  /home/vagrant/chef-bcpc/wait_for_hosts.rb:9:in `require_relative'
  /home/vagrant/chef-bcpc/wait_for_hosts.rb:9:in `<top (required)>'
Connection to 127.0.0.1 closed.
```

This PR fully initialises Hashie before loading the Hashie logger.