### PR TITLE
add global vip to no_proxy environment

### DIFF
--- a/cookbooks/bcpc/attributes/chef_client.rb
+++ b/cookbooks/bcpc/attributes/chef_client.rb
@@ -37,7 +37,7 @@ default['chef_client']['config'].tap do |config|
                       node[:hostname],
                       node[:fqdn],
                       node[:bcpc][:bootstrap][:server],
-                      node[:bcpc][:bootstrap][:server],
+                      node[:bcpc][:management][:vip],
                       node[:domain] ? "*#{node[:domain]}" : nil
                      ].compact.uniq
 


### PR DESCRIPTION
Useful for http clients invoked in chef run that are able to use no_proxy