### PR TITLE
Restart the chef-server everyweek

### DIFF
--- a/cookbooks/bcpc/recipes/bootstrap.rb
+++ b/cookbooks/bcpc/recipes/bootstrap.rb
@@ -148,3 +148,10 @@ end
 package 'sshpass'
 
 include_recipe 'bcpc::chef_client'
+
+cron 'restart-chefserver' do
+  command '/usr/bin/chef-server-ctl restart'
+  day '1'
+  hour '10'
+  weekday '1'
+end


### PR DESCRIPTION
Manage the restart over cron because a chef-client restarting its own
chef-server doesn't seem like a good idea.