### PR TITLE
Fix issue seen on VM clusters with unset JAVA_HOME

### DIFF
--- a/cookbooks/bach_opentsdb/recipes/default.rb
+++ b/cookbooks/bach_opentsdb/recipes/default.rb
@@ -106,7 +106,8 @@ execute 'create-opentsdb-hbase-tables' do
   group 'hbase'
   environment(
     COMPRESSION: 'LZO',
-    HBASE_HOME: '/usr/hdp/current/hbase-client'
+    HBASE_HOME: '/usr/hdp/current/hbase-client',
+    JAVA_HOME: node['bach_opentsdb']['java_home']
   )
   not_if 'echo "list" | hbase shell | grep -q "tsdb"'
   notifies :restart, 'service[opentsdb]', :delayed


### PR DESCRIPTION
This should be the final fix for the issue mentioned by @vineshcpaul in #1065. The fixed items in #1066 and #1069 helped to an extent, but I finally encountered the same error as Vinesh (error shown in full below). This fix forces setting `JAVA_HOME` in the environment before running the create tables shell script, which should resolve the issue. Currently testing in my VM cluster.



```
  * execute[create-opentsdb-hbase-tables] action run+======================================================================+
|                    Error: JAVA_HOME is not set                       |
+----------------------------------------------------------------------+
| Please download the latest Sun JDK from the Sun Java web site        |
|     > http://www.oracle.com/technetwork/java/javase/downloads        |
|                                                                      |
| HBase requires Java 1.7 or later.                                    |
+======================================================================+

    [execute] +======================================================================+
              |                    Error: JAVA_HOME is not set                       |
              +----------------------------------------------------------------------+
              | Please download the latest Sun JDK from the Sun Java web site        |
              |     > http://www.oracle.com/technetwork/java/javase/downloads        |
              |                                                                      |
              | HBase requires Java 1.7 or later.                                    |
              +======================================================================+
    
    ================================================================================
    Error executing action `run` on resource 'execute[create-opentsdb-hbase-tables]'
    ================================================================================
    
    Mixlib::ShellOut::ShellCommandFailed
    ------------------------------------
    Expected process to exit with [0], but received '1'
    ---- Begin output of /usr/share/opentsdb/tools/create_table.sh ----
    STDOUT: 
    STDERR: +======================================================================+
    |                    Error: JAVA_HOME is not set                       |
    +----------------------------------------------------------------------+
    | Please download the latest Sun JDK from the Sun Java web site        |
    |     > http://www.oracle.com/technetwork/java/javase/downloads        |
    |                                                                      |
    | HBase requires Java 1.7 or later.                                    |
    +======================================================================+
    ---- End output of /usr/share/opentsdb/tools/create_table.sh ----
    Ran /usr/share/opentsdb/tools/create_table.sh returned 1
    
    Resource Declaration:
    ---------------------
    # In /var/chef/cache/cookbooks/bach_opentsdb/recipes/default.rb
    
    103: execute 'create-opentsdb-hbase-tables' do
    104:   command '/usr/share/opentsdb/tools/create_table.sh'
    105:   user 'hbase'
    106:   group 'hbase'
    107:   environment(
    108:     COMPRESSION: 'LZO',
    109:     HBASE_HOME: '/usr/hdp/current/hbase-client'
    110:   )
    111:   not_if 'echo "list" | hbase shell | grep -q "tsdb"'
    112:   notifies :restart, 'service[opentsdb]', :delayed
    113: end
    114: 
    
    Compiled Resource:
    ------------------
    # Declared in /var/chef/cache/cookbooks/bach_opentsdb/recipes/default.rb:103:in `from_file'
    
    execute("create-opentsdb-hbase-tables") do
      action [:run]
      retries 0
      retry_delay 2
      default_guard_interpreter :execute
      command "/usr/share/opentsdb/tools/create_table.sh"
      backup 5
      environment {:COMPRESSION=>"LZO", :HBASE_HOME=>"/usr/hdp/current/hbase-client"}
      group "hbase"
      returns 0
      user "hbase"
      declared_type :execute
      cookbook_name "bach_opentsdb"
      recipe_name "default"
      not_if "echo "list" | hbase shell | grep -q "tsdb""
    end
    
    Platform:
    ---------
    x86_64-linux
```