### PR TITLE
[HDP] - Upgrade to 2.6.3.22-1 patch release

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -9,7 +9,7 @@ user = node['bcpc']['bootstrap']['admin']['user']
 default['bcpc']['cluster']['file_path'] = "/home/#{user}/chef-bcpc/cluster.txt"
 
 default['bcpc']['hadoop'] = {}
-default['bcpc']['hadoop']['distribution']['release'] = '2.6.3.0-235'
+default['bcpc']['hadoop']['distribution']['release'] = '2.6.3.22-1'
 default['bcpc']['hadoop']['distribution']['active_release'] = \
   node['bcpc']['hadoop']['distribution']['release']
 default['bcpc']['hadoop']['decommission']['hosts'] = []

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -164,7 +164,7 @@ default['bcpc']['repos_for']['trusty'].tap do |trusty_repos|
     repo[:distribution] = 'HDP'
     repo[:key] = 'hortonworks.key'
     repo[:uri] =
-      'http://public-repo-1.hortonworks.com/HDP/ubuntu14/2.x/updates/2.6.3.0'
+      'http://private-repo-1.hortonworks.com/HDP/ubuntu14/2.x/updates/2.6.3.22-1'
   end
 
   trusty_repos['hdp-utils'].tap do |repo|
@@ -172,7 +172,7 @@ default['bcpc']['repos_for']['trusty'].tap do |trusty_repos|
     repo[:distribution] = 'HDP-UTILS'
     repo[:key] = 'hortonworks.key'
     repo[:uri] =
-      'http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/ubuntu14'
+      'http://private-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/ubuntu14'
   end
 
   trusty_repos['zabbix'].tap do |repo|


### PR DESCRIPTION
#### HDP-2.6.3.22-1 includes fixes for the following Apache JIRAs: 

**HBase:**  module base-backup including [HBASE-14123](https://issues.apache.org/jira/browse/HBASE-14123) [HBASE-14135](https://issues.apache.org/jira/browse/HBASE-14135) and [HBASE-17850](https://issues.apache.org/jira/browse/HBASE-17850) ; [HBASE-19285](https://issues.apache.org/jira/browse/HBASE-19285) - Add per-table latency histograms
**Oozie:** [OOZIE-2606](https://issues.apache.org/jira/browse/OOZIE-2606) [OOZIE-2658](https://issues.apache.org/jira/browse/OOZIE-2658) [OOZIE-2787](https://issues.apache.org/jira/browse/OOZIE-2787) [OOZIE-2802](https://issues.apache.org/jira/browse/OOZIE-2802) (Oozie with Spark2 fixes) 
**Yarn:** [YARN-3742](https://issues.apache.org/jira/browse/YARN-3742) [YARN-6061](https://issues.apache.org/jira/browse/YARN-6061) (Issues related to Yarn RM standby not able to become active)

Operation steps of what we usually do (stolen from Allan's earlier PR):

1.  Set `node['bcpc']['hadoop']['distribution']['active_release']` to 2.6.1
2.  Deploy the new set of cookbooks with 2.6.3
3.  Unset `node['bcpc']['hadoop']['distribution']['active_release']`