### PR TITLE
Travis Style Check Support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 AllCops:
-  TargetRubyVersion: 1.9
-
+  TargetRubyVersion: 2.3
+  DisplayCopNames: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: ruby
+sudo: false
+rvm:
+  - 2.0
+  - 2
+bundler_args: --without cookbooks
+cache: bundler
+gemfile: Gemfile
+before_install:
+  - chef --version &> /dev/null || curl -L https://www.getchef.com/chef/install.sh | sudo bash -s -- -P chefdk -v 1.2.22
+  - eval "$(/opt/chefdk/bin/chef shell-init bash)"
+  - bundle config --local PATH vendor/bundle
+  - bundle config --local DISABLE_SHARED_GEMS true
+before_script:
+  - chef --version
+  - cookstyle --version
+  - foodcritic --version
+script: rake style:diff

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,9 @@ source 'https://rubygems.org' do
 end
 
 # Pull in the other Gemfiles from our cookbooks
-Dir.glob(File.join(File.dirname(__FILE__), 'cookbooks',
-    '**', "Gemfile")) do |gemfile|
-  eval(IO.read(gemfile), binding)
+group :cookbooks do
+  Dir.glob(File.join(File.dirname(__FILE__), 'cookbooks',
+      '**', "Gemfile")) do |gemfile|
+    eval(IO.read(gemfile), binding)
+  end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,41 @@
+#!/usr/bin/env rake
+
+require 'mixlib/shellout'
+
+chef_version = '12.19.36'
+namespace :style do
+  desc 'Style check with rubocop'
+  task :rubocop do
+    sh '/opt/chefdk/embedded/bin/rubocop -P'
+  end
+
+  desc 'Style check with foodcritic'
+  task :foodcritic do
+    sh '/opt/chefdk/embedded/bin/foodcritic --role-path ./stub-environment/roles/ --environment-path ./stub-environment/environments/Test-Laptop.json --epic-fail none cookbooks/'
+  end
+
+  desc 'Check style violation difference'
+  task('diff'.to_sym) do
+    sh './compare_style.sh'
+  end
+end
+
+desc 'Run style checks'
+task style: %w(style:rubocop style:foodcritic)
+
+desc 'Clean some generated files'
+task :clean do
+  %w(
+    **/Berksfile.lock
+    .bundle
+    .cache
+    **/Gemfile.lock
+    .kitchen
+    vendor
+    ../cluster
+    vbox
+  ).each { |f| FileUtils.rm_rf(Dir.glob(f)) }
+  # XXX should remove VBox VM's
+end
+
+task :default => 'style'

--- a/compare_style.sh
+++ b/compare_style.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+###########################################
+# Script to compare style check differences
+# between branches of code to make sure we
+# are cleaning up and not regressing code
+###########################################
+
+########################################
+# Function to gather master style output
+# arguments: file path to write rake sytle output
+# post-condition: the file path has rake style output
+# returns: 1 on error
+function gather_master_style {
+  local my_branch=$(git branch | grep '^* ' | sed 's/^* //')
+  if [[ -z $1 ]]; then
+    echo -e 'gather_master_style:\tNeeds a filename to write rake style report' \
+            'got nothing' > /dev/stderr
+    return 1
+  fi
+  if [[ -z ${my_branch:=${TRAVIS_BRANCH}} ]]; then
+    echo -e 'gather_master_style:\tFailed to get a current Git branch!' \
+      > /dev/stderr
+    return 1
+  fi
+  # since we are switching branches make sure to stash any local changes
+  local git_message='compare_style.sh:gather_master_style()'
+  if [[ -n $(git status -s) ]]; then
+    export GIT_AUTHOR_EMAIL=${GIT_AUTHOR_EMAIL:=compare_style.sh@example.com}
+    export GIT_AUTHOR_NAME=${GIT_AUTHOR_NAME:=compare_style.sh script}
+    echo 'Stashing local changes to checkout master'
+    git stash save -a "${git_message}" >/dev/null 2>&1
+  fi
+  git remote add bloomberg https://github.com/bloomberg/chef-bach \
+    >/dev/null 2>&1
+  git fetch bloomberg master >/dev/null 2>&1
+  git checkout bloomberg/master >/dev/null 2>&1
+  if [[ $(git branch | grep '^* ' | sed 's/^* //') != \
+        '(HEAD detached at bloomberg/master)' ]]; then
+    echo -e 'gather_master_style:\tFailed to pull Bloomberg master' \
+      > /dev/stderr
+    return 1
+  fi
+  rake style >$1 2>&1 || true
+  git checkout ${my_branch} >/dev/null 2>&1
+  # re-apply any changes if we stashed changes
+  if (($(git stash list --author=${GIT_AUTHOR_EMAIl} --grep=${git_mssage} | wc -l) == 1)); then
+    echo 'Restoring local changes'
+    git stash pop >/dev/null 2>&1
+  fi
+}
+
+####################################################
+# Function to parse FoodCritic Rake output to return
+# the number of offenses
+# arguments: file path with rake sytle output
+#            (or will wait for standard-in to close)
+# output: the integer number of offenses
+function gather_chef_style_offenses {
+  egrep '^FC[0-9]*:' $1 | wc -l
+}
+
+
+#################################################
+# Function to parse RuboCop Rake output to return
+# the number of offenses
+# arguments: file path with rake sytle output
+#            (or will wait for standard-in to close)
+# output: the integer number of offenses
+function gather_ruby_style_offenses {
+  sed -n 's/^[0-9]* files inspected, \([0-9]*\) offenses detected$/\1/p' $1
+}
+
+###############################################
+# Function to compare rake style outputs to see
+# if the number of offenses if more than master
+# argument: file path with local rake sytle output
+# output: admonishment or congratulations for the
+#         code under validation
+# returns: 0: if there are fewer or equal offenses
+#          1: if there are more offenses
+#          2: if there was an error
+function compare_offenses {
+  if [[ -z $1 || ! -e $1 ]]; then
+    echo -e 'compare_offenses:\tNeeds a filename with a rake style report' \
+            "got: $1" > /dev/stderr
+    return 2
+  fi
+  local master_style_file="${REPORT_DIR}/master_style.txt"
+  gather_master_style ${master_style_file} || return 2
+  local master_ruby_offenses=$(gather_ruby_style_offenses ${master_style_file})
+  local master_chef_offenses=$(gather_chef_style_offenses ${master_style_file})
+  local my_ruby_offenses=$(gather_ruby_style_offenses $1)
+  local my_chef_offenses=$(gather_chef_style_offenses $1)
+  if [[ -z "$master_ruby_offenses" || -z "$my_ruby_offenses" ]]; then 
+    echo -e 'compare_offenses:\tFailed to gather Ruby offenses:\n' \
+            "\tmaster:\t${master_ruby_offenses}\n\tmine:\t${my_ruby_offenses}"\
+            "\n\tMaster style file ${master_style_file}"
+    return 2
+  elif [[ -z "$master_chef_offenses" || -z "$my_chef_offenses" ]]; then 
+    echo -e 'compare_offenses:\tFailed to gather Chef offenses:\n' \
+            "\tmaster:\t${master_chef_offenses}\n\tmine:\t${my_chef_offenses}"
+            "\n\tMaster style file ${master_style_file}"
+    return 2
+  fi
+  echo '############################################################'
+  echo -e "## Found my offenses are:" \
+       "Ruby: ${my_ruby_offenses} Chef: ${my_chef_offenses}" \
+       "\n## Master's offenses are:" \
+       "Ruby: ${master_ruby_offenses} Chef: ${master_chef_offenses}"
+  if (( ${master_ruby_offenses} < ${my_ruby_offenses} || \
+        ${master_chef_offenses} < ${my_chef_offenses})); then
+    echo '## Commit regressed style!'
+    echo '############################################################'
+    return 1
+  elif (( ${master_ruby_offenses} == ${my_ruby_offenses} && \
+        ${master_chef_offenses} == ${my_chef_offenses})); then
+    echo '## Commit did not improve style!'
+    echo '############################################################'
+    return 0
+  else
+    echo '## Commit improved style!'
+    echo '############################################################'
+    return 0
+  fi
+}
+
+function setup_report_dir {
+  export REPORT_DIR=$(mktemp -d --suffix '_chef-bach_build_out')
+  echo "Using REPORT_DIR: ${REPORT_DIR}" >/dev/stderr
+}
+
+# only execute functions if being run and not sourced
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  setup_report_dir
+  echo "Running rake style"
+  rake style > "${REPORT_DIR}/style_output" 2>&1 || \
+    echo "Swallowing -- guaranteed -- style failure"
+  echo "Comparing offenses"
+  compare_offenses "${REPORT_DIR}/style_output"
+fi


### PR DESCRIPTION
This provides for us to enable [Travis CI](http://travis-ci.org) for pull request checking. Particularly this adds support for us to start using `rake` along with a few tasks:

* `rake clean` -- A stub to clean the repository up after a cluster build
* `rake style` -- Runs all `style:*` verbos checks
* `rake style:diff` -- Provides if your repo improves or degrades style (a quick go/no-go one can run)
* `rake style:foodcritic` -- foodcritic for all cookbooks
* `rake style:rubocop` -- RuboCop

I have tested this with TravisCI ensuring we improve or at least maintain style quality every commit. As soon as this goes into master, I can work with the Bloomberg organization owners to enable chef-bach for TravisCI.