### PR TITLE
Oozie Client Library Cookbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ vbox/**
 bins/
 cookbooks/*/
 !cookbooks/bach_common
+!cookbooks/bach_oozie
 !cookbooks/bach_repository
 !cookbooks/bach_spark
 !cookbooks/bcpc

--- a/Berksfile
+++ b/Berksfile
@@ -8,6 +8,7 @@ metadata
 #
 cookbook 'bach_common', path: './cookbooks/bach_common'
 cookbook 'bach_krb5', path: './cookbooks/bach_krb5'
+cookbook 'bach_oozie', path: './cookbooks/bach_oozie'
 cookbook 'bach_repository', path: './cookbooks/bach_repository'
 cookbook 'bach_spark', path: './cookbooks/bach_spark'
 cookbook 'bcpc', path: './cookbooks/bcpc'

--- a/cookbooks/bach_oozie/README.md
+++ b/cookbooks/bach_oozie/README.md
@@ -1,0 +1,4 @@
+# bach_oozie
+
+Oozie client library wrapper.
+Contains the useful oozie_client.rb library file.

--- a/cookbooks/bach_oozie/libraries/oozie_client.rb
+++ b/cookbooks/bach_oozie/libraries/oozie_client.rb
@@ -19,13 +19,14 @@
 
 module Oozie
   class ClientV1
-    attr_accessor :host, :port, :user
+    attr_accessor :oozie_url, :user
 
     def initialize(oozie_url='http://localhost:11000/oozie', user='oozie')
       @oozie = oozie_url 
       @user = user
     end
 
+    # list the oozie jobs on the server.
     def jobs(filter={}, jobtype='workflow', len=10)
       execute('jobs', user, {
         oozie: @oozie,
@@ -35,6 +36,7 @@ module Oozie
       })
     end
 
+    # kill the oozie jobs the match the filter.
     def kill_jobs(filter={}, jobtype='workflow', len=1000)
       execute('jobs', user, {
         oozie: @oozie,
@@ -45,6 +47,7 @@ module Oozie
       })
     end
 
+    # run an oozie job.
     def run(config, user=@user)
       execute('job', user, {
         oozie: @oozie,
@@ -53,6 +56,7 @@ module Oozie
       })
     end
 
+    # rerun an oozie action.
     def rerun(action_id, config, user=@user)
       execute('job', user, {
         oozie: @oozie,
@@ -61,6 +65,7 @@ module Oozie
       })
     end
 
+    # kill an oozie job with the given id.
     def kill(job_id, user=@user)
       execute('job', user, {
         oozie: @oozie,
@@ -68,6 +73,7 @@ module Oozie
       })
     end
 
+    # get the id of an oozie job with the given name (if it exists).
     def get_id(job_name, jobtype='workflow', status='RUNNING')
       jobs_cmd = jobs({ name: job_name, status: status }, 'coordinator', 1)
       match = jobs_cmd.stdout.match(/(\S+)\s+#{job_name}/)

--- a/cookbooks/bach_oozie/libraries/oozie_client.rb
+++ b/cookbooks/bach_oozie/libraries/oozie_client.rb
@@ -1,0 +1,100 @@
+#
+# oozie_client.rb
+# ruby client for oozie
+#
+# Copyright 2018, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Oozie
+  class ClientV1
+    attr_accessor :host, :port, :user
+
+    def initialize(host='localhost', port=11000, user='oozie')
+      @host = host
+      @port = port
+      @user = user
+
+      @oozie = "http://#{host}:#{port}/oozie"
+    end
+
+    def jobs(filter={}, jobtype='workflow', len=10)
+      execute('jobs', user, {
+        oozie: @oozie,
+        jobtype: jobtype,
+        filter: "\"#{filter_string(filter)}\"",
+        len: len
+      })
+    end
+
+    def kill_jobs(filter={}, jobtype='workflow', len=1000)
+      execute('jobs', user, {
+        oozie: @oozie,
+        jobtype: jobtype,
+        filter: "\"#{filter_string(filter)}\"",
+        len: len,
+        kill: nil
+      })
+    end
+
+    def run(config, user=@user)
+      execute('job', user, {
+        oozie: @oozie,
+        config: config,
+        run: nil
+      })
+    end
+
+    def rerun(action_id, config, user=@user)
+      execute('job', user, {
+        oozie: @oozie,
+        config: config,
+        rerun: action_id
+      })
+    end
+
+    def kill(job_id, user=@user)
+      execute('job', user, {
+        oozie: @oozie,
+        kill: job_id
+      })
+    end
+
+    def get_id(job_name, jobtype='workflow', status='RUNNING')
+      jobs_cmd = jobs({ name: job_name, status: status }, 'coordinator', 1)
+      match = jobs_cmd.stdout.match(/(\S+)\s+#{job_name}/)
+      return match.nil? ? nil : match[1]
+    end
+
+    private ## private methods
+
+    def execute(subcommand, user=@user, options={})
+      require 'mixlib/shellout'
+      command = "sudo -u #{user} oozie #{subcommand} #{options_string(options)}"
+      # puts command ## print debug command
+      return Mixlib::ShellOut.new(command, timeout: 90).run_command
+    end
+
+    def options_string(options)
+      options.map { |key, value| "-#{key.to_s} #{value}" }.join(' ')
+    end
+
+    def filter_string(filter)
+      filter.map { |key, value| "#{key.to_s}=#{value}" }.join(';')
+    end
+  end
+
+  class Client < ClientV1
+  end
+end

--- a/cookbooks/bach_oozie/libraries/oozie_client.rb
+++ b/cookbooks/bach_oozie/libraries/oozie_client.rb
@@ -21,12 +21,9 @@ module Oozie
   class ClientV1
     attr_accessor :host, :port, :user
 
-    def initialize(host='localhost', port=11000, user='oozie')
-      @host = host
-      @port = port
+    def initialize(oozie_url='http://localhost:11000/oozie', user='oozie')
+      @oozie = oozie_url 
       @user = user
-
-      @oozie = "http://#{host}:#{port}/oozie"
     end
 
     def jobs(filter={}, jobtype='workflow', len=10)
@@ -81,9 +78,9 @@ module Oozie
 
     def execute(subcommand, user=@user, options={})
       require 'mixlib/shellout'
-      command = "sudo -u #{user} oozie #{subcommand} #{options_string(options)}"
+      command = "oozie #{subcommand} #{options_string(options)}"
       # puts command ## print debug command
-      return Mixlib::ShellOut.new(command, timeout: 90).run_command
+      return Mixlib::ShellOut.new(command, user: user, timeout: 90).run_command
     end
 
     def options_string(options)

--- a/cookbooks/bach_oozie/metadata.rb
+++ b/cookbooks/bach_oozie/metadata.rb
@@ -1,19 +1,7 @@
-name 'bach_oozie'
-maintainer 'The Authors'
-maintainer_email 'you@example.com'
-license 'all_rights'
-description 'Installs/Configures bach_oozie'
-long_description 'Installs/Configures bach_oozie'
-version '0.1.0'
-
-# The `issues_url` points to the location where issues for this cookbook are
-# tracked.  A `View Issues` link will be displayed on this cookbook's page when
-# uploaded to a Supermarket.
-#
-# issues_url 'https://github.com/<insert_org_here>/bach_oozie/issues' if respond_to?(:issues_url)
-
-# The `source_url` points to the development reposiory for this cookbook.  A
-# `View Source` link will be displayed on this cookbook's page when uploaded to
-# a Supermarket.
-#
-# source_url 'https://github.com/<insert_org_here>/bach_oozie' if respond_to?(:source_url)
+name             'bach_oozie'
+maintainer       'Bloomberg Finance L.P.'
+maintainer_email 'hadoop@bloomberg.net'
+license          'Apache License 2.0'
+description      'Library cookbook for a simple oozie client'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'

--- a/cookbooks/bach_oozie/metadata.rb
+++ b/cookbooks/bach_oozie/metadata.rb
@@ -1,0 +1,19 @@
+name 'bach_oozie'
+maintainer 'The Authors'
+maintainer_email 'you@example.com'
+license 'all_rights'
+description 'Installs/Configures bach_oozie'
+long_description 'Installs/Configures bach_oozie'
+version '0.1.0'
+
+# The `issues_url` points to the location where issues for this cookbook are
+# tracked.  A `View Issues` link will be displayed on this cookbook's page when
+# uploaded to a Supermarket.
+#
+# issues_url 'https://github.com/<insert_org_here>/bach_oozie/issues' if respond_to?(:issues_url)
+
+# The `source_url` points to the development reposiory for this cookbook.  A
+# `View Source` link will be displayed on this cookbook's page when uploaded to
+# a Supermarket.
+#
+# source_url 'https://github.com/<insert_org_here>/bach_oozie' if respond_to?(:source_url)

--- a/cookbooks/bach_oozie/recipes/default.rb
+++ b/cookbooks/bach_oozie/recipes/default.rb
@@ -1,0 +1,5 @@
+#
+# Cookbook:: bach_oozie
+# Recipe:: default
+#
+# Copyright:: 2018, The Authors, All Rights Reserved.

--- a/cookbooks/bach_oozie/recipes/default.rb
+++ b/cookbooks/bach_oozie/recipes/default.rb
@@ -1,5 +1,18 @@
 #
-# Cookbook:: bach_oozie
+# Cookbook Name:: bach_oozie
 # Recipe:: default
 #
-# Copyright:: 2018, The Authors, All Rights Reserved.
+# Copyright 2018, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/cookbooks/bach_oozie/resources/oozie_job.rb
+++ b/cookbooks/bach_oozie/resources/oozie_job.rb
@@ -1,0 +1,76 @@
+#
+# Cookbook Name:: backup
+# Custom oozie job resource
+#
+# Copyright 2018, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+resource_name :oozie_job
+provides :oozie_job
+
+property :name, String, name_property: true
+property :url, String, required: true
+property :config, String, required: true
+property :user, String
+
+action_class do
+  include Oozie
+end
+
+action :run do
+  Chef::Log.info("Starting oozie job: #{name}")
+  client = Oozie::Client.new(url, user)
+
+  # check if the job is already running
+  job_id = client.get_id(name, 'coordinator', 'RUNNING')
+
+  # start the service
+  if job_id.nil?
+    run_cmd = client.run(config, user)
+    run_cmd.error!
+  end
+end
+
+action :restart do
+  Chef::Log.info("Rerunning oozie job: #{name}")
+  client = Oozie::Client.new(url, user)
+
+  # check if the job is already running
+  job_id = client.get_id(name, 'coordinator', 'RUNNING')
+
+  if job_id.nil?
+    # start the service
+    run_cmd = client.run(config, user)
+    run_cmd.error!
+  else
+    # kill and restart the service
+    kill_cmd = client.kill(job_id, user)
+    kill_cmd.error!
+    rerun_cmd = client.run(config, user)
+    rerun_cmd.error!
+  end
+end
+
+action :kill do
+  Chef::Log.info("Killing oozie job: #{name}")
+  client = Oozie::Client.new(url, user)
+
+  # kill the service (if it exists)
+  jobs_cmd = client.kill_jobs({ name: name }, "coordinator")
+  jobs_cmd.error!
+end
+
+action :nothing do
+end


### PR DESCRIPTION
This adds a cookbook that contains a simple oozie library client.
It doesn't search for a running oozie host like the helper methods in the smoke tests, but that can be added if necessary.