### PR TITLE
Specify alternative db for hive metastore

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hive.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hive.rb
@@ -13,6 +13,11 @@ default['bcpc']['hadoop']['hive']['warehouse']['dir'] = \
   ::File.join(node[:bcpc][:hadoop][:hdfs_url], '/user/hive/warehouse')
 default['bcpc']['hadoop']['hive']['scratch']['dir'] = \
   ::File.join(node[:bcpc][:hadoop][:hdfs_url], '/tmp/hive-scratch/')
+# Database overrides
+default['bcpc']['hadoop']['hive']['mysql_hosts'] = []
+default['bcpc']['hadoop']['hive']['mysql_port'] = nil
+default['bcpc']['hadoop']['hive']['mysql_user'] = 'hive'
+default['bcpc']['hadoop']['hive']['mysql_db'] = 'metastore'
 
 # These will become key/value pairs in 'hive_site.xml'
 default[:bcpc][:hadoop][:hive][:site_xml].tap do |site_xml|
@@ -42,7 +47,7 @@ default[:bcpc][:hadoop][:hive][:site_xml].tap do |site_xml|
   site_xml['datanucleus.autoCreateSchema'] = false
   site_xml['datanucleus.fixedDatastore'] = true
   site_xml['javax.jdo.option.ConnectionDriverName'] = 'com.mysql.jdbc.Driver'
-  site_xml['javax.jdo.option.ConnectionUserName'] = 'hive'
+  site_xml['javax.jdo.option.ConnectionUserName'] = node['bcpc']['hadoop']['hive']['mysql_user']
 end
 
 # These will become key/value pairs in 'hive-env.sh'

--- a/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hive_hcatalog.rb
@@ -61,8 +61,8 @@ bash 'create-hive-scratch' do
 end
 
 hive_metastore_database 'hive' do
-  hive_password lazy { get_config 'mysql-hive-password' }
-  root_password lazy { get_config! 'password', 'mysql-root', 'os' }
+  dbadmin_password lazy { get_config! 'password', 'mysql-root', 'os' }
+  metastore_db_password lazy { get_config 'mysql-hive-password' }
   schematool_path '/usr/hdp/current/hive-metastore/bin/schematool'
   action %w(create init upgrade)
   notifies :enable, "service[hive-metastore]", :delayed


### PR DESCRIPTION
This pull requests grants us ability to specify alternative database parameters such as a different server and name for the metastore database