### PR TITLE
make smoke test user an admin of some hbase namespace

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/smoke_test_wrapper.rb
+++ b/cookbooks/bcpc-hadoop/recipes/smoke_test_wrapper.rb
@@ -34,7 +34,7 @@ bash "HBASE namespace for smoke tests #{hbase_ns}" do
   echo "create_namespace '#{hbase_ns}'" | hbase shell
   EOH
   user 'hbase'
-  not_if "hbase shell <<< 'list_namespace' | grep #{hbase_ns}", user: 'hbase'
+  not_if "hbase shell <<< 'list_namespace' | grep '#{hbase_ns}'", user: 'hbase'
 end
 
 # Permissions test user to access HBase and get DTs

--- a/cookbooks/smoke-tests/attributes/default.rb
+++ b/cookbooks/smoke-tests/attributes/default.rb
@@ -3,6 +3,7 @@ default['hadoop_smoke_tests'] = {}
 default['hadoop_smoke_tests']['app_name'] = 'Oozie-Smoke-Test-Coordinator'
 default['hadoop_smoke_tests']['oozie_hosts'] = ['f-bcpc-vm2.bcpc.example.com']
 default['hadoop_smoke_tests']['oozie_user'] = 'ubuntu'
+default['hadoop_smoke_tests']['hbase_ns'] = 'smoketests'
 default['hadoop_smoke_tests']['wf_path'] =
   'hdfs://Test-Laptop/user/ubuntu/oozie-smoke-tests/wf'
 default['hadoop_smoke_tests']['carbon-line-receiver'] = '10.0.100.5'


### PR DESCRIPTION
Currently for the hbase portion of the smoke test a list command is issued, for more complicated work in the future added a configurable namespace to be created