### PR TITLE
Upgrade to HDP 2.6.3

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -9,7 +9,7 @@ user = node['bcpc']['bootstrap']['admin']['user']
 default['bcpc']['cluster']['file_path'] = "/home/#{user}/chef-bcpc/cluster.txt"
 
 default['bcpc']['hadoop'] = {}
-default['bcpc']['hadoop']['distribution']['release'] = '2.6.1.17-1'
+default['bcpc']['hadoop']['distribution']['release'] = '2.6.3.0-235'
 default['bcpc']['hadoop']['distribution']['active_release'] = \
   node['bcpc']['hadoop']['distribution']['release']
 default['bcpc']['hadoop']['decommission']['hosts'] = []

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -164,7 +164,7 @@ default['bcpc']['repos_for']['trusty'].tap do |trusty_repos|
     repo[:distribution] = 'HDP'
     repo[:key] = 'hortonworks.key'
     repo[:uri] =
-      'http://private-repo-1.hortonworks.com/HDP/ubuntu14/2.x/updates/2.6.1.17-1'
+      'http://public-repo-1.hortonworks.com/HDP/ubuntu14/2.x/updates/2.6.3.0'
   end
 
   trusty_repos['hdp-utils'].tap do |repo|
@@ -172,7 +172,7 @@ default['bcpc']['repos_for']['trusty'].tap do |trusty_repos|
     repo[:distribution] = 'HDP-UTILS'
     repo[:key] = 'hortonworks.key'
     repo[:uri] =
-      'http://private-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/ubuntu14'
+      'http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/ubuntu14'
   end
 
   trusty_repos['zabbix'].tap do |repo|


### PR DESCRIPTION
Operation steps of what we usually do:

1.  Set `node['bcpc']['hadoop']['distribution']['active_release']` to 2.6.1
2.  Deploy the new set of cookbooks with 2.6.3
3.  Unset `node['bcpc']['hadoop']['distribution']['active_release']`