### PR TITLE
do not run checks or submit coordinator job if submit flag is disabled

### DIFF
--- a/cookbooks/smoke-tests/attributes/default.rb
+++ b/cookbooks/smoke-tests/attributes/default.rb
@@ -1,5 +1,6 @@
 # vim: tabstop=2:shiftwidth=2:softtabstop=2
 default['hadoop_smoke_tests'] = {}
+default['hadoop_smoke_tests']['oozie_submit_enable'] = true 
 default['hadoop_smoke_tests']['app_name'] = 'Oozie-Smoke-Test-Coordinator'
 default['hadoop_smoke_tests']['oozie_hosts'] = ['f-bcpc-vm2.bcpc.example.com']
 default['hadoop_smoke_tests']['oozie_user'] = 'ubuntu'

--- a/cookbooks/smoke-tests/attributes/default.rb
+++ b/cookbooks/smoke-tests/attributes/default.rb
@@ -1,6 +1,6 @@
 # vim: tabstop=2:shiftwidth=2:softtabstop=2
 default['hadoop_smoke_tests'] = {}
-default['hadoop_smoke_tests']['oozie_submit_enable'] = true 
+default['hadoop_smoke_tests']['oozie_submit_enable'] = true
 default['hadoop_smoke_tests']['app_name'] = 'Oozie-Smoke-Test-Coordinator'
 default['hadoop_smoke_tests']['oozie_hosts'] = ['f-bcpc-vm2.bcpc.example.com']
 default['hadoop_smoke_tests']['oozie_user'] = 'ubuntu'

--- a/cookbooks/smoke-tests/recipes/oozie_smoke_test.rb
+++ b/cookbooks/smoke-tests/recipes/oozie_smoke_test.rb
@@ -107,6 +107,9 @@ ruby_block 'smoke test coordinator status' do
            (line.include? 'RUNNING') }).empty?
       end
     end
+    # no need to interact with command line
+    # we do not plan to submit
+    only_if { node['hadoop_smoke_tests']['oozie_submit_enable'] == true } 
 end
 
 ruby_block 'submit oozie smoke test' do
@@ -115,5 +118,8 @@ ruby_block 'submit oozie smoke test' do
       test_user,
       "#{cache_dir}/smoke_test_coordinator.properties")
   end
-  only_if { node.run_state['need_coordinator_submit'] == true }
+  only_if { 
+    node['hadoop_smoke_tests']['oozie_submit_enable'] == true && 
+    node.run_state['need_coordinator_submit'] == true 
+  }
 end

--- a/cookbooks/smoke-tests/recipes/oozie_smoke_test.rb
+++ b/cookbooks/smoke-tests/recipes/oozie_smoke_test.rb
@@ -109,7 +109,7 @@ ruby_block 'smoke test coordinator status' do
     end
     # no need to interact with command line
     # we do not plan to submit
-    only_if { node['hadoop_smoke_tests']['oozie_submit_enable'] == true } 
+    only_if { node['hadoop_smoke_tests']['oozie_submit_enable'] == true }
 end
 
 ruby_block 'submit oozie smoke test' do


### PR DESCRIPTION
This pull request will will allow to add smoke `bcpc-hadoop::smoke_test_wrapper` to the BCPC-Hadoop-Worker.  Originally when developed, smoke test recipe could only be added to one worker in the cluster, as we needed to be able to stop chef and manually delete the coordinator job, in order for new definitions to be submitted again.  It would not have been feasible to stop chef client on all nodes in order to stop them from racing to submit a coordinator.  With this pull request it is no longer necessary, just disable submission in the environment by setting `default['hadoop_smoke_tests']['oozie_submit_enable']` to false, make the necessary changes and set it again.