### PR TITLE
Fix bootstrap_hostname value in graphite queries

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/graphite_queries.rb
+++ b/cookbooks/bcpc-hadoop/recipes/graphite_queries.rb
@@ -5,7 +5,7 @@ graphite_query_time = "#{node["bcpc"]["hadoop"]["zabbix"]["graphite_query_time"]
 triggers_sensitivity = "#{node["bcpc"]["hadoop"]["zabbix"]["triggers_sensitivity"]}m"
 
 head_nodes_objs = get_head_nodes
-bootstrap_hostname = node['bcpc']['bootstrap']['hostname']
+bootstrap_hostname = get_bootstrap
 
 # Graphite queries which specify property to query and alarming trigger,
 # severity(maps to zabbix's api -> trigger -> priority)and owner who the


### PR DESCRIPTION
Causing head nodes to fail Chef runs in a hardware cluster, as the attribute being used is empty. Seems like it gets populated in VM clusters only (it's modified by Vagrant, but I don't see it being used or touched elsewhere).