### PR TITLE
Fix core site error seen

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/core_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/core_site.rb
@@ -77,7 +77,7 @@ end
 
 ruby_block 'node.run_state[:core_site_generated_values]' do
   block do
-    mounts = node.run_state[:bcpc_hadoop_disks][:mounts]
+    mounts = node.run_state['bcpc_hadoop_disks']['mounts']
     directory_values =
       {
        'mapreduce.cluster.local.dir' =>

--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -160,7 +160,7 @@ template "/etc/hadoop/conf/container-executor.cfg" do
   owner "root"
   group "yarn"
   mode "0400"
-  variables lazy{{mounts: node.run_state[:bcpc_hadoop_disks][:mounts]}}
+  variables lazy{{mounts: node.run_state['bcpc_hadoop_disks']['mounts']}}
   action :create
   notifies :run, "bash[verify-container-executor]", :immediate
 end
@@ -209,7 +209,7 @@ end
 ruby_block 'count-mounts' do
   block do
     mount_count =
-      node.run_state[:bcpc_hadoop_disks][:mounts].length rescue 0
+      node.run_state['bcpc_hadoop_disks']['mounts'].length rescue 0
     tolerated_failures =
       node[:bcpc][:hadoop][:hdfs][:failed_volumes_tolerated]
     if mount_count <= tolerated_failures
@@ -234,7 +234,7 @@ end
 # Build nodes for HDFS storage
 ruby_block 'create-hdfs-directories' do
   block do
-    node.run_state[:bcpc_hadoop_disks][:mounts].each do |i|
+    node.run_state['bcpc_hadoop_disks']['mounts'].each do |i|
       Chef::Resource::Directory.new("/disk/#{i}/dfs",
                                     node.run_context).tap do |dd|
         dd.owner 'hdfs'

--- a/cookbooks/bcpc-hadoop/recipes/disks.rb
+++ b/cookbooks/bcpc-hadoop/recipes/disks.rb
@@ -47,7 +47,7 @@ ruby_block 'enumerate-disks' do
     # node[:bcpc][:hadoop][:disks] is for static attributes that we
     # know in advance.  These are easily overridden in an environment.
     #
-    node.run_state[:bcpc_hadoop_disks] = {}
+    node.run_state['bcpc_hadoop_disks'] = {}
   end
 end
 
@@ -268,9 +268,9 @@ ruby_block 'hadoop-disk-reservations' do
         (0..(available_disks.length - 1)).to_a -
         reservation_requests.each_index.to_a
 
-      node.run_state[:bcpc_hadoop_disks][:mounts] = mount_indexes
+      node.run_state['bcpc_hadoop_disks']['mounts'] = mount_indexes
     else
-      node.run_state[:bcpc_hadoop_disks][:mounts] =
+      node.run_state['bcpc_hadoop_disks']['mounts'] =
         (0..(available_disks.length - 1)).to_a
     end
   end

--- a/cookbooks/bcpc-hadoop/recipes/hdfs_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hdfs_site.rb
@@ -8,7 +8,7 @@ ruby_block "hdfs_site_generated_values_common" do
     node.run_state['hdfs_site_generated_values'] =
     {
      'dfs.namenode.name.dir' =>
-       node.run_state[:bcpc_hadoop_disks][:mounts]
+       node.run_state['bcpc_hadoop_disks']['mounts']
        .map{ |d| "file:///disk/#{d}/dfs/nn" }.join(','),
 
      "dfs.ha.namenodes.#{node.chef_environment}" =>
@@ -17,11 +17,11 @@ ruby_block "hdfs_site_generated_values_common" do
        .map{ |nn| "namenode#{nn[:bcpc][:node_number]}" }.join(','),
 
      'dfs.datanode.data.dir' =>
-       node.run_state[:bcpc_hadoop_disks][:mounts]
+       node.run_state['bcpc_hadoop_disks']['mounts']
        .map{ |d| "file:///disk/#{d}/dfs/dn" }.join(','),
 
      'dfs.journalnode.edits.dir' =>
-       File.join('/disk', node.run_state[:bcpc_hadoop_disks][:mounts][0].to_s, 'dfs', 'jn'),
+       File.join('/disk', node.run_state['bcpc_hadoop_disks']['mounts'][0].to_s, 'dfs', 'jn'),
 
      'dfs.client.local.interfaces' =>
        node['bcpc']['floating']['ip'] + '/32'
@@ -33,7 +33,7 @@ ruby_block "hdfs_site_generated_values_balancer_properties" do
   block do
     # get the speed of the fastest interface and use
     max_concurrent_moves =
-      node.run_state[:bcpc_hadoop_disks][:mounts].length *
+      node.run_state['bcpc_hadoop_disks']['mounts'].length *
       node['hadoop']['hdfs']['balancer']['max_concurrent_moves_multiplier']
 
     default_speed = node['hadoop']['hdfs']['balancer']['bandwidth']
@@ -269,7 +269,7 @@ ruby_block "hdfs_site_generated_values_ha_properties" do
 
          # Why is this added twice?
          'dfs.journalnode.edits.dir' =>
-           File.join('/disk', node.run_state[:bcpc_hadoop_disks][:mounts][0].to_s, 'dfs', 'jn')
+           File.join('/disk', node.run_state['bcpc_hadoop_disks']['mounts'][0].to_s, 'dfs', 'jn')
         }
       node.run_state['hdfs_site_generated_values'].merge!(ha_properties)
     end

--- a/cookbooks/bcpc-hadoop/recipes/journalnode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/journalnode.rb
@@ -50,7 +50,7 @@ end
 
 ruby_block 'setup-jn-data' do
   block do
-    jndisk="/disk/#{node.run_state[:bcpc_hadoop_disks][:mounts][0]}"
+    jndisk="/disk/#{node.run_state['bcpc_hadoop_disks']['mounts'][0]}"
     jnfile="/dfs/jn/#{node.chef_environment}/current/VERSION"
     jncurrent="/dfs/jn/#{node.chef_environment}/current"
     jnfile2chk=jndisk + jnfile

--- a/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_master.rb
@@ -80,7 +80,7 @@ end
 
 ruby_block 'create-nn-directories' do
   block do
-    node.run_state[:bcpc_hadoop_disks][:mounts].each do |disk_number|
+    node.run_state['bcpc_hadoop_disks']['mounts'].each do |disk_number|
       Chef::Resource::Directory.new("/disk/#{disk_number}/dfs/nn",
                                     node.run_context).tap do |dd|
         dd.owner 'hdfs'
@@ -113,8 +113,8 @@ bash "format namenode" do
   code "#{hdfs_cmd} namenode -format -nonInteractive -force"
   user "hdfs"
   action :run
-  creates lazy { "/disk/#{node.run_state[:bcpc_hadoop_disks][:mounts][0]}/dfs/nn/current/VERSION" }
-  not_if { node.run_state[:bcpc_hadoop_disks][:mounts].any? { |d| File.exists?("/disk/#{d}/dfs/nn/current/VERSION") } }
+  creates lazy { "/disk/#{node.run_state['bcpc_hadoop_disks']['mounts'][0]}/dfs/nn/current/VERSION" }
+  not_if { node.run_state['bcpc_hadoop_disks']['mounts'].any? { |d| File.exists?("/disk/#{d}/dfs/nn/current/VERSION") } }
 end
 
 bash "format-zk-hdfs-ha" do
@@ -158,7 +158,7 @@ service "bring hadoop-hdfs-namenode down for shared edits and HA transition" do
   action :stop
   supports :status => true
   notifies :run, "bash[initialize shared edits]", :immediately
-  only_if { node.run_state[:bcpc_hadoop_disks][:mounts].all? { |d| not File.exists?("/disk/#{d}/dfs/jn/#{node.chef_environment}/current/VERSION") } }
+  only_if { node.run_state['bcpc_hadoop_disks']['mounts'].all? { |d| not File.exists?("/disk/#{d}/dfs/jn/#{node.chef_environment}/current/VERSION") } }
 end
 
 bash "initialize shared edits" do
@@ -199,12 +199,12 @@ end
 
 ruby_block "create-format-UUID-File" do
   block do
-    Dir.chdir("/disk/#{node.run_state[:bcpc_hadoop_disks][:mounts][0]}/dfs/") do
+    Dir.chdir("/disk/#{node.run_state['bcpc_hadoop_disks']['mounts'][0]}/dfs/") do
       system("tar czvf #{Chef::Config[:file_cache_path]}/jn_fmt.tgz jn/#{node.chef_environment}/current/VERSION")
     end
   end
   action :run
-  only_if { File.exists?("/disk/#{node.run_state[:bcpc_hadoop_disks][:mounts][0]}/dfs/jn/#{node.chef_environment}/current/VERSION") }
+  only_if { File.exists?("/disk/#{node.run_state['bcpc_hadoop_disks']['mounts'][0]}/dfs/jn/#{node.chef_environment}/current/VERSION") }
 end
 
 ruby_block "upload-format-UUID-File" do

--- a/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_no_HA.rb
@@ -78,7 +78,7 @@ end
 
 ruby_block 'create-nn-directories' do
   block do
-    node.run_state[:bcpc_hadoop_disks][:mounts].each do |disk_number|
+    node.run_state['bcpc_hadoop_disks']['mounts'].each do |disk_number|
       Chef::Resource::Directory.new("/disk/#{disk_number}/dfs/nn",
                                     node.run_context).tap do |dd|
         dd.owner 'hdfs'
@@ -111,8 +111,8 @@ bash "format namenode" do
   code "#{hdfs_cmd} namenode -format -nonInteractive -force"
   user "hdfs"
   action :run
-  creates lazy { "/disk/#{node.run_state[:bcpc_hadoop_disks][:mounts][0]}/dfs/nn/current/VERSION" }
-  not_if { node.run_state[:bcpc_hadoop_disks][:mounts].any? { |d| File.exists?("/disk/#{d}/dfs/nn/current/VERSION") } }
+  creates lazy { "/disk/#{node.run_state['bcpc_hadoop_disks']['mounts'][0]}/dfs/nn/current/VERSION" }
+  not_if { node.run_state['bcpc_hadoop_disks']['mounts'].any? { |d| File.exists?("/disk/#{d}/dfs/nn/current/VERSION") } }
 end
 
 link "/etc/init.d/hadoop-hdfs-namenode" do

--- a/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
+++ b/cookbooks/bcpc-hadoop/recipes/namenode_standby.rb
@@ -74,7 +74,7 @@ end
 
 ruby_block 'create-namenode-directories' do
   block do
-    node.run_state[:bcpc_hadoop_disks][:mounts].each do |d|
+    node.run_state['bcpc_hadoop_disks']['mounts'].each do |d|
       Chef::Resource::Directory.new("/disk/#{d}/dfs/nn",
                                     node.run_context).tap do |dd|
         dd.owner "hdfs"

--- a/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
+++ b/cookbooks/bcpc-hadoop/recipes/resource_manager.rb
@@ -4,7 +4,7 @@ include_recipe 'bcpc-hadoop::hadoop_config'
 
 ruby_block 'create-yarn-directories' do
   block do
-    node.run_state[:bcpc_hadoop_disks][:mounts].each do |disk_number|
+    node.run_state['bcpc_hadoop_disks']['mounts'].each do |disk_number|
       Chef::Resource::Directory.new("/disk/#{disk_number}/yarn/local",
                                     node.run_context).tap do |dd|
         dd.owner 'yarn'

--- a/cookbooks/bcpc-hadoop/recipes/yarn_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/yarn_site.rb
@@ -257,7 +257,7 @@ end
 
 ruby_block 'yarn_site_generated_values' do
   block do
-    mounts = node.run_state[:bcpc_hadoop_disks][:mounts]
+    mounts = node.run_state['bcpc_hadoop_disks']['mounts']
     directory_values =
     {
      'yarn.nodemanager.local-dirs' =>


### PR DESCRIPTION
Change the attribute reference from ":" to "'"    
================================================================================
    Error executing action `run` on resource 'ruby_block[node.run_state[:core_site_generated_values]]'
    ================================================================================

    NoMethodError
    -------------
    undefined method `[]' for nil:NilClass