### PR TITLE
Add in all dependencies in vm-to-cluster.sh

### DIFF
--- a/vm-to-cluster.sh
+++ b/vm-to-cluster.sh
@@ -13,7 +13,7 @@ cd $REPO_DIR
 
 if [ $(dpkg-query -W -f='${Status}' libaugeas-dev 2>/dev/null | grep -c 'ok installed') -ne 1 ] && [ "$(uname)" != "Darwin" ]; then
   echo "#### Need libaugeas-dev for the Augeas Gem" > /dev/stderr
-  sudo apt-get install -y libaugeas-dev
+  sudo apt-get install -y libaugeas-dev libmysqlclient-dev libmysqlclient20 libmysqld-dev
 fi
 
 if [ $(dpkg-query -W -f='${Status}' libkrb5-dev 2>/dev/null | grep -c 'ok installed') -ne 1 ] && [ "$(uname)" != "Darwin" ]; then
@@ -24,5 +24,5 @@ fi
 export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig
 bundle config --local PATH vendor/bundle
 bundle config --local DISABLE_SHARED_GEMS true
-bundle package --path vendor/bundle > /dev/null
+bundle package --path vendor/bundle
 bundle exec --keep-file-descriptors ./vm_to_cluster.rb $*


### PR DESCRIPTION
This installs more Gem dependency packages at the moment. Ideally we can keep from having to install all gems on the hypervisors but this is a stop-gap to build on a fresh machine.

With out this, one will often see the hypervisor gem install fail which looks like:
```+ ./vm-to-cluster.sh
Using a proxy at http://proxy.bloomberg.com:81
Force Ruby ecosystem to use system SSL certificates
Could not find gem 'fpm' in any of the gem sources listed in your Gemfile or available on this machine.
Run `bundle install` to install missing gems.
+ echo '############## VBOX CREATE CLUSTER VMs RETURNED 7 ##############'
############## VBOX CREATE CLUSTER VMs RETURNED 7 ##############
+ exit 1
cbaenzig@clay-desktop:```

Now one also gets the output of the `bundle package` output too.