### PR TITLE
Open up Jolokia HTTP requests globally, but read-only

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/jolokia.rb
+++ b/cookbooks/bcpc-hadoop/attributes/jolokia.rb
@@ -28,11 +28,6 @@
 node.default['bcpc']['jolokia'].tap do |jolokia|
   jolokia['policy_path'] = '/etc/bach/jolokia_security_policy.xml'
   jolokia['jar_path'] = '/usr/local/jolokia/lib/jolokia-jvm.jar'
-  jolokia['whitelist'] = [
-                          '127.0.0.1',
-                          node[:bcpc][:bootstrap][:ip],
-                          node[:bcpc][:management][:ip]
-                         ]
   jolokia['host'] = '0.0.0.0'
   jolokia['port'] = 7777
   jolokia['jvm_args'] =

--- a/cookbooks/bcpc-hadoop/recipes/jolokia.rb
+++ b/cookbooks/bcpc-hadoop/recipes/jolokia.rb
@@ -56,5 +56,4 @@ template node['bcpc']['jolokia']['policy_path'] do
   mode 0444
   user 'root'
   group 'root'
-  variables({ whitelist: node['bcpc']['jolokia']['whitelist'] })
 end

--- a/cookbooks/bcpc-hadoop/templates/default/jolokia_security_policy.xml.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/jolokia_security_policy.xml.erb
@@ -1,8 +1,11 @@
 <!-- This file was created by Chef.  Local changes may be reverted. -->
+
+<!-- Do away with a whitelist, and allow global read-only access. -->
 <restrict>
-  <remote>
-  <% @whitelist.each do |source| %>
-    <%= "<host>#{source}</host>" %>
-  <% end %> 
-  </remote>
+  <commands>
+    <command>list</command>
+    <command>read</command>
+    <command>search</command>
+    <command>version</command>
+  </commands>
 </restrict>


### PR DESCRIPTION
Previously, we whitelisted source IPs for Jolokia requests.   Managing the lists has been something of a pain.

This PR updates the Jolokia security policy to accept all read requests from all source IPs.  