### PR TITLE
Activate ACLs in the jobhistory server

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/mapred.rb
+++ b/cookbooks/bcpc-hadoop/attributes/mapred.rb
@@ -58,4 +58,7 @@ default[:bcpc][:hadoop][:mapreduce][:site_xml].tap do |site_xml|
 
   site_xml['yarn.app.mapreduce.am.staging-dir'] =
     node["bcpc"]["hadoop"]["yarn"]["app"]["mapreduce"]["am"]["staging-dir"]
+
+  site_xml['mapreduce.job.acl-view-job'] = '*'
+  site_xml['mapreduce.cluster.acls.enabled'] = true
 end

--- a/cookbooks/bcpc-hadoop/attributes/yarn.rb
+++ b/cookbooks/bcpc-hadoop/attributes/yarn.rb
@@ -131,7 +131,6 @@ default['bcpc']['hadoop']['yarn']['site_xml'].tap do |site_xml|
 
   site_xml['yarn.scheduler.maximum-allocation-mb'] = yarn_max_memory.call
   site_xml['yarn.acl.enable'] = 'true'
-  site_xml['mapreduce.job.acl-view-job'] = '*'
 
   site_xml['yarn.timeline-service.client.max-retries'] = 0
   site_xml['yarn.nodemanager.disk-health-checker.min-free-space-per-disk-mb'] = node['bcpc']['hadoop']['yarn']['min-free-space-per-disk-mb']


### PR DESCRIPTION
Since ACLs are activated in YARN, it needs to be activated in the
JobHistoryServer as well so that dr.who (anonymous user) can be
configured to view mapreduce job logs as before.


To be bacported to 3.0