### PR TITLE
Calling knife without sudo results in permission errors

### DIFF
--- a/setup_chef_bootstrap_node.sh
+++ b/setup_chef_bootstrap_node.sh
@@ -25,7 +25,7 @@ sudo chmod 550 $PEM_RELATIVE_PATH
 [ ! -L ~/.chef ] && \
   sudo ln -s $(readlink -f .chef) ~/.chef
 
-admin_val=`knife client show $(hostname -f) -c .chef/knife.rb | grep ^admin: | sed "s/admin:[^a-z]*//"`
+admin_val=`sudo knife client show $(hostname -f) -c .chef/knife.rb | grep ^admin: | sed "s/admin:[^a-z]*//"`
 if [[ "$admin_val" != "true" ]]; then
   # Make this client an admin user before proceeding.
   echo -e "/\"admin\": false\ns/false/true\nw\nq\n" | EDITOR=ed sudo -E knife client edit `hostname -f` -c .chef/knife.rb -k /etc/chef-server/admin.pem -u admin


### PR DESCRIPTION
````
vagrant@bcpc-bootstrap:~/chef-bcpc$ knife client show $(hostname -f) -c .chef/knife.rb
/opt/chefdk/embedded/lib/ruby/2.3.0/open-uri.rb:37:in `initialize': Permission denied @ rb_sysopen - /var/log/chef/client.log (Errno::EACCES)
        from /opt/chefdk/embedded/lib/ruby/2.3.0/open-uri.rb:37:in `open'
        from /opt/chefdk/embedded/lib/ruby/2.3.0/open-uri.rb:37:in `open'
        from /opt/chefdk/embedded/lib/ruby/2.3.0/logger.rb:703:in `open_logfile'
        from /opt/chefdk/embedded/lib/ruby/2.3.0/logger.rb:695:in `set_dev'
        from /opt/chefdk/embedded/lib/ruby/2.3.0/logger.rb:635:in `initialize'
        from /opt/chefdk/embedded/lib/ruby/2.3.0/logger.rb:353:in `new'
        from /opt/chefdk/embedded/lib/ruby/2.3.0/logger.rb:353:in `initialize'
        from /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/mixlib-log-1.7.1/lib/mixlib/log.rb:163:in `new'
        from /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/mixlib-log-1.7.1/lib/mixlib/log.rb:163:in `logger_for'
        from /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/mixlib-log-1.7.1/lib/mixlib/log.rb:81:in `init'
        from /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-12.18.31/lib/chef/knife.rb:401:in `apply_computed_config'
        from /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-12.18.31/lib/chef/knife.rb:416:in `configure_chef'
        from /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-12.18.31/lib/chef/knife.rb:218:in `run'
        from /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-12.18.31/lib/chef/application/knife.rb:156:in `run'
        from /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-12.18.31/bin/knife:25:in `<top (required)>'
        from /usr/bin/knife:57:in `load'
        from /usr/bin/knife:57:in `<main>'
````