### PR TITLE
invoke zabbix client with no_proxy

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
+++ b/cookbooks/bcpc-hadoop/recipes/graphite_to_zabbix.rb
@@ -54,7 +54,8 @@ ruby_block "zabbix_monitor" do
       :url => "https://#{node['bcpc']['management']['vip']}" +
         ":#{node['bcpc']['zabbix']['web_port']}/api_jsonrpc.php",
       :user => get_config!('zabbix-admin-user'),
-      :password => "#{get_config!('password','zabbix-admin','os')}"
+      :password => "#{get_config!('password','zabbix-admin','os')}",
+      :no_proxy => true
     )
     if zbx.nil?
       Chef::Log.error("Could not connect to Zabbix server")


### PR DESCRIPTION
This will work some day 
https://github.com/express42/zabbixapi/issues/79

The work around is to set ENV['http_proxy'] to nil and then set it back
````ruby
ENV['http_proxy'] = nil
ENV['HTTP_PROXY'] = nil
zbx = ZabbixApi.connect(
  :url => "https://#{node['bcpc']['management']['vip']}" +
    ":#{node['bcpc']['zabbix']['web_port']}/api_jsonrpc.php",
   :user => get_config!('zabbix-admin-user'),
   :password => "#{get_config!('password','zabbix-admin','os')}",
   :no_proxy => true
 )
````
But I am loathe to add this to our code base, until I see some traction the above mentioned issue 