### PR TITLE
Clear /tmp every week

### DIFF
--- a/cookbooks/bcpc/attributes/cronjobs.rb
+++ b/cookbooks/bcpc/attributes/cronjobs.rb
@@ -1,0 +1,4 @@
+default['bcpc']['cronjobs'].tap do |cron|
+  cron['clear_tmp']['frequency'] = 604_800 # in seconds (at 1 week)
+  cron['clear_tmp']['atime_age'] = 7 # in days
+end

--- a/cookbooks/bcpc/recipes/cronjobs.rb
+++ b/cookbooks/bcpc/recipes/cronjobs.rb
@@ -1,0 +1,32 @@
+# Cookbook Name:: bcpc
+# Recipe:: cronjobs
+#
+# Copyright 2017, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Base cronjobs/ pseudo-cronjobs that should be on all machines in the cluster.
+
+clear_tmp = node['bcpc']['cronjobs']['clear_tmp']
+execute 'clear /tmp' do
+  command '/usr/bin/find /tmp -type f '\
+          "-atime +#{clear_tmp['atime_age']} -delete && "\
+          '/usr/bin/touch /var/lib/clear-temp.run'
+  not_if do
+    update_frequency = clear_tmp['frequency']
+    update_file = '/var/lib/clear-temp.run'
+    ::File.exist?(update_file) &&
+      ::File.mtime(update_file) > Time.now - update_frequency
+  end
+end

--- a/cookbooks/bcpc/recipes/default.rb
+++ b/cookbooks/bcpc/recipes/default.rb
@@ -39,6 +39,7 @@ include_recipe 'bcpc::packages'
 include_recipe 'ubuntu'
 include_recipe 'bcpc::cluster_local_repository'
 include_recipe 'bcpc::jmxtrans_agent'
+include_recipe 'bcpc::cronjobs'
 
 require 'ipaddr'
 


### PR DESCRIPTION
Insert a cronjob recipe in base bcpc::default.

# Operation Notes

On first deploy, the deletion of `/tmp` might take a long time.  Chef failures need to be tracked on first run.

Or run it by hand at first to prevent chef failures from timeouts in the first place.