### PR TITLE
Revert "should be active release"

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/configs.rb
+++ b/cookbooks/bcpc-hadoop/recipes/configs.rb
@@ -69,7 +69,7 @@ include_recipe 'java::oracle_jce'
 include_recipe 'bcpc-hadoop::jvmkill'
 
 %w(zookeeper).each do |pkg|
-  package hwx_pkg_str(pkg, node[:bcpc][:hadoop][:distribution][:active_release]) do
+  package hwx_pkg_str(pkg, node[:bcpc][:hadoop][:distribution][:release]) do
     action :upgrade
   end
 end


### PR DESCRIPTION
Reverts bloomberg/chef-bach#1099 per the comment in #1099 explaining that package installations are keyed off `node['bcpc']['hadoop']['distribution']['release']` not `node['bcpc']['hadoop']['distribution']['active_release']` we should correct the code back.