### PR TITLE
Correct gem installs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,17 @@
 # -*- mode: enh-ruby -*-
 ruby RUBY_VERSION
-# These versions are pinned to match ChefDK
-if File.exist?('/opt/chefdk/Gemfile')
+# These versions are pinned to match Chef --
+# to avoid having different Ruby versions try Chef before ChefDK
+if File.exist?('/opt/chef/Gemfile')
+  # overload the path so we do not re-cache these gems
+    opscode_gem_data = IO.read("/opt/chef/Gemfile")
+    instance_eval(opscode_gem_data, "/opt/chef/Gemfile")
+elsif File.exist?('/opt/chefdk/Gemfile')
   # overload the path so we do not re-cache these gems
     opscode_gem_data = IO.read("/opt/chefdk/Gemfile")
     # strip off a Gem from a Git repo as it seems to confuse things
     opscode_gem_data.gsub!(/^gem.*opscode-pushy-client.*\n/,'')
     instance_eval(opscode_gem_data, "/opt/chefdk/Gemfile")
-elsif File.exist?('/opt/chef/Gemfile')
-  # overload the path so we do not re-cache these gems
-    opscode_gem_data = IO.read("/opt/chef/Gemfile")
-    instance_eval(opscode_gem_data, "/opt/chef/Gemfile")
 else
   source 'https://rubygems.org' do
     gem 'parallel'

--- a/vm-to-cluster.sh
+++ b/vm-to-cluster.sh
@@ -11,15 +11,13 @@ REPO_DIR="`dirname ${BASH_SOURCE[0]}`"
 cd $REPO_DIR
 . ./proxy_setup.sh
 
-if [ $(dpkg-query -W -f='${Status}' libaugeas-dev 2>/dev/null | grep -c 'ok installed') -ne 1 ] && [ "$(uname)" != "Darwin" ]; then
-  echo "#### Need libaugeas-dev for the Augeas Gem" > /dev/stderr
-  sudo apt-get install -y libaugeas-dev libmysqlclient-dev libmysqlclient20 libmysqld-dev
-fi
-
-if [ $(dpkg-query -W -f='${Status}' libkrb5-dev 2>/dev/null | grep -c 'ok installed') -ne 1 ] && [ "$(uname)" != "Darwin" ]; then
-  echo "#### Need libkrb5-dev for the rkerberos Gem" > /dev/stderr
-  sudo apt-get install -y libkrb5-dev
-fi
+# Iterate over a list of "<dpkg name> <gem name>" necessary for the Gemfile
+for p in "libaugeas-dev ruby-augeas" "libmysqlclient-dev mysql2" "libmysqlclient20 mysql2" "libmysqld-dev mysql2" "libkrb5-dev rkerberos"; do 
+  if [ $(dpkg-query -W -f='${Status}' ${p% *} 2>/dev/null | grep -c 'ok installed') -ne 1 ] && [ "$(uname)" != "Darwin" ]; then
+    echo "#### Need ${p% *} for the ${p#* } Gem" > /dev/stderr
+    sudo apt-get install -y ${p% *}
+  fi
+done
 
 export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig
 bundle config --local PATH vendor/bundle


### PR DESCRIPTION
This is a further correction to #986 ; it also ensures we pin against `/opt/chef`'s Gemfile if available before `/opt/chefdk`'s. This further ensures we do validate that all packages are installed properly and lists which gem they are needed for. (Still, our Gemfile should not pull in cluster gems for a hypervisor; but that'll get fixed later.)