### PR TITLE
Workaround for the halite no_lazy_load_issue

### DIFF
--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -288,7 +288,9 @@ function install_cluster {
   echo "N.B. This may take approximately 30-45 minutes to complete."
   vagrant ssh -c 'sudo rm -f /var/chef/cache/chef-stacktrace.out'
   ./bootstrap_chef.sh --vagrant-remote $ip $environment
-  if vagrant ssh -c 'test -e /var/chef/cache/chef-stacktrace.out' || \
+  if vagrant ssh -c 'sudo grep -i halite /var/chef/cache/chef-stacktrace.out'; then
+      :
+  elif vagrant ssh -c 'test -e /var/chef/cache/chef-stacktrace.out' || \
       ! vagrant ssh -c 'test -d /etc/chef-server'; then
     echo '========= Failed to Chef!' >&2
     exit 1

--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -288,8 +288,8 @@ function install_cluster {
   echo "N.B. This may take approximately 30-45 minutes to complete."
   vagrant ssh -c 'sudo rm -f /var/chef/cache/chef-stacktrace.out'
   ./bootstrap_chef.sh --vagrant-remote $ip $environment
-  if vagrant ssh -c 'sudo grep -i halite /var/chef/cache/chef-stacktrace.out'; then
-      :
+  if vagrant ssh -c 'sudo grep -i no_lazy_load /var/chef/cache/chef-stacktrace.out'; then
+      vagrant ssh -c 'sudo rm /var/chef/cache/chef-stacktrace.out' 
   elif vagrant ssh -c 'test -e /var/chef/cache/chef-stacktrace.out' || \
       ! vagrant ssh -c 'test -d /etc/chef-server'; then
     echo '========= Failed to Chef!' >&2


### PR DESCRIPTION
Since the the `good` #1010 solution is not working, I am proposing this ugly hack as the ongoing solution.  My rational here is that this halite issue only seems to be hurting us at build time.  And seems to be working otherwise, hence if the stack trace file contains `no_lazy_load` we delete the stack trace and continue. 