### PR TITLE
ignore unenroll failure during repxe

### DIFF
--- a/repxe_host.rb
+++ b/repxe_host.rb
@@ -496,7 +496,11 @@ if __FILE__ == $PROGRAM_NAME
   unless options[:newmachine]
     delete_node_data(vm_entry)
     rotate_vault_keys
-    cobbler_unenroll(vm_entry)
+    begin
+      cobbler_unenroll(vm_entry)
+    rescue
+      puts "WARNING: Unenroll failed, will continue anyway" 
+    end
   end
 
   # HACK: restart to free up memory.  Chef server 11 has a memory leak.


### PR DESCRIPTION
during repxe if we do not indicate `-n`, repxe_host.rb will attempt to first unenroll the host,  it is possible however that the host may not already be enrolled.  As a result the script crashes and we have to manually enroll just to get it to work.  I propose we ignore this here, and let it fail at enroll phase if there is indeed an issue