### PR TITLE
handle cluster.txt rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ Using the script [tests/automated_install.sh](./tests/automated_install.sh) on M
 will require [`brew`](http://brew.sh) to be available/installed.
 
 Note: To run more than one test cluster at a time with VirtualBox, one may
-      set in `tests/automated_install.sh` their desired cluster name prefix.
+      export BACH_CLUSTER_PREFIX to set their desired cluster name prefix.
       This will namespace the cluster's virtual machines to not collide on the
-      hypervisor. One also needs to ensure their management, float and storage
+      hypervisor.  Lacking that tests/automated_install.sh will use a default 
+      One also needs to ensure their management, float and storage
       network ranges are exclusive in the environment and cluster.txt)
       updated to be unique as well. Further, one needs to have each cluster's
       repository in a different parent directory (to avoid the `cluster`

--- a/README.md
+++ b/README.md
@@ -86,8 +86,18 @@ will require [`brew`](http://brew.sh) to be available/installed.
 
 Note: To run more than one test cluster at a time with VirtualBox, one may
       export BACH_CLUSTER_PREFIX to set their desired cluster name prefix.
-      This will namespace the cluster's virtual machines to not collide on the
-      hypervisor.  Lacking that tests/automated_install.sh will use a default 
+      This will set the namespace so that the cluster's virtual machines do not 
+      collide on the hypervisor.  Resulting in names following the convention
+
+````
+      $BACH_CLUSTER_PREFIX-bcpc-bootstrap
+      $BACH_CLUSTER_PREFIX-bcpc-vm1
+      $BACH_CLUSTER_PREFIX-bcpc-vm2
+      $BACH_CLUSTER_PREFIX-bcpc-vm3
+````
+
+      Lacking that tests/automated_install.sh 
+      not assign a cluster prefix to the cluster hosts or bootstrap 
       One also needs to ensure their management, float and storage
       network ranges are exclusive in the environment and cluster.txt)
       updated to be unique as well. Further, one needs to have each cluster's

--- a/cluster.txt
+++ b/cluster.txt
@@ -1,3 +1,1 @@
-foo-bcpc-vm1 08:00:27:31:ED:7D 10.0.101.11 - bcpc_host_precise bcpc.example.com role[BCPC-Hadoop-Head],role[BCPC-Hadoop-Head-Namenode],role[BCPC-Hadoop-Head-HBase],recipe[bcpc-hadoop::copylog]
-foo-bcpc-vm2 08:00:27:66:07:ED 10.0.101.12 - bcpc_host_precise bcpc.example.com role[BCPC-Hadoop-Head],role[BCPC-Hadoop-Head-ResourceManager],role[BCPC-Hadoop-Head-Namenode-Standby],role[BCPC-Hadoop-Head-MapReduce],role[BCPC-Hadoop-Head-Hive],recipe[bcpc-hadoop::copylog],role[BCPC-Hadoop-Head-YarnTimeLineServer]
-foo-bcpc-vm3 08:00:27:BC:FA:15 10.0.101.13 - bcpc_host_precise bcpc.example.com role[BCPC-Hadoop-Worker],recipe[bcpc-hadoop::copylog]
+../cluster/cluster.txt

--- a/stub-environment/environments/Test-Laptop.json
+++ b/stub-environment/environments/Test-Laptop.json
@@ -2,7 +2,6 @@
   "name": "Test-Laptop",
   "override_attributes": {
     "bcpc": {
-      "cluster_name": "foo",
       "management": {
         "vip" : "10.0.101.5"
       },

--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -20,7 +20,7 @@ if [[ "$(pwd)" != "$(git rev-parse --show-toplevel)" ]]; then
 fi
 
 export BACH_ENVIRONMENT='Test-Laptop'
-export BACH_CLUSTER_PREFIX='foo'
+export BACH_CLUSTER_PREFIX={BACH_CLUSTER_PREFIX:-'foo'}
 export BOOTSTRAP_VM_MEM=${BOOTSTRAP_VM_MEM:-5096}
 export BOOTSTRAP_VM_CPUs=${BOOTSTRAP_VM_CPUS:-2}
 export CLUSTER_VM_MEM=${CLUSTER_VM_MEM:-7120}

--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -20,12 +20,19 @@ if [[ "$(pwd)" != "$(git rev-parse --show-toplevel)" ]]; then
 fi
 
 export BACH_ENVIRONMENT='Test-Laptop'
-export BACH_CLUSTER_PREFIX={BACH_CLUSTER_PREFIX:-''}
+export BACH_CLUSTER_PREFIX=${BACH_CLUSTER_PREFIX:-''}
 export BOOTSTRAP_VM_MEM=${BOOTSTRAP_VM_MEM:-5096}
 export BOOTSTRAP_VM_CPUs=${BOOTSTRAP_VM_CPUS:-2}
 export CLUSTER_VM_MEM=${CLUSTER_VM_MEM:-7120}
 export CLUSTER_VM_CPUs=${CLUSTER_VM_CPUs:-4}
 export CLUSTER_TYPE=${CLUSTER_TYPE:-Hadoop}
+
+BOOTSTRAP_NAME="bcpc-bootstrap"
+if [ $BACH_CLUSTER_PREFIX != '' ]; then
+  BOOTSTRAP_NAME="${BACH_CLUSTER_PREFIX}-bcpc-bootstrap"
+fi
+
+export BOOTSTRAP_NAME
 
 # normalize capitaliztion of CLUSTER_TYPE to lower case
 typeset -l CLUSTER_TYPE="${CLUSTER_TYPE}"
@@ -74,7 +81,7 @@ printf "#### Cobbler Boot\n"
 printf "Snapshotting pre-Cobbler and booting (unless already running)\n"
 
 vms_started="False"
-for vm in ${VM_LIST[*]} ${BACH_CLUSTER_PREFIX}bcpc-bootstrap; do
+for vm in ${VM_LIST[*]} ${BOOTSTRAP_NAME}; do
   vboxmanage showvminfo $vm | grep -q '^State:.*running' || vms_started="True"
   if [[ ! $(vboxmanage snapshot $vm list --machinereadable | grep -q 'Shoe-less') ]]; then
     vboxmanage showvminfo $vm | grep -q '^State:.*running' || VBoxManage snapshot $vm take Shoe-less
@@ -109,7 +116,7 @@ fi
 
 vagrant ssh -c "cd chef-bcpc; source proxy_setup.sh; ./wait-for-hosts.sh ${VM_LIST[*]}"
 printf "Snapshotting post-Cobbler\n"
-for vm in ${VM_LIST[*]} ${BACH_CLUSTER_PREFIX}bcpc-bootstrap; do
+for vm in ${VM_LIST[*]} ${BOOTSTRAP_NAME}; do
   [[ $(vboxmanage snapshot $vm list --machinereadable | grep -q 'Post-Cobble') ]] || \
     [[ "$vms_started" == "True" ]] && VBoxManage snapshot $vm take Post-Cobble --live &
 done
@@ -119,7 +126,7 @@ printf "#### Chef the nodes with Basic role\n"
 vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $BACH_ENVIRONMENT Basic"
 
 printf "Snapshotting Post-Basic\n"
-for vm in ${VM_LIST[*]} ${BACH_CLUSTER_PREFIX}bcpc-bootstrap; do
+for vm in ${VM_LIST[*]} ${BOOTSTRAP_NAME}; do
   [[ $(vboxmanage snapshot $vm list --machinereadable | grep -q 'Post-Basic') ]] || \
     VBoxManage snapshot $vm take Basic --live &
 done
@@ -139,7 +146,7 @@ if [ "${CLUSTER_TYPE,,}" == "hadoop" ]; then
   # if we still fail here we have some other issue
   set -e
   vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $BACH_ENVIRONMENT Bootstrap"
-  for vm in ${VM_LIST[*]} ${BACH_CLUSTER_PREFIX}bcpc-bootstrap; do
+  for vm in ${VM_LIST[*]} ${BOOTSTRAP_NAME}; do
     [[ $(vboxmanage snapshot $vm list --machinereadable | grep -q 'Post-Bootstrap') ]] || \
       VBoxManage snapshot $vm take Post-Bootstrap --live &
   done

--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -164,7 +164,7 @@ if [[ "${CLUSTER_TYPE,,}" == "hadoop" ]]; then
 fi
 
 printf "Snapshotting Post-Install\n"
-for vm in ${VM_LIST[*]} ${BACH_CLUSTER_PREFIX}bcpc-bootstrap; do
+for vm in ${VM_LIST[*]} ${BOOTSTRAP_NAME}; do
   [[ $(vboxmanage snapshot $vm list --machinereadable | grep -q 'Post-Install') ]] || \
     VBoxManage snapshot $vm take Post-Install --live &
 done

--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -75,9 +75,6 @@ done
 download_VM_files || ( echo "############## VBOX CREATE DOWNLOAD VM FILES RETURNED $? ##############" && exit 1 )
 create_bootstrap_VM || ( echo "############## VBOX CREATE BOOTSTRAP VM RETURNED $? ##############" && exit 1 )
 
-echo "VM LIST"
-for vm in ${VM_LIST[*]}; do echo "${vm} "; done
-
 python_to_find_bootstrap_ip="import json; j = json.load(file('${environments[0]}')); print j['override_attributes']['bcpc']['bootstrap']['server']"
 BOOTSTRAP_IP=$(python -c "$python_to_find_bootstrap_ip")
 

--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -66,10 +66,17 @@ printf "#### Setup VB's and Bootstrap\n"
 source ./vbox_create.sh
 
 # Ensure we got VM_LIST from vbox_create.sh
-echo "Using CLUSTER_PREFIX=${BACH_CLUSTER_PREFIX} VM_LIST=${VM_LIST}"
+echo "Using CLUSTER_PREFIX=${BACH_CLUSTER_PREFIX}"
+echo "VM LIST"
+for vm in ${VM_LIST[*]}; do
+  echo $vm
+done
 
 download_VM_files || ( echo "############## VBOX CREATE DOWNLOAD VM FILES RETURNED $? ##############" && exit 1 )
 create_bootstrap_VM || ( echo "############## VBOX CREATE BOOTSTRAP VM RETURNED $? ##############" && exit 1 )
+
+echo "VM LIST"
+for vm in ${VM_LIST[*]}; do echo "${vm} "; done
 
 python_to_find_bootstrap_ip="import json; j = json.load(file('${environments[0]}')); print j['override_attributes']['bcpc']['bootstrap']['server']"
 BOOTSTRAP_IP=$(python -c "$python_to_find_bootstrap_ip")

--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -20,7 +20,7 @@ if [[ "$(pwd)" != "$(git rev-parse --show-toplevel)" ]]; then
 fi
 
 export BACH_ENVIRONMENT='Test-Laptop'
-export BACH_CLUSTER_PREFIX={BACH_CLUSTER_PREFIX:-'foo'}
+export BACH_CLUSTER_PREFIX={BACH_CLUSTER_PREFIX:-''}
 export BOOTSTRAP_VM_MEM=${BOOTSTRAP_VM_MEM:-5096}
 export BOOTSTRAP_VM_CPUs=${BOOTSTRAP_VM_CPUS:-2}
 export CLUSTER_VM_MEM=${CLUSTER_VM_MEM:-7120}

--- a/tests/edit_environment.rb
+++ b/tests/edit_environment.rb
@@ -134,8 +134,7 @@ environment_data['override_attributes'].tap do |attrs|
   # if we have a clusetr_name prefix adjust the necessary parameters
   if cluster_name
     attrs['bcpc']['cluster_name'] = cluster_name
-    attrs['bcpc']['bootstrap']['hostname'] = \
-      cluster_name + attrs['bcpc']['bootstrap']['hostname'] unless \
+    attrs['bcpc']['bootstrap']['hostname'] = ENV['BOOTSTRAP_NAME']
       attrs['bcpc']['bootstrap']['hostname'].start_with?(cluster_name)
   end
 

--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -155,7 +155,7 @@ function create_cluster_VMs {
   # Gather VirtualBox networks in use by bootstrap VM
   oifs="$IFS"
   IFS=$'\n'
-  bootstrap_interfaces=($($VBM showvminfo ${BACH_CLUSTER_PREFIX}bcpc-bootstrap \
+  bootstrap_interfaces=($($VBM showvminfo ${BACH_CLUSTER_PREFIX}-bcpc-bootstrap \
     --machinereadable | \
     egrep '^hostonlyadapter[0-9]=' | \
     sort | \

--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -155,6 +155,10 @@ function create_cluster_VMs {
   # Gather VirtualBox networks in use by bootstrap VM
   oifs="$IFS"
   IFS=$'\n'
+  bootstrap_name="bcpc-bootstrap"
+  if [ $BACH_CLUSTER_PREFIX != '']; then
+    bootstrap_name="${BACH_CLUSTER_PREFIX}-bcpc-bootstrap"
+  elif
   bootstrap_interfaces=($($VBM showvminfo ${BACH_CLUSTER_PREFIX}-bcpc-bootstrap \
     --machinereadable | \
     egrep '^hostonlyadapter[0-9]=' | \

--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -155,11 +155,7 @@ function create_cluster_VMs {
   # Gather VirtualBox networks in use by bootstrap VM
   oifs="$IFS"
   IFS=$'\n'
-  bootstrap_name="bcpc-bootstrap"
-  if [ $BACH_CLUSTER_PREFIX != '']; then
-    bootstrap_name="${BACH_CLUSTER_PREFIX}-bcpc-bootstrap"
-  elif
-  bootstrap_interfaces=($($VBM showvminfo ${BACH_CLUSTER_PREFIX}-bcpc-bootstrap \
+  bootstrap_interfaces=($($VBM showvminfo ${BOOTSTRAP_NAME} \
     --machinereadable | \
     egrep '^hostonlyadapter[0-9]=' | \
     sort | \

--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -56,8 +56,22 @@ VBOX_DIR="`dirname ${BASH_SOURCE[0]}`/vbox"
 [[ -d $VBOX_DIR ]] || mkdir $VBOX_DIR
 P=`python -c "import os.path; print os.path.abspath(\"${VBOX_DIR}/\")"`
 
-# Populate the VM list array from cluster.txt
-export VM_LIST=( $(cut -f1 -d' ' ./cluster.txt) )
+# populate the VM_LIST array from cluster.txt
+# HACK: This is called prior to cluster.txt modification
+# we need to "manually" prepend BACH_CLUSTER_PREFIX to
+# all hostnames as we will generate VMs before cluster.txt
+# is edited
+if [ ${BACH_CLUSTER_PREFIX} == '']; then
+  export VM_LIST=( $(cut -f1 -d' ' ./cluster.txt) )
+else
+  vms=( $(cut -f1 -d' ' ./cluster.txt) )
+  VM_LIST=()
+  for old_vm in ${vms[*]}; do
+    VM_LIST+=( "${BACH_CLUSTER_PREFIX}-${old_vm}" )
+  done
+  echo "NEW VM LIST ${VM_LIST}"
+  export VM_LIST
+fi
 
 ######################################################
 # Function to download files necessary for VM stand-up

--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -44,10 +44,6 @@ if (( ${#environments[*]} > 1 )); then
   exit 1
 fi
 
-# Prefix a name to the cluster for running multiple tests per machine
-python_to_find_cluster_name="import json; j = json.load(file('${environments[0]}')); print j['override_attributes']['bcpc'].get('cluster_name','')"
-export CLUSTER_PREFIX=$(python -c "$python_to_find_cluster_name")
-
 if !hash vagrant 2> /dev/null ; then
   echo 'Vagrant not detected - we need Vagrant!' >&2
   exit 1
@@ -59,13 +55,6 @@ CLUSTER_VM_ROOT_DRIVE_SIZE=$((CLUSTER_VM_DRIVE_SIZE + CLUSTER_VM_MEM - 2048))
 VBOX_DIR="`dirname ${BASH_SOURCE[0]}`/vbox"
 [[ -d $VBOX_DIR ]] || mkdir $VBOX_DIR
 P=`python -c "import os.path; print os.path.abspath(\"${VBOX_DIR}/\")"`
-
-# ensure cluster.txt has CLUSTER_PREFIX prepended before VM names
-# NOTE: somewhat crude we see if any line does not start with the
-# cluster name and if so all lines have it prepended
-if [[ -n "$(grep -v "^${CLUSTER_PREFIX}" ./cluster.txt)" ]]; then
-  sed -i "s/^/${CLUSTER_PREFIX}-/" cluster.txt
-fi
 
 # Populate the VM list array from cluster.txt
 export VM_LIST=( $(cut -f1 -d' ' ./cluster.txt) )
@@ -166,7 +155,7 @@ function create_cluster_VMs {
   # Gather VirtualBox networks in use by bootstrap VM
   oifs="$IFS"
   IFS=$'\n'
-  bootstrap_interfaces=($($VBM showvminfo ${CLUSTER_PREFIX}bcpc-bootstrap \
+  bootstrap_interfaces=($($VBM showvminfo ${BACH_CLUSTER_PREFIX}bcpc-bootstrap \
     --machinereadable | \
     egrep '^hostonlyadapter[0-9]=' | \
     sort | \

--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -165,6 +165,7 @@ function create_cluster_VMs {
   # Gather VirtualBox networks in use by bootstrap VM
   oifs="$IFS"
   IFS=$'\n'
+  # BOOTSTRAP_NAME is exported by automated_install.sh
   bootstrap_interfaces=($($VBM showvminfo ${BOOTSTRAP_NAME} \
     --machinereadable | \
     egrep '^hostonlyadapter[0-9]=' | \

--- a/vm_to_cluster.rb
+++ b/vm_to_cluster.rb
@@ -79,8 +79,8 @@ if File.basename(__FILE__) == File.basename($PROGRAM_NAME)
     profile = ! vms.key?(e[:hostname]) ?  e[:cobbler_profile] : \
       virtualbox_bios(e[:hostname]).eql?('EFI') ? \
       EFI_COBBLER_PROFILE : LEGACY_COBBLER_PROFILE
-
-    [e[:hostname], mac, ip, e[:ilo_address], profile, e[:dns_domain], e[:runlist]]
+    host_name = "#{ENV['BACH_CLUSTER_PREFIX']}-e[:hostname]"
+    [host_name, mac, ip, e[:ilo_address], profile, e[:dns_domain], e[:runlist]]
   end
 
   # check to see if we should raise an error

--- a/vm_to_cluster.rb
+++ b/vm_to_cluster.rb
@@ -79,7 +79,13 @@ if File.basename(__FILE__) == File.basename($PROGRAM_NAME)
     profile = ! vms.key?(e[:hostname]) ?  e[:cobbler_profile] : \
       virtualbox_bios(e[:hostname]).eql?('EFI') ? \
       EFI_COBBLER_PROFILE : LEGACY_COBBLER_PROFILE
-    host_name = "#{ENV['BACH_CLUSTER_PREFIX']}-e[:hostname]"
+
+    # make sure to handle no prefix
+    host_name = if ENV['BACH_CLUSTER_PREFIX'] != '' then 
+                  "#{ENV['BACH_CLUSTER_PREFIX']}-#{e[:hostname]}"
+                else
+                  e[:hostname]
+                end
     [host_name, mac, ip, e[:ilo_address], profile, e[:dns_domain], e[:runlist]]
   end
 

--- a/vm_to_cluster.rb
+++ b/vm_to_cluster.rb
@@ -67,6 +67,12 @@ if File.basename(__FILE__) == File.basename($PROGRAM_NAME)
   entries = parse_cluster_txt(cluster_txt)
 
   cluster_lines = entries.map do |e|
+    # HACK: We have not edited cluster.txt yet, but may have 
+    # forced the VMs to have a ${BACH_CLUSTER_PREFIX}-
+    # when we generated VM_LIST in vbox_create.sh
+    if ENV['BACH_CLUSTER_PREFIX'] != '' then
+      e[:hostname] = "#{ENV['BACH_CLUSTER_PREFIX']}-#{e[:hostname]}"
+    end
     # use a bogus MAC for not yet created VMs in case it gets handed to Cobbler
     # otherwise use the MAC as passed in
     mac = vms.key?(e[:hostname]) ? virtualbox_mac(e[:hostname]) : \
@@ -80,13 +86,7 @@ if File.basename(__FILE__) == File.basename($PROGRAM_NAME)
       virtualbox_bios(e[:hostname]).eql?('EFI') ? \
       EFI_COBBLER_PROFILE : LEGACY_COBBLER_PROFILE
 
-    # make sure to handle no prefix
-    host_name = if ENV['BACH_CLUSTER_PREFIX'] != '' then 
-                  "#{ENV['BACH_CLUSTER_PREFIX']}-#{e[:hostname]}"
-                else
-                  e[:hostname]
-                end
-    [host_name, mac, ip, e[:ilo_address], profile, e[:dns_domain], e[:runlist]]
+    [e[:hostname], mac, ip, e[:ilo_address], profile, e[:dns_domain], e[:runlist]]
   end
 
   # check to see if we should raise an error


### PR DESCRIPTION
- cluster.txt is once more a symlink
- removed cluster name from environment
- removed export of CLUSTER_PREFIX from `vbox_create.sh`, will use BACH_CLUSTER_PREFIX already defined in `tests/automated_install.sh`
- removed host renaming in `vbox_create.sh` we assume that hosts in cluster.txt will never have a prefix until processed
- `vm_to_cluster.rb` will rename hosts in `cluster.txt` 
- `tests/automated_install.sh` will now pick up `BACH_CLUSTER_PREFIX` if one was exported or use a built in default
- updated `README.md` to reflect that change
- Fixes up VM_LIST since it is source before cluster.txt is rendered.
- Adjusts e[:hostname] to have a BACH_CLUSTER_PREFIX in vm_to_cluster.rb


Another pleasant side effect as that this method will not change repo artifacts