### PR TITLE
Rearrange the prefixing of graphite and statsd

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/jmxtrans_agent.rb
+++ b/cookbooks/bcpc-hadoop/attributes/jmxtrans_agent.rb
@@ -535,7 +535,7 @@ default['bcpc']['hadoop']['jmxtrans_agent']['basic']['queries'] = [
 
 # HDFS namenode
 default['bcpc']['hadoop']['jmxtrans_agent']['namenode']['xml'] = '/etc/hadoop/conf/jmxtrans_agent_namenode.xml'
-default['bcpc']['hadoop']['jmxtrans_agent']['namenode']['name_prefix'] = "jmx.namenode.#{node.chef_environment}"
+default['bcpc']['hadoop']['jmxtrans_agent']['namenode']['name_prefix'] = 'jmx.namenode'
 default['bcpc']['hadoop']['jmxtrans_agent']['namenode']['queries'] = default['bcpc']['hadoop']['jmxtrans_agent']['basic']['queries'] + [
   {
     'objectName' => 'Hadoop:name=JvmMetrics,service=NameNode',
@@ -687,7 +687,7 @@ default['bcpc']['hadoop']['jmxtrans_agent']['namenode']['queries'] = default['bc
 
 # HDFS datanode
 default['bcpc']['hadoop']['jmxtrans_agent']['datanode']['xml'] = '/etc/hadoop/conf/jmxtrans_agent_datanode.xml'
-default['bcpc']['hadoop']['jmxtrans_agent']['datanode']['name_prefix'] = "jmx.datanode.#{node.chef_environment}"
+default['bcpc']['hadoop']['jmxtrans_agent']['datanode']['name_prefix'] = 'jmx.datanode'
 default['bcpc']['hadoop']['jmxtrans_agent']['datanode']['queries'] = default['bcpc']['hadoop']['jmxtrans_agent']['basic']['queries'] + [
   {
     'objectName' => 'Hadoop:name=JvmMetrics,service=DataNode',
@@ -703,7 +703,7 @@ default['bcpc']['hadoop']['jmxtrans_agent']['datanode']['queries'] = default['bc
 
 # HDFS journalnode
 default['bcpc']['hadoop']['jmxtrans_agent']['journalnode']['xml'] = '/etc/hadoop/conf/jmxtrans_agent_journalnode.xml'
-default['bcpc']['hadoop']['jmxtrans_agent']['journalnode']['name_prefix'] = "jmx.journalnode.#{node.chef_environment}"
+default['bcpc']['hadoop']['jmxtrans_agent']['journalnode']['name_prefix'] = 'jmx.journalnode'
 default['bcpc']['hadoop']['jmxtrans_agent']['journalnode']['queries'] = default['bcpc']['hadoop']['jmxtrans_agent']['basic']['queries'] + [
   {
     'objectName' => 'Hadoop:service=JournalNode,name=RpcDetailedActivityForPort*',
@@ -789,7 +789,7 @@ default['bcpc']['hadoop']['jmxtrans_agent']['journalnode']['queries'] = default[
 
 # HBase master
 default['bcpc']['hadoop']['jmxtrans_agent']['hbase_master']['xml'] = '/etc/hadoop/conf/jmxtrans_agent_hbase_master.xml'
-default['bcpc']['hadoop']['jmxtrans_agent']['hbase_master']['name_prefix'] = "jmx.hbase_master.#{node.chef_environment}"
+default['bcpc']['hadoop']['jmxtrans_agent']['hbase_master']['name_prefix'] = 'jmx.hbase_master'
 default['bcpc']['hadoop']['jmxtrans_agent']['hbase_master']['queries'] = default['bcpc']['hadoop']['jmxtrans_agent']['basic']['queries'] + [
   {
     'objectName' => 'Hadoop:name=JvmMetrics,service=HBase',
@@ -821,7 +821,7 @@ default['bcpc']['hadoop']['jmxtrans_agent']['hbase_master']['queries'] = default
 
 # HBase region server
 default['bcpc']['hadoop']['jmxtrans_agent']['hbase_rs']['xml'] = '/etc/hadoop/conf/jmxtrans_agent_hbase_rs.xml'
-default['bcpc']['hadoop']['jmxtrans_agent']['hbase_rs']['name_prefix'] = "jmx.hbase_rs.#{node.chef_environment}"
+default['bcpc']['hadoop']['jmxtrans_agent']['hbase_rs']['name_prefix'] = 'jmx.hbase_rs'
 default['bcpc']['hadoop']['jmxtrans_agent']['hbase_rs']['queries'] = default['bcpc']['hadoop']['jmxtrans_agent']['basic']['queries'] + [
   {
     'objectName' => 'Hadoop:name=JvmMetrics,service=HBase',
@@ -890,7 +890,7 @@ default['bcpc']['hadoop']['jmxtrans_agent']['hbase_rs']['queries'] = default['bc
 
 # nodemanager
 default['bcpc']['hadoop']['jmxtrans_agent']['nodemanager']['xml'] = '/etc/hadoop/conf/jmxtrans_agent_nodemanager.xml'
-default['bcpc']['hadoop']['jmxtrans_agent']['nodemanager']['name_prefix'] = "jmx.nodemanager.#{node.chef_environment}"
+default['bcpc']['hadoop']['jmxtrans_agent']['nodemanager']['name_prefix'] = 'jmx.nodemanager'
 default['bcpc']['hadoop']['jmxtrans_agent']['nodemanager']['queries'] = default['bcpc']['hadoop']['jmxtrans_agent']['basic']['queries'] + [
   {
     'objectName' => 'Hadoop:service=NodeManager,name=NodeManagerMetrics',
@@ -918,7 +918,7 @@ default['bcpc']['hadoop']['jmxtrans_agent']['nodemanager']['queries'] = default[
 
 # resource manager
 default['bcpc']['hadoop']['jmxtrans_agent']['resourcemanager']['xml'] = '/etc/hadoop/conf/jmxtrans_agent_resourcemanager.xml'
-default['bcpc']['hadoop']['jmxtrans_agent']['resourcemanager']['name_prefix'] = "jmx.resourcemanager.#{node.chef_environment}"
+default['bcpc']['hadoop']['jmxtrans_agent']['resourcemanager']['name_prefix'] = 'jmx.resourcemanager'
 default['bcpc']['hadoop']['jmxtrans_agent']['resourcemanager']['queries'] = default['bcpc']['hadoop']['jmxtrans_agent']['basic']['queries'] + [
   {
     'objectName' => 'Hadoop:service=ResourceManager,name=ClusterMetrics*',
@@ -947,7 +947,7 @@ default['bcpc']['hadoop']['jmxtrans_agent']['resourcemanager']['queries'] = defa
 
 # zookeeper
 default['bcpc']['hadoop']['jmxtrans_agent']['zookeeper']['xml'] = '/etc/hadoop/conf/jmxtrans_agent_zookeeper.xml'
-default['bcpc']['hadoop']['jmxtrans_agent']['zookeeper']['name_prefix'] = "jmx.zookeeper.#{node.chef_environment}"
+default['bcpc']['hadoop']['jmxtrans_agent']['zookeeper']['name_prefix'] = 'jmx.zookeeper'
 default['bcpc']['hadoop']['jmxtrans_agent']['zookeeper']['queries'] = default['bcpc']['hadoop']['jmxtrans_agent']['basic']['queries'] + [
   {
     'objectName' => 'org.apache.ZooKeeperService:name0=ReplicatedServer_id*',
@@ -963,7 +963,7 @@ default['bcpc']['hadoop']['jmxtrans_agent']['zookeeper']['queries'] = default['b
 
 # kafka
 default['bcpc']['hadoop']['jmxtrans_agent']['kafka']['xml'] = '/etc/hadoop/conf/jmxtrans_agent_kafka.xml'
-default['bcpc']['hadoop']['jmxtrans_agent']['kafka']['name_prefix'] = "jmx.kafka.#{node.chef_environment}"
+default['bcpc']['hadoop']['jmxtrans_agent']['kafka']['name_prefix'] = 'jmx.kafka'
 default['bcpc']['hadoop']['jmxtrans_agent']['kafka']['queries'] = default['bcpc']['hadoop']['jmxtrans_agent']['basic']['queries'] + [
   {
     'objectName' => '\\\'kafka.server\\\':type=\\\'BrokerTopicMetrics\\\',name=*',

--- a/cookbooks/bcpc-hadoop/recipes/jmxtrans_agent.rb
+++ b/cookbooks/bcpc-hadoop/recipes/jmxtrans_agent.rb
@@ -1,12 +1,12 @@
 node['bcpc']['hadoop']['jmxtrans_agent'].tap do |agent|
   graphite = agent['graphite'].dup
-  def graphite.with_prefix(component)
-    self.merge('namePrefix' => "#{component['name_prefix']}.#escaped_hostname#.")
+  def graphite.with_prefix(component, cluster)
+    self.merge('namePrefix' => "#{component['name_prefix']}.#{cluster}.#escaped_hostname#.")
   end
 
   statsd = agent['statsd'].dup
   def statsd.with_prefix(component)
-    self.merge('metricName' => "#{component['name_prefix']}.#escaped_hostname#")
+    self.merge('metricName' => "bach.#{component['name_prefix']}")
   end
   
   %w(namenode datanode journalnode hbase_master hbase_rs nodemanager
@@ -17,7 +17,7 @@ node['bcpc']['hadoop']['jmxtrans_agent'].tap do |agent|
       variables(
         collect_interval_in_seconds: agent['collect_interval_in_seconds'],
         output_writers: agent['output_writers'],
-        graphite: graphite.with_prefix(agent[component]),
+        graphite: graphite.with_prefix(agent[component], node.chef_environment),
         statsd: statsd.with_prefix(agent[component]),
         queries: agent[component]['queries']
       )


### PR DESCRIPTION
The Influx+StatsD protocol will actually be used so tagging is
supported.  The prefixes are only needed in graphite.