### PR TITLE
Use only chefdk on bootstrap

### DIFF
--- a/build_bins.sh
+++ b/build_bins.sh
@@ -17,11 +17,6 @@ fi
 # Clean up any left-behind chef config from prior runs.
 rm -f /tmp/build_bins_chef_config.?????????.rb
 
-#
-# It's important to install the chefdk before chef, so that
-# /usr/bin/knife and /usr/bin/chef-client are symlinks into /opt/chef
-# instead of /opt/chefdk.
-#
 DIR=`dirname $0`
 mkdir -p $DIR/bins
 pushd $DIR/bins/ > /dev/null

--- a/setup_chef_bootstrap_node.sh
+++ b/setup_chef_bootstrap_node.sh
@@ -16,7 +16,7 @@ CHEF_SERVER=$1
 CHEF_ENVIRONMENT=$2
 
 # Assume we are running in the chef-bcpc directory
-sudo chef-client -E "$CHEF_ENVIRONMENT" -c .chef/knife.rb
+sudo /opt/chefdk/bin/chef-client -E "$CHEF_ENVIRONMENT" -c .chef/knife.rb
 PEM_RELATIVE_PATH=.chef/$(hostname -f).pem
 sudo chown $(whoami):root $PEM_RELATIVE_PATH
 sudo chmod 550 $PEM_RELATIVE_PATH
@@ -34,15 +34,15 @@ fi
 # still need to configure Apache and chef-vault before doing a
 # complete Chef run.
 #
-sudo -E chef-client \
+sudo -E /opt/chefdk/bin/chef-client \
      -c .chef/knife.rb \
      -o 'recipe[bcpc::apache-mirror]'
 
-sudo -E chef-client \
+sudo -E /opt/chefdk/bin/chef-client \
      -c .chef/knife.rb \
      -o 'recipe[bcpc::chef_vault_install]'
 
-sudo chef-client \
+sudo /opt/chefdk/bin/chef-client \
      -c .chef/knife.rb \
      -o 'recipe[bcpc::chef_poise_install]'
 
@@ -52,7 +52,7 @@ sudo chef-client \
 # BCPC-Bootstrap so that we have os in the chef vault to allow bootstrap-gpg
 # to be properly put inside the configs/Test-Laptop data bag as we aren't even installing the chef vault until after the first apt run
 #
-sudo -E chef-client \
+sudo -E /opt/chefdk/bin/chef-client \
      -c .chef/knife.rb \
      -o 'recipe[bach_repository::apt]'
 
@@ -62,7 +62,7 @@ sudo -E chef-client \
 # With chef-vault installed and the repo configured, it's safe to save
 # and converge the complete runlist.
 #
-sudo -E chef-client \
+sudo -E /opt/chefdk/bin/chef-client \
      -c .chef/knife.rb \
      -r 'role[BCPC-Bootstrap]'
 
@@ -71,6 +71,6 @@ sudo -E chef-client \
 # bug in the bach_repository::apt recipe.  The bootstrap fails to save
 # its GPG public/private keys even after it should be able to do so.
 #
-sudo -E chef-client \
+sudo -E /opt/chefdk/bin/chef-client \
      -c .chef/knife.rb \
      -o 'recipe[bach_repository::apt]'

--- a/setup_chef_server.sh
+++ b/setup_chef_server.sh
@@ -30,12 +30,9 @@ apt-get -o Dir::Etc::SourceList=/etc/apt/sources.list.d/bcpc.list \
 	-o APT::Get::List-Cleanup="0" \
 	update
 
-apt-get -y install chef=12.19.36-1
-
-if dpkg -s chef-server 2>/dev/null | grep -q ^Status.*installed && \
-   dpkg -s chef 2>/dev/null | grep -q ^Version.*12; then
+if dpkg -s chef-server 2>/dev/null | grep -q ^Status.*installed; then 
   chef-server-ctl restart
-  echo 'chef-server and client are installed and the server has been restarted'
+  echo 'chef-server is installed and the server has been restarted'
 else
   apt-get -y install chef-server
   mkdir -p /etc/chef-server


### PR DESCRIPTION
This resolves recent gem issues and version mismatches we've had during builds.  Also fixes long outstanding issues of gem and ruby runtime mismatches