### PR TITLE
Add attribute to modify HDFS client socket timeout

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hdfs.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hdfs.rb
@@ -103,4 +103,7 @@ default[:bcpc][:hadoop][:hdfs][:site_xml].tap do |site_xml|
   
   site_xml['dfs.namenode.handler.count'] =
     node[:bcpc][:hadoop][:namenode][:handler][:count]
+
+  site_xml['dfs.client.socket-timeout'] =
+    '30000'
 end


### PR DESCRIPTION
Setting the DFS client socket timeout to 30 secs instead of the default 60 sec so that it can fail quickly in case a DN is down.