### PR TITLE
add chef libraries to PATH

### DIFF
--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -26,6 +26,7 @@ export BOOTSTRAP_VM_CPUs=${BOOTSTRAP_VM_CPUS:-2}
 export CLUSTER_VM_MEM=${CLUSTER_VM_MEM:-7120}
 export CLUSTER_VM_CPUs=${CLUSTER_VM_CPUs:-4}
 export CLUSTER_TYPE=${CLUSTER_TYPE:-Hadoop}
+export PATH=/opt/chefdk/embedded/bin:$PATH
 
 BOOTSTRAP_NAME="bcpc-bootstrap"
 if [ "$BACH_CLUSTER_PREFIX" != "" ]; then


### PR DESCRIPTION
ran into 
```ubuntu@dnj2-bach-r3n16:~/chef-bcpc$ tests/automated_install.sh 
#### Setup configuration files
/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- mixlib/shellout (LoadError)
        from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from ./tests/edit_environment.rb:23:in `<main>'
```