### PR TITLE
slider support

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/datanode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/datanode.rb
@@ -321,3 +321,5 @@ locking_resource 'hadoop-hdfs-nodemanager-restart' do
   subscribes :serialize, 'log[jdk-version-changed]', :delayed
   subscribes :serialize, node['bcpc']['hadoop']['jmxtrans_agent']['nodemanager']['xml'], :delayed
 end
+
+include_recipe 'bcpc-hadoop::slider'

--- a/cookbooks/bcpc-hadoop/recipes/slider.rb
+++ b/cookbooks/bcpc-hadoop/recipes/slider.rb
@@ -10,6 +10,18 @@ end
 
 hdp_select('slider-client', node[:bcpc][:hadoop][:distribution][:active_release])
 
+site_xml = node.default[:bcpc][:hadoop][:yarn][:site_xml]
+
+slider_properties = {
+  'hadoop.registry.zk.quorum' =>
+    zk_hosts.map{ |h| float_host(h[:hostname]) +
+      ":#{node[:bcpc][:hadoop][:zookeeper][:port]}"}
+    .join(','),
+  'hadoop.registry.rm.enabled' => true
+}
+site_xml.merge!(slider_properties)
+
+
 node.default['bcpc']['hadoop']['slider']['env'] = {}
 node.default['bcpc']['hadoop']['slider']['env'].tap do |slider_env|
   slider_env['JAVA_HOME'] = node[:bcpc][:hadoop][:java]

--- a/cookbooks/bcpc-hadoop/recipes/slider.rb
+++ b/cookbooks/bcpc-hadoop/recipes/slider.rb
@@ -11,7 +11,7 @@ end
 hdp_select('slider-client', node[:bcpc][:hadoop][:distribution][:active_release])
 
 node.default['bcpc']['hadoop']['slider']['env'] = {}
-node.default['bcpc']['hadoop']['sliser']['env'].tap do |slider_env|
+node.default['bcpc']['hadoop']['slider']['env'].tap do |slider_env|
   slider_env['JAVA_HOME'] = node[:bcpc][:hadoop][:java]
   slider_env['HADOOP_CONF_DIR'] = '/etc/hadoop/conf'
 end

--- a/cookbooks/bcpc-hadoop/recipes/slider.rb
+++ b/cookbooks/bcpc-hadoop/recipes/slider.rb
@@ -1,3 +1,5 @@
+# vim: tabstop=2:shiftwidth=2:softtabstop=2
+
 ::Chef::Recipe.send(:include, Bcpc_Hadoop::Helper)
 
 [ hwx_pkg_str("slider", node[:bcpc][:hadoop][:distribution][:release]) ].each do |pkg|
@@ -6,4 +8,16 @@
   end
 end
 
-hdp_select('slider', node[:bcpc][:hadoop][:distribution][:active_release])
+hdp_select('slider-client', node[:bcpc][:hadoop][:distribution][:active_release])
+
+node.default['bcpc']['hadoop']['slider']['env'] = {}
+node.default['bcpc']['hadoop']['sliser']['env'].tap do |slider_env|
+  slider_env['JAVA_HOME'] = node[:bcpc][:hadoop][:java]
+  slider_env['HADOOP_CONF_DIR'] = '/etc/hadoop/conf'
+end
+
+template '/etc/slider/conf/slider-env.sh' do
+  source 'generic_env.sh.erb'
+  mode 0o0555
+  variables(options: node['bcpc']['hadoop']['slider']['env'])
+end

--- a/cookbooks/bcpc-hadoop/recipes/slider.rb
+++ b/cookbooks/bcpc-hadoop/recipes/slider.rb
@@ -1,0 +1,9 @@
+::Chef::Recipe.send(:include, Bcpc_Hadoop::Helper)
+
+[ hwx_pkg_str("slider", node[:bcpc][:hadoop][:distribution][:release]) ].each do |pkg|
+  package pkg do
+    action :upgrade
+  end
+end
+
+hdp_select('slider', node[:bcpc][:hadoop][:distribution][:active_release])

--- a/cookbooks/bcpc-hadoop/recipes/yarn_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/yarn_site.rb
@@ -244,15 +244,6 @@ if node.roles.include?("BCPC-Hadoop-Head-YarnTimeLineServer")
   node.run_state[:yarn_site_generated_values].merge!(yts_properties)
 end
 
-slider_properties = {
-  'hadoop.registry.zk.quorum' =>
-    zk_hosts.map{ |h| float_host(h[:hostname]) +
-      ":#{node[:bcpc][:hadoop][:zookeeper][:port]}"}
-    .join(','),
-  'hadoop.registry.rm.enabled' => true
-}
-node.run_state[:yarn_site_generated_values].merge!(slider_properties)
-
 # This is another set of cached node searches.
 hs_hosts = node[:bcpc][:hadoop][:hs_hosts]
 if not hs_hosts.empty?

--- a/cookbooks/bcpc-hadoop/recipes/yarn_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/yarn_site.rb
@@ -51,12 +51,7 @@ if rm_hosts.length >= 2
      'yarn.resourcemanager.zk-address' =>
        zk_hosts.map{ |h| float_host(h[:hostname]) +
          ":#{node[:bcpc][:hadoop][:zookeeper][:port]}"}
-       .join(','),
-     'hadoop.registry.zk.quorum' =>
-       zk_hosts.map{ |h| float_host(h[:hostname]) +
-         ":#{node[:bcpc][:hadoop][:zookeeper][:port]}"}
-       .join(','),
-     'hadoop.registry.rm.enabled' => true
+       .join(',')
     }
 
   # Using 'map', a hash is built for each host.
@@ -248,6 +243,15 @@ if node.roles.include?("BCPC-Hadoop-Head-YarnTimeLineServer")
    } 
   node.run_state[:yarn_site_generated_values].merge!(yts_properties)
 end
+
+slider_properties = {
+  'hadoop.registry.zk.quorum' =>
+    zk_hosts.map{ |h| float_host(h[:hostname]) +
+      ":#{node[:bcpc][:hadoop][:zookeeper][:port]}"}
+    .join(','),
+  'hadoop.registry.rm.enabled' => true
+}
+node.run_state[:yarn_site_generated_values].merge!(slider_properties)
 
 # This is another set of cached node searches.
 hs_hosts = node[:bcpc][:hadoop][:hs_hosts]

--- a/cookbooks/bcpc-hadoop/recipes/yarn_site.rb
+++ b/cookbooks/bcpc-hadoop/recipes/yarn_site.rb
@@ -51,7 +51,12 @@ if rm_hosts.length >= 2
      'yarn.resourcemanager.zk-address' =>
        zk_hosts.map{ |h| float_host(h[:hostname]) +
          ":#{node[:bcpc][:hadoop][:zookeeper][:port]}"}
-       .join(',')
+       .join(','),
+     'hadoop.registry.zk.quorum' =>
+       zk_hosts.map{ |h| float_host(h[:hostname]) +
+         ":#{node[:bcpc][:hadoop][:zookeeper][:port]}"}
+       .join(','),
+     'hadoop.registry.rm.enabled' => true
     }
 
   # Using 'map', a hash is built for each host.


### PR DESCRIPTION
# Slider support
- YARN settings
- Install slider client on workers
- Update slider-env.sh

# Caveats
- The version of slider shipped currently does not grab HDFS delegation tokens, so even if a long running (> 7 days) process is not required, the cluster will not start, unless a keytab is provided
- Slider does not work with multihomed systems, the URL registered in yarn points to `host` as opposed to `f-host`, one way around this was to issue a `sudo hostname f-bcpc-vm3` on bcpc-vm3 prior to launching the cluster.  Opened https://issues.apache.org/jira/browse/SLIDER-1259

# Testing
Tested using a simple setup in https://github.com/pu239ppy/slider_poc

# What does it look like?
Here I am asking for two instances of a service, and the services are running on ephemeral ports
````
ubuntu   13491     1  0 16:37 ?        00:00:00 /usr/bin/python /disk/2/yarn/local/usercache/ubuntu/appcache/application_1515102595090_0151/container_1515102595090_0151_01_000003/app/install/mysvc.py 60468
ubuntu   13492     1  0 16:37 ?        00:00:00 /usr/bin/python /disk/2/yarn/local/usercache/ubuntu/appcache/application_1515102595090_0151/container_1515102595090_0151_01_000002/app/install/mysvc.py 60391
````

Here is what the exports query returns
````
{
  "host_port" : [ {
    "value" : "f-bcpc-vm3.bcpc.example.com:60468",
    "containerId" : "container_1515102595090_0151_01_000003",
    "tag" : "1",
    "level" : "component",
    "updatedTime" : "Mon Jan 08 11:37:13 EST 2018"
  }, {
    "value" : "f-bcpc-vm3.bcpc.example.com:60391",
    "containerId" : "container_1515102595090_0151_01_000002",
    "tag" : "2",
    "level" : "component",
    "updatedTime" : "Mon Jan 08 11:37:13 EST 2018"
  } ]

```` 
  