### PR TITLE
Restart the chef-client when rotating logs

### DIFF
--- a/cookbooks/bcpc/attributes/chef_client.rb
+++ b/cookbooks/bcpc/attributes/chef_client.rb
@@ -16,6 +16,8 @@ sudo_user = node['bcpc']['bootstrap']['admin']['user']
 #
 # XXX this keeps breaking Chef12 knife default['ohai']['disabled_plugins'] = [ 'passwd' ]
 
+# FIXME No longer needed in chef-client 13.2+
+default['chef_client']['log_rotation']['postrotate'] = '/etc/init.d/chef-client restart >/dev/null || :'
 default['chef_client']['config'].tap do |config|
   config['log_level'] = ':info'
   config['log_location'] = 'STDOUT'


### PR DESCRIPTION
The original call is a reload [1].  This makes the chef-client crash during logrotate because of  chef/chef#4578 . A restart is the prescribed workaround for this in Chef-client 12.19+.  The workaround is no longer needed on chef-client 13.2+.

[1] https://github.com/chef-cookbooks/chef-client/blob/master/attributes/default.rb#L180