### PR TITLE
Move to sysctl_param and remove sysctl::apply

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/configs.rb
+++ b/cookbooks/bcpc-hadoop/recipes/configs.rb
@@ -35,7 +35,6 @@ if !node.key?('pam_d') || !node['pam_d'].key?('services') || !node['pam_d']['ser
 end
 
 # set vm.swapiness to 0 (to lessen swapping)
-include_recipe 'sysctl::default'
 sysctl_param 'vm.swappiness' do
   value 0
 end
@@ -43,8 +42,8 @@ end
 # Populate node attributes for all kind of hosts
 set_hosts
 node.override['locking_resource']['zookeeper_servers'] = \
-  node[:bcpc][:hadoop][:zookeeper][:servers].map do |server|
-    [float_host(server['hostname']), node[:bcpc][:hadoop][:zookeeper][:port]].join(':')
+  node['bcpc']['hadoop']['zookeeper']['servers'].map do |server|
+    [float_host(server['hostname']), node['bcpc']['hadoop']['zookeeper']['port']].join(':')
   end
 
 package 'bigtop-jsvc'
@@ -69,11 +68,13 @@ include_recipe 'java::oracle_jce'
 include_recipe 'bcpc-hadoop::jvmkill'
 
 %w(zookeeper).each do |pkg|
-  package hwx_pkg_str(pkg, node[:bcpc][:hadoop][:distribution][:release]) do
+  package hwx_pkg_str(pkg, node['bcpc']['hadoop']['distribution']['release']) do
     action :upgrade
   end
 end
 
-# incrase max_map_count
-node.default['sysctl']['params']['vm']['max_map_count'] = (node.memory.total.to_i) / 16
-include_recipe 'sysctl::apply'
+# We need more maps!
+max_maps = node['memory']['total'].to_i / 16
+sysctl_param 'vm.max_map_count' do
+  value max_maps
+end

--- a/cookbooks/bcpc_kafka/recipes/default.rb
+++ b/cookbooks/bcpc_kafka/recipes/default.rb
@@ -47,7 +47,6 @@ if not node.has_key?('pam_d') or not node['pam_d'].has_key?('services') or not n
 end
 
 # set vm.swapiness to 0 (to lessen swapping)
-include_recipe 'sysctl::default'
 sysctl_param 'vm.swappiness' do
   value 0
 end


### PR DESCRIPTION
As the title says. This PR should resolve issues we're currently facing after the latest `sysctl` cookbook changes. I see no mentions in the readme of `include_recipe` anymore, so I think it's safe to remove, as the `depends` in the metadata is supposed to be sufficient. This still needs to be tested, and I'll update once the testing has completed. This time, I didn't separate FC/Rubocop fixes in separate commits. Please have mercy on my soul.