### PR TITLE
added alarms for journalnode txid and epoch

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/journalnode.rb
+++ b/cookbooks/bcpc-hadoop/attributes/journalnode.rb
@@ -1,0 +1,2 @@
+default['bcpc']['hadoop']['journalnode']['alarm']['trigger_cond']['LastWrittenTxId'] = '>100'
+default['bcpc']['hadoop']['journalnode']['alarm']['trigger_cond']['LastWriterEpoch'] = '>1'

--- a/cookbooks/bcpc-hadoop/recipes/journalnode.rb
+++ b/cookbooks/bcpc-hadoop/recipes/journalnode.rb
@@ -2,6 +2,7 @@ require 'base64'
 include_recipe 'bcpc-hadoop::hadoop_config'
 ::Chef::Recipe.send(:include, Bcpc_Hadoop::Helper)
 ::Chef::Resource::Bash.send(:include, Bcpc_Hadoop::Helper)
+include_recipe 'bcpc-hadoop::journalnode_queries'
 
 hdprel=node[:bcpc][:hadoop][:distribution][:active_release]
 hdppath="/usr/hdp/#{hdprel}"

--- a/cookbooks/bcpc-hadoop/recipes/journalnode_queries.rb
+++ b/cookbooks/bcpc-hadoop/recipes/journalnode_queries.rb
@@ -1,0 +1,26 @@
+triggers_sensitivity = '10m'
+txid_threshold = node['bcpc']['hadoop']['journalnode']['alarm']['trigger_cond']['LastWrittenTxId']
+epoch_threshold = node['bcpc']['hadoop']['journalnode']['alarm']['trigger_cond']['LastWriterEpoch']
+
+node.default['bcpc']['hadoop']['graphite']['service_queries']['journalnode'] = {
+  'journalnode.LastWrittenTxId' => {
+    'query' => "rangeOfSeries(jmx.journalnode.#{node.chef_environment}.*.journal_node.Journal-#{node.chef_environment}.LastWrittenTxId)",
+    'trigger_val' => "min(#{triggers_sensitivity})",
+    'trigger_cond' => txid_threshold,
+    'trigger_name' => 'JournalNodeLastWrittenTxId',
+    'enable' => true,
+    'trigger_desc' => "Journalnodes have LastWrittenTxId drifted apart more than #{txid_threshold}",
+    'severity' => 3,
+    'route_to' => 'admin'
+  },
+  'journalnode.LastWriterEpoch' => {
+    'query' => "rangeOfSeries(jmx.journalnode.#{node.chef_environment}.*.journal_node.Journal-#{node.chef_environment}.LastWriterEpoch)",
+    'trigger_val' => "min(#{triggers_sensitivity})",
+    'trigger_cond' => epoch_threshold,
+    'trigger_name' => 'JournalNodeLastWriterEpoch',
+    'enable' => true,
+    'trigger_desc' => "Journalnodes have LastWriterEpoch drifted apart more than #{epoch_threshold}",
+    'severity' => 3,
+    'route_to' => 'admin'
+  }
+}


### PR DESCRIPTION
reopen for https://github.com/bloomberg/chef-bach/pull/977 with graphite-1.1.1
Tested on VM.