### PR TITLE
Fix embedded Chef server Nginx logrotate config

### DIFF
--- a/cookbooks/bcpc/recipes/rotate_chef_nginx_access_log.rb
+++ b/cookbooks/bcpc/recipes/rotate_chef_nginx_access_log.rb
@@ -10,6 +10,6 @@ logrotate_app 'chef-server-nginx-access-log' do
   path '/var/log/chef-server/nginx/access.log'
   frequency 'daily'
   rotate 5
-  options %w(missingok compress)
-  postrotate '/usr/bin/truncate --size=0 /var/log/chef-server/nginx/access.log'
+  options %w(missingok notifempty compress delaycompress copytruncate)
+  postrotate '/opt/chef-server/embedded/sbin/nginx -s reopen'
 end

--- a/cookbooks/bcpc/recipes/rotate_chef_nginx_access_log.rb
+++ b/cookbooks/bcpc/recipes/rotate_chef_nginx_access_log.rb
@@ -10,6 +10,7 @@ logrotate_app 'chef-server-nginx-access-log' do
   path '/var/log/chef-server/nginx/access.log'
   frequency 'daily'
   rotate 5
+  maxsize '1G'
   options %w(missingok notifempty compress delaycompress copytruncate)
   postrotate '/opt/chef-server/embedded/sbin/nginx -s reopen'
 end

--- a/cookbooks/bcpc/recipes/rotate_chef_nginx_access_log.rb
+++ b/cookbooks/bcpc/recipes/rotate_chef_nginx_access_log.rb
@@ -1,15 +1,15 @@
 #
-# Cookbook Name:: bcpc 
+# Cookbook Name:: bcpc
 # Recipe:: rotate_chef_nginx_access_log
 #
-# Prevent chef-server's nginx access.log from filling up 
-# a partition 
+# Prevent chef-server's nginx access.log from filling up
+# a partition
 #
 
 logrotate_app 'chef-server-nginx-access-log' do
   path '/var/log/chef-server/nginx/access.log'
   frequency 'daily'
   rotate 5
-  options   ['missingok', 'compress']
+  options %w(missingok compress)
   postrotate '/usr/bin/truncate --size=0 /var/log/chef-server/nginx/access.log'
 end


### PR DESCRIPTION
- Add `copytruncate`, `notifempty` and `delaycompress` options to ensure we get the behavior we actually want.
- With `copytruncate` chosen, we can then remove the existing `postrotate` command and replace it with the equivalent of a `SIGUSR1`, known as a `reopen` to the Nginx daemon, which will release any open
log file handles.
- As usual, I've done the rubocop/foodcritic cleanup in a separate commit than the actual changes.