### PR TITLE
Generate keytabs for Hannibal

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/kerberos.rb
+++ b/cookbooks/bcpc-hadoop/attributes/kerberos.rb
@@ -118,6 +118,15 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     princhost: '_HOST',
     perms: '0440',
     spnego_keytab: 'spnego.service.keytab'
+  },
+  hannibal: {
+    principal: 'hannibal',
+    keytab: 'hannibal.service.keytab',
+    owner: 'hbase',
+    group: 'hbase',
+    princhost: '_HOST',
+    perms: '0440',
+    spnego_keytab: 'spnego.service.keytab'
   }
 }
 default[:bcpc][:hadoop][:kerberos][:keytab][:dir] = "/etc/security/keytabs"


### PR DESCRIPTION
This PR adds data structure that is required for generating a keytab for `hannibal` service. 