### PR TITLE
Option to enable/disable Jolokia agent to collect JMX stat

### DIFF
--- a/cookbooks/bach_repository/attributes/default.rb
+++ b/cookbooks/bach_repository/attributes/default.rb
@@ -76,6 +76,9 @@ default['bcpc']['hadoop']['java'] = "/usr/lib/jvm/java-8-oracle-amd64"
 default['bach']['repository']['jmxtrans_agent']['download_url'] = 'https://github.com/jmxtrans/jmxtrans-agent/releases/download/jmxtrans-agent-1.2.5/jmxtrans-agent-1.2.5.jar'
 default['bach']['repository']['jmxtrans_agent']['checksum'] = 'd351ac0b863ffb2742477001296f65cbca6f8e9bb5bec3dc2194c447d838ae17'
 
+# jolokia-agent (https://github.com/rhuss/jolokia)
+default['bach']['repository']['jolokia_agent']['download_url'] = 'https://github.com/rhuss/jolokia/releases/download/v1.5.0/jolokia-1.5.0-bin.tar.gz'
+
 # OpenTSDB deb package details
 default['bach']['repository']['opentsdb']['version'] = '2.3.0'
 default['bach']['repository']['opentsdb']['package_name'] = "opentsdb-#{node['bach']['repository']['opentsdb']['version']}_all.deb"

--- a/cookbooks/bach_repository/recipes/default.rb
+++ b/cookbooks/bach_repository/recipes/default.rb
@@ -40,5 +40,8 @@ include_recipe 'bach_repository::jvmkill'
 # download jmxtrans-agent
 include_recipe 'bach_repository::jmxtrans_agent'
 
+# download jolokia-agent
+include_recipe 'bach_repository::jolokia_agent'
+
 # Run after everything to fix perms.
 include_recipe 'bach_repository::permissions'

--- a/cookbooks/bach_repository/recipes/jolokia_agent.rb
+++ b/cookbooks/bach_repository/recipes/jolokia_agent.rb
@@ -1,0 +1,32 @@
+#
+# Cookbook Name:: bach_repository
+# Recipe:: jolokia_agent
+#
+require 'tmpdir'
+include_recipe 'bach_repository::directory'
+bins_dir = node['bach']['repository']['bins_directory']
+jolokia_extract_dir = Dir.mktmpdir
+jolokia_tar_file = bins_dir + '/jolokia-1.5.0-bin.tar.gz'
+target_file = bins_dir + '/jolokia-jvm.jar'
+
+remote_file jolokia_tar_file do
+  source node['bach']['repository']['jolokia_agent']['download_url']
+  user 'root'
+  group 'root'
+  mode 0444
+  notifies :run, 'execute[extract_jolokia_tar]', :immediately
+  not_if { File.exist?(target_file) }
+end
+
+execute 'extract_jolokia_tar' do
+  command "tar xvf #{jolokia_tar_file} -C #{jolokia_extract_dir}"
+  cwd bins_dir
+  notifies :run, 'execute[copy_jolokia_agent_jar]', :immediately
+  action :nothing
+end
+
+execute 'copy_jolokia_agent_jar' do
+  command "cp #{jolokia_extract_dir}/jolokia-1.5.0/agents/jolokia-jvm.jar ."
+  cwd bins_dir
+  action :nothing
+end

--- a/cookbooks/bcpc-hadoop/attributes/jolokia.rb
+++ b/cookbooks/bcpc-hadoop/attributes/jolokia.rb
@@ -26,6 +26,7 @@
 # independent port.
 #
 node.default['bcpc']['jolokia'].tap do |jolokia|
+  jolokia['enable'] = false
   jolokia['policy_path'] = '/etc/bach/jolokia_security_policy.xml'
   jolokia['jar_path'] = '/usr/local/jolokia/lib/jolokia-jvm.jar'
   jolokia['host'] = '0.0.0.0'

--- a/cookbooks/bcpc-hadoop/recipes/jolokia.rb
+++ b/cookbooks/bcpc-hadoop/recipes/jolokia.rb
@@ -25,6 +25,9 @@
 #
 
 include_recipe 'bcpc-hadoop::maven_config'
+lib_file = node['bcpc']['jolokia']['jar_path']
+lib_file_name = Pathname.new(lib_file).basename.to_s
+src_file_url = File.join(get_binary_server_url, lib_file_name)
 
 directory File.dirname(node['bcpc']['jolokia']['jar_path']) do
   mode 0555
@@ -34,13 +37,11 @@ directory File.dirname(node['bcpc']['jolokia']['jar_path']) do
   action :create
 end
 
-maven 'jolokia-jvm' do
-  group_id 'org.jolokia'
-  version  '1.3.7'
-  dest File.dirname(node['bcpc']['jolokia']['jar_path'])
-  classifier 'agent'
-  action :put
-  timeout 1800
+remote_file lib_file.to_s do
+  source src_file_url
+  owner 'ubuntu'
+  group 'ubuntu'
+  mode '0755'
 end
 
 directory File.dirname(node['bcpc']['jolokia']['policy_path']) do

--- a/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
+++ b/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
@@ -25,6 +25,11 @@ link "/usr/bin/zookeeper-server-initialize" do
   to "/usr/hdp/current/zookeeper-client/bin/zookeeper-server-initialize"
 end
 
+#Install jolokia's jvm agent to node['bcpc']['jolokia']['path']
+if node[:bcpc][:jolokia][:enable] == true
+  include_recipe 'bcpc-hadoop::jolokia'
+end
+
 template "#{node[:bcpc][:hadoop][:zookeeper][:conf_dir]}/zookeeper-env.sh" do
   source "zk_zookeeper-env.sh.erb"
   mode 0644

--- a/cookbooks/bcpc-hadoop/recipes/zookeeper_server.rb
+++ b/cookbooks/bcpc-hadoop/recipes/zookeeper_server.rb
@@ -1,5 +1,4 @@
 include_recipe 'bcpc-hadoop::zookeeper_config'
-node.override['bcpc']['jolokia']['jvm_args'] = ''
 include_recipe 'bcpc-hadoop::zookeeper_impl'
 
 # Set Zookeeper related zabbix triggers

--- a/cookbooks/bcpc-hadoop/templates/default/zk_zookeeper-env.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/zk_zookeeper-env.sh.erb
@@ -12,7 +12,12 @@ export ZOO_PID_DIR=/var/run/zookeeper
 export ZOOPIDFILE=$ZOO_PID_DIR/zookeeper-server
 export ZOOCFGDIR=<%= node['bcpc']['hadoop']['zookeeper']['conf_dir'] %>
 export ZOO_DATADIR_AUTOCREATE_DISABLE=1
-SERVER_JVMFLAGS="$SERVER_JVMFLAGS -Djute.maxbuffer=<%= node['bcpc']['hadoop']['jute']['maxbuffer']  %> <%= node['bcpc']['jolokia']['jvm_args'] %>"
+SERVER_JVMFLAGS="$SERVER_JVMFLAGS -Djute.maxbuffer=<%= node['bcpc']['hadoop']['jute']['maxbuffer']  %>"
+
+<% if node[:bcpc][:jolokia][:enable] %>
+SERVER_JVMFLAGS="$SERVER_JVMFLAGS <%= node['bcpc']['jolokia']['jvm_args'] %>"
+<% end %>
+
 CLIENT_JVMFLAGS="$CLIENT_JVMFLAGS -Djute.maxbuffer=<%= node['bcpc']['hadoop']['jute']['maxbuffer'] %>"
 <% if node['bcpc']['hadoop'].attribute?(:jmx_enabled) and node['bcpc']['hadoop']['jmx_enabled'] %>
 export JMXPORT=<%= @zk_jmx_port %>

--- a/cookbooks/bcpc_kafka/recipes/kafka.rb
+++ b/cookbooks/bcpc_kafka/recipes/kafka.rb
@@ -19,6 +19,7 @@
 
 include_recipe 'bcpc_kafka::default'
 
+node.force_override[:bcpc][:jolokia][:enable] = true
 #
 # We need node search to set a reasonable value for num.partitions, so
 # the value from the attributes file must be overriden.

--- a/cookbooks/bcpc_kafka/recipes/kafka.rb
+++ b/cookbooks/bcpc_kafka/recipes/kafka.rb
@@ -71,10 +71,12 @@ node.default[:kafka][:broker][:log][:dirs] = data_volumes.map do |dd|
 end
 
 # Install jolokia's jvm agent to node['bcpc']['jolokia']['path']
-include_recipe 'bcpc-hadoop::jolokia'
+if node[:bcpc][:jolokia][:enable] == true
+  include_recipe 'bcpc-hadoop::jolokia'
 
-# Add the jolokia agent to the Kafka broker's launch options
-node.default[:kafka][:generic_opts] = node[:bcpc][:jolokia][:jvm_args]
+  # Add the jolokia agent to the Kafka broker's launch options
+  node.default[:kafka][:generic_opts] = node[:bcpc][:jolokia][:jvm_args]
+end
 
 # Increase the default FD limit -- kafka opens a lot of sockets.
 node.default[:kafka][:ulimit_file] = 32_768

--- a/cookbooks/bcpc_kafka/recipes/zookeeper_server.rb
+++ b/cookbooks/bcpc_kafka/recipes/zookeeper_server.rb
@@ -13,9 +13,8 @@ include_recipe 'bcpc_kafka::default'
 
 # For the time being, this will have to be force_override.
 node.force_override[:bcpc][:hadoop][:kerberos][:enable] = false
-
-# Install jolokia's jvm agent to node['bcpc']['jolokia']['path']
-include_recipe 'bcpc-hadoop::jolokia'
+node.force_override[:bcpc][:hadoop][:jmx_agent_enabled] = false
+node.force_override[:bcpc][:jolokia][:enable] = true
 
 include_recipe 'bcpc-hadoop::zookeeper_config'                                  
 include_recipe 'bcpc-hadoop::zookeeper_impl'


### PR DESCRIPTION
Since ``Jolokia`` agent is used to collect JMX stats from ``kafka``, want to use the same for the ``ZooKeeper`` processes on the ``Kafka`` clusters. By default enabling ``Jolokia`` agent is set to ``false`` so that ``jmx-agents`` will be used. When enabled, ``jmx-agents`` need to be [disabled](https://github.com/bloomberg/chef-bach/blob/56c6c208629e34c9a778bad75e489a360bcbcaaf/cookbooks/bcpc-hadoop/attributes/default.rb#L38).

*Note:* Not tested yet. Raised this to get early feedback.  