### PR TITLE
Passwd fix

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -144,10 +144,26 @@ def get_config(key, item=node.chef_environment, bag="configs")
   end
 
   #
-  # We should always provide the vault item if possible.
-  # If that fails, fall back to the data bag.
+  # This is the second iteration of get_config.
+  # Items are retrieved from chef-vault.
   #
-  get_vault_item(key, item, bag) || get_data_bag_item(key, item, bag)
+  def get_node_item(key, item, bag)
+    begin
+      node['bcpc']['databag_overrides'][bag][item][key]
+    # we get a NoMethodError if a key returns nil (not defined)
+    rescue NoMethodError
+      nil
+    end
+  end
+
+  #
+  # We should allow test overrides in the environment, otherwise
+  # provide the vault item if possible. If that fails,
+  # fall back to the data bag.
+  #
+  get_node_item(key, item, bag) || \
+    get_vault_item(key, item, bag) || \
+    get_data_bag_item(key, item, bag)
 end
 
 def delete_config(key)

--- a/stub-environment/environments/Test-Laptop.json
+++ b/stub-environment/environments/Test-Laptop.json
@@ -2,6 +2,13 @@
   "name": "Test-Laptop",
   "override_attributes": {
     "bcpc": {
+      "databag_overrides": {
+        "configs": {
+          "Test-Laptop": {
+            "cobbler-root-password": "hadoopy"
+          }
+        }
+      },
       "domain_name": "bcpc.example.com",
       "management": {
         "vip" : "10.0.100.5"


### PR DESCRIPTION
This allows one to override databag entries. Specifically this means one can now use the environment file for testing to set a human reasonable default password -- now `hadoopy`!

Also, this improves snapshot handling as it seemed Shoe-Less wasn't getting taken for the bootstrap VM previously; now a library function in `vbox_create` unifies snapshot handling and a state machine is called out in `automated_install.sh` for the snapshot names.