### PR TITLE
Remove the phoenix jars from the mapred classpath

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/mapred.rb
+++ b/cookbooks/bcpc-hadoop/attributes/mapred.rb
@@ -42,7 +42,6 @@ default[:bcpc][:hadoop][:mapreduce][:site_xml].tap do |site_xml|
      '$PWD/mr-framework/hadoop/share/hadoop/hdfs/lib/*',
      "#{hdp_path}/hadoop/lib/hadoop-lzo-0.6.0." +
        "#{node[:bcpc][:hadoop][:distribution][:active_release]}.jar",
-     "#{hdp_path}/phoenix/phoenix-server.jar",
      '$HADOOP_CONF_DIR',
     ].join(',')
 


### PR DESCRIPTION
Phoenix jars and hive-cli in the Oozie sharedlibs have conflicting
versions of the libfb thrift jars (in HDP 2.6.1).  Removing this allows Hive actions in
Oozie to work.

To be ported in 3.0