### PR TITLE
Correct Chef-BACH #990

### DIFF
--- a/stub-environment/roles/BCPC-Hadoop-Head-HBase.json
+++ b/stub-environment/roles/BCPC-Hadoop-Head-HBase.json
@@ -3,8 +3,8 @@
   "json_class": "Chef::Role",
   "run_list": [
     "role[Basic]",
-    "recipe[bcpc-hadoop::hbase_repl]",
     "recipe[bcpc-hadoop::hbase_master]",
+    "recipe[bcpc-hadoop::hbase_repl]",
     "recipe[bcpc_jmxtrans]",
     "recipe[bcpc::diamond]"
   ],


### PR DESCRIPTION
This addresses Chef-BACH #990's fix in #994 which then breaks a fresh VM cluster. This was tested on my HDFS-DU branch rebased on master last night.