### PR TITLE
Reindex by hand

### DIFF
--- a/cluster_assign_roles.rb
+++ b/cluster_assign_roles.rb
@@ -120,11 +120,10 @@ class ClusterAssignRoles
         break
       else
         if (ii % 60).zero?
-          reindex_chef_server if ii.zero?
           puts "Waiting for nodes to appear in search results (#{search})..."
         elsif ii == (timeout - 1)
           raise "Did not find indexed roles for #{fqdn_list} " \
-                "after #{timeout} secs!"
+                "after #{timeout} secs! Reindex by hand or wait again"
         end
         sleep 1
       end

--- a/cluster_assign_roles.rb
+++ b/cluster_assign_roles.rb
@@ -123,7 +123,9 @@ class ClusterAssignRoles
           puts "Waiting for nodes to appear in search results (#{search})..."
         elsif ii == (timeout - 1)
           raise "Did not find indexed roles for #{fqdn_list} " \
-                "after #{timeout} secs! Reindex by hand or wait again"
+                "after #{timeout} secs! Reindex by hand or wait again\n" \
+                'WARNING: Reindex is a dangerous cluster operation. Refer '\
+                'to runbooks for details.'
         end
         sleep 1
       end

--- a/lib/chef_node.rb
+++ b/lib/chef_node.rb
@@ -114,7 +114,9 @@ module BACH
             # iteration.
             elsif i == 179
               raise "Did not find indexed node for #{entry[:fqdn]} " \
-                "after #{timeout} secs! Reindex by hand or wait again"
+                "after #{timeout} secs! Reindex by hand or wait again.\n" \
+                'WARNING: Reindex is a dangerous cluster operation. Refer '\
+                'to runbooks for details.'
             end
             sleep 1
           end

--- a/lib/chef_node.rb
+++ b/lib/chef_node.rb
@@ -108,11 +108,13 @@ module BACH
             puts "Found #{entry[:fqdn]} in search index"
             return
           else
-            # the #times method counts up, not down, so i == 179 on the 180th iteration.
-            reindex_chef_server if i == 179
-
-            if i % 60 == 0
+            if i % 61 == 0
               puts "Waiting for #{entry[:fqdn]} to appear in Chef index..."
+            # the #times method counts up, not down, so i == 179 on the 180th
+            # iteration.
+            elsif ii == 179
+              raise "Did not find indexed node for #{entry[:fqdn]} " \
+                "after #{timeout} secs! Reindex by hand or wait again"
             end
             sleep 1
           end

--- a/lib/chef_node.rb
+++ b/lib/chef_node.rb
@@ -108,11 +108,11 @@ module BACH
             puts "Found #{entry[:fqdn]} in search index"
             return
           else
-            if i % 61 == 0
+            if i % 60 == 0
               puts "Waiting for #{entry[:fqdn]} to appear in Chef index..."
             # the #times method counts up, not down, so i == 179 on the 180th
             # iteration.
-            elsif ii == 179
+            elsif i == 179
               raise "Did not find indexed node for #{entry[:fqdn]} " \
                 "after #{timeout} secs! Reindex by hand or wait again"
             end

--- a/setup_chef_server.sh
+++ b/setup_chef_server.sh
@@ -46,6 +46,10 @@ else
   printf "chef_server_webui['enable'] = false\n" >> /etc/chef-server/chef-server.rb
   printf "nginx['enable_non_ssl'] = false\n" >> /etc/chef-server/chef-server.rb
   printf "nginx['non_ssl_port'] = 4000\n" >> /etc/chef-server/chef-server.rb
+  # Configure Solr to index right away when we a new node.  
+  # Reference: https://docs.chef.io/config_rb_server.html#opscode-solr4
+  # Called opscode_solr4 in chef-server 12+
+  printf "chef_solr['max_commit_docs'] = 1\n" >> /etc/chef-server/chef-server.rb
   # we can take about 45 minutes to Chef the first machine when running on VMs
   # so follow tuning from CHEF-4253
   printf "erchef['s3_url_ttl'] = 3600\n" >> /etc/chef-server/chef-server.rb


### PR DESCRIPTION
by setting the update interval to every 1 node object, `c-a-r` runs fast and doesn't wait very long to get a correct index :O

To update the chef-server:

1.  update `/etc/chef-server/chef-server.rb`
2.  run `chef-server-ctl reconfigure`
3.  restart solr `chef-server-ctl restart chef-solr`


Downsides: since indexing (not reindexing) happens more often, the chef-server sometimes responds with a 500.  Saw it once while fiddling with my VM cluster.