### PR TITLE
Separate management of client.rb and knife.rb

### DIFF
--- a/cookbooks/bcpc/recipes/chef_client.rb
+++ b/cookbooks/bcpc/recipes/chef_client.rb
@@ -48,13 +48,16 @@ if node[:fqdn] == get_bootstrap
   # Clone client.rb that is managed by the chef-client cookbook so that knife.rb
   # can be managed by chef-client::config as well
   client_rb = resources("template[#{node['chef_client']['conf_dir']}/client.rb]")
+  knife_config = client_rb.variables
+  knife_config[:chef_config] = knife_config[:chef_config].to_hash
+  knife_config[:chef_config].delete('log_location')
   template knife_rb do
     source client_rb.source
     cookbook 'chef-client'
     owner user
     group client_rb.group
     mode client_rb.mode
-    variables client_rb.variables
+    variables knife_config
   end
 end
 

--- a/cookbooks/bcpc/recipes/chef_client.rb
+++ b/cookbooks/bcpc/recipes/chef_client.rb
@@ -68,7 +68,8 @@ if node[:bcpc][:bootstrap][:proxy]
   # bcpc/templates/default/client.rb.erb will render the original
   # upstream template, then append proxy environment variables.
   #
-  chef_templates = ["#{node['chef_client']['conf_dir']}/client.rb", knife_rb]
+  chef_templates = ["#{node['chef_client']['conf_dir']}/client.rb"]
+  chef_templates << knife_rb if node['fqdn'] == get_bootstrap
   chef_templates.each do |chef_template|
     edit_resource!(:template, chef_template) do
       source 'client.rb.erb'

--- a/cookbooks/bcpc/recipes/chef_client.rb
+++ b/cookbooks/bcpc/recipes/chef_client.rb
@@ -45,8 +45,13 @@ include_recipe 'chef-client::config'
 knife_rb = "/home/#{user}/chef-bcpc/.chef/knife.rb"
 
 if node[:fqdn] == get_bootstrap
-  # Clone client.rb that is managed by the chef-client cookbook so that knife.rb
-  # can be managed by chef-client::config as well
+  # Manage knife.rb through chef-client::config (except the log location) as
+  # well.  Allows the following:
+  #   * Remove the need for running `sudo knife ...` in the bootstrap.
+  #   * Upload failures in `knife cookbook upload ...` will be in STDOUT instead
+  #     of being written in /var/log/chef/client.log.
+  #   * Prevent a pet configuration of knife.rb in our physical cluster's
+  #     bootstrap machines.
   client_rb = resources("template[#{node['chef_client']['conf_dir']}/client.rb]")
   knife_config = client_rb.variables
   knife_config[:chef_config] = knife_config[:chef_config].to_hash


### PR DESCRIPTION
Manage knife.rb through chef-client::config (except the log location) as well.  Allows the following:

* Remove the need for running `sudo knife ...` in the bootstrap.
* Upload failures in `knife cookbook upload ...` will be in STDOUT instead of being written in `/var/log/chef/client.log`.