### PR TITLE
Changes to enable HBase regionserver groups

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/hbase.rb
+++ b/cookbooks/bcpc-hadoop/attributes/hbase.rb
@@ -19,6 +19,7 @@ default["bcpc"]["hadoop"]["hbase"]["dfs"]["client"]["read"]["shortcircuit"]["buf
 default["bcpc"]["hadoop"]["hbase"]["regionserver"]["handler"]["count"] = 128
 # Interval in milli seconds when HBase major compaction need to be run. Disabled by default
 default["bcpc"]["hadoop"]["hbase"]["major_compact"]["time"] = 0
+default["bcpc"]["hadoop"]["hbase"]["rsgroup"]["enabled"] = false
 default["bcpc"]["hadoop"]["hbase"]["bucketcache"]["enabled"] = false
 default["bcpc"]["hadoop"]["hbase_rs"]["coprocessor"]["abortonerror"] = true
 default["bcpc"]["hadoop"]["hbase"]["blockcache"]["size"] = 0.4

--- a/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
@@ -137,6 +137,18 @@ if node["bcpc"]["hadoop"]["hbase"]["bucketcache"]["enabled"] == true then
   end
 end
 
+# If HBASE RS group is enabled the properties from this section will be included in hbase-site.xml
+#
+if node["bcpc"]["hadoop"]["hbase"]["rsgroup"]["enabled"] == true then
+  if generated_values['hbase.coprocessor.master.classes'].nil?
+    generated_values['hbase.coprocessor.master.classes'] = 'org.apache.hadoop.hbase.rsgroup.RSGroupAdminEndpoint'
+  else
+    generated_values['hbase.coprocessor.master.classes'] = generated_values['hbase.coprocessor.master.classes'] +
+                                                           ',org.apache.hadoop.hbase.rsgroup.RSGroupAdminEndpoint'
+  end
+  generated_values['hbase.master.loadbalancer.class'] = 'org.apache.hadoop.hbase.rsgroup.RSGroupBasedLoadBalancer'
+end
+
 #
 # if HBASE region replication is enabled the properties in this section will be included in hbase-site.xml
 #


### PR DESCRIPTION
PR includes changes to enable ``HBase`` region server groups and by default it is disabled.

Refer comments below for the verification for the changes.