### PR TITLE
The sysctl include_recipe is still needed for resource collection

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/configs.rb
+++ b/cookbooks/bcpc-hadoop/recipes/configs.rb
@@ -2,6 +2,7 @@ require 'base64'
 ::Chef::Recipe.send(:include, Bcpc_Hadoop::Helper)
 
 include_recipe 'bcpc-hadoop::default'
+include_recipe 'sysctl::default'
 
 # disable IPv6 (e.g. for HADOOP-8568)
 case node['platform_family']

--- a/cookbooks/bcpc-hadoop/recipes/configs.rb
+++ b/cookbooks/bcpc-hadoop/recipes/configs.rb
@@ -2,6 +2,7 @@ require 'base64'
 ::Chef::Recipe.send(:include, Bcpc_Hadoop::Helper)
 
 include_recipe 'bcpc-hadoop::default'
+# NOTE: This include_recipe is necessary for resource collection
 include_recipe 'sysctl::default'
 
 # disable IPv6 (e.g. for HADOOP-8568)
@@ -36,6 +37,7 @@ if !node.key?('pam_d') || !node['pam_d'].key?('services') || !node['pam_d']['ser
 end
 
 # set vm.swapiness to 0 (to lessen swapping)
+# NOTE: See above for note about resource collection
 sysctl_param 'vm.swappiness' do
   value 0
 end

--- a/cookbooks/bcpc_kafka/recipes/default.rb
+++ b/cookbooks/bcpc_kafka/recipes/default.rb
@@ -47,6 +47,7 @@ if not node.has_key?('pam_d') or not node['pam_d'].has_key?('services') or not n
 end
 
 # set vm.swapiness to 0 (to lessen swapping)
+# NOTE: This include_recipe is necessary for resource collection
 include_recipe 'sysctl::default'
 sysctl_param 'vm.swappiness' do
   value 0

--- a/cookbooks/bcpc_kafka/recipes/default.rb
+++ b/cookbooks/bcpc_kafka/recipes/default.rb
@@ -47,6 +47,7 @@ if not node.has_key?('pam_d') or not node['pam_d'].has_key?('services') or not n
 end
 
 # set vm.swapiness to 0 (to lessen swapping)
+include_recipe 'sysctl::default'
 sysctl_param 'vm.swappiness' do
   value 0
 end


### PR DESCRIPTION
This fixes a bug I created in #1118 by removing the `include_recipe` entries. It seemed that was no longer required, and it worked in my testing, however, when testing in a physical cluster again, I noticed the resource collection didn't complete properly without it.