### PR TITLE
Fixing ./tests/automated_install.sh: line 31: [: !=: unary operator expected

### DIFF
--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -28,7 +28,7 @@ export CLUSTER_VM_CPUs=${CLUSTER_VM_CPUs:-4}
 export CLUSTER_TYPE=${CLUSTER_TYPE:-Hadoop}
 
 BOOTSTRAP_NAME="bcpc-bootstrap"
-if [ $BACH_CLUSTER_PREFIX != '' ]; then
+if [ "$BACH_CLUSTER_PREFIX" != "" ]; then
   BOOTSTRAP_NAME="${BACH_CLUSTER_PREFIX}-bcpc-bootstrap"
 fi
 


### PR DESCRIPTION
Fixing ./tests/automated_install.sh: line 31: [: !=: unary operator expected
Reported in #1019