### PR TITLE
Update service name for kafka broker

### DIFF
--- a/cookbooks/bcpc_kafka/recipes/kafka.rb
+++ b/cookbooks/bcpc_kafka/recipes/kafka.rb
@@ -89,7 +89,7 @@ include_recipe 'kafka::default'
 
 user_ulimit 'kafka' do
   filehandle_limit node[:kafka][:ulimit_file]
-  notifies :restart, 'service[kafka-broker]', :immediately
+  notifies :restart, 'service[kafka]', :immediately
 end
 
 #


### PR DESCRIPTION
bcpc_kafka was configured to use a non-existent service name for
Kafka when updating a ulimit.

This patch uses the correct service resource name from the upstream
Kafka cookbook.