### PR TITLE
save the queries to normal precedence, to replace previously saved ones.

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/journalnode_queries.rb
+++ b/cookbooks/bcpc-hadoop/recipes/journalnode_queries.rb
@@ -2,7 +2,7 @@ triggers_sensitivity = '10m'
 txid_threshold = node['bcpc']['hadoop']['journalnode']['alarm']['trigger_cond']['LastWrittenTxId']
 epoch_threshold = node['bcpc']['hadoop']['journalnode']['alarm']['trigger_cond']['LastWriterEpoch']
 
-node.default['bcpc']['hadoop']['graphite']['service_queries']['journalnode'] = {
+node.set['bcpc']['hadoop']['graphite']['service_queries']['journalnode'] = {
   'journalnode.LastWrittenTxId' => {
     'query' => "rangeOfSeries(jmx.journalnode.#{node.chef_environment}.*.journal_node.Journal-#{node.chef_environment}.LastWrittenTxId)",
     'trigger_val' => "min(#{triggers_sensitivity})",


### PR DESCRIPTION
Should use normal precedence to replace previously saved value, since attributes at different precedence level merges rather than replaces. The queries will end up with a mix of old and new values.
```
chef (12.19.36)> pp node.debug_value('bcpc', 'hadoop', 'graphite', 'service_queries', 'journalnode')
[["default",
  {"journalnode.LastWrittenTxId"=>
    {"query"=> "rangeOfSeries(jmx.journalnode.<chef_env>.*.journal_node.Journal-<chef_env>.LastWrittenTxId)", ...
   "journalnode.LastWriterEpoch"=>
    {"query"=> "rangeOfSeries(jmx.journalnode.<chef_env>.*.journal_node.Journal-<chef_env>.LastWriterEpoch)", ...
 ["env_default", :not_present],
 ["role_default", :not_present],
 ["force_default", :not_present],
 ["normal",
  {"journalnode.LastWrittenTxId"=>
    {"query"=> "rangeOfSeries(jmx.journalnode.*.journal_node.Journal-<chef_env>.LastWrittenTxId)",...
   "journalnode.LastPromisedEpoch"=>
    {"query"=> "rangeOfSeries(jmx.journalnode.*.journal_node.Journal-<chef_env>.LastPromisedEpoch)",...
```