### PR TITLE
should be active release

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/configs.rb
+++ b/cookbooks/bcpc-hadoop/recipes/configs.rb
@@ -69,7 +69,7 @@ include_recipe 'java::oracle_jce'
 include_recipe 'bcpc-hadoop::jvmkill'
 
 %w(zookeeper).each do |pkg|
-  package hwx_pkg_str(pkg, node[:bcpc][:hadoop][:distribution][:release]) do
+  package hwx_pkg_str(pkg, node[:bcpc][:hadoop][:distribution][:active_release]) do
     action :upgrade
   end
 end


### PR DESCRIPTION
Got error when HDP-2.6.1 is supposed to be deployed but not upgraded.
```
Recipe: bcpc-hadoop::configs
  * package[zookeeper-2-6-1-17-1] action upgrade
    * No candidate version available for zookeeper-2-6-1-17-1
================================================================================
Error executing action `upgrade` on resource 'package[zookeeper-2-6-1-17-1]'
================================================================================

Chef::Exceptions::Package
-------------------------
No candidate version available for zookeeper-2-6-1-17-1

Resource Declaration:
---------------------
# In /var/chef/cache/cookbooks/bcpc-hadoop/recipes/configs.rb

 70:   package hwx_pkg_str(pkg, node[:bcpc][:hadoop][:distribution][:release]) do
 71:     action :upgrade
 72:   end
 73: end

Compiled Resource:
------------------
# Declared in /var/chef/cache/cookbooks/bcpc-hadoop/recipes/configs.rb:70:in `block in from_file'

package("zookeeper-2-6-1-17-1") do
  action [:upgrade]
  retries 0
  retry_delay 2
  guard_interpreter :default
  package_name "zookeeper-2-6-1-17-1"
  cookbook_name "bcpc-hadoop"
  recipe_name "configs"
end
```