### PR TITLE
Rollup of changes from dev Kafka

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -34,7 +34,6 @@ default['bcpc']['hadoop']['hdfs']['dfs_blocksize'] = '128m'
 default['bcpc']['hadoop']['hdfs_url'] = "hdfs://#{node.chef_environment}"
 default['bcpc']['hadoop']['jmx_enabled'] = false
 default['bcpc']['hadoop']['jmx_agent_enabled'] = true
-default['bcpc']['hadoop']['java_https_keystore'] = '/usr/local/maven/conf/keystore'
 
 # for jvmkill library
 default['bcpc-hadoop']['jvmkill']['lib_file'] = '/var/lib/jvmkill/libjvmkill.so'
@@ -171,3 +170,7 @@ default['java']['oracle']['jce']['8']['url'] = get_binary_server_url + jce_tgz_n
 
 # Set the JAVA_HOME for Hadoop components
 default['bcpc']['hadoop']['java'] = '/usr/lib/jvm/java-8-oracle-amd64'
+
+# See bcpc-hadoop::ssl_configuration
+default['bcpc']['hadoop']['java_ssl']['keystore'] = '/etc/bach/tls/keystore'
+default['bcpc']['hadoop']['java_ssl']['password'] = 'changeit'

--- a/cookbooks/bcpc-hadoop/attributes/jolokia.rb
+++ b/cookbooks/bcpc-hadoop/attributes/jolokia.rb
@@ -26,6 +26,7 @@
 # independent port.
 #
 node.default['bcpc']['jolokia'].tap do |jolokia|
+  jolokia['enable'] = false
   jolokia['policy_path'] = '/etc/bach/jolokia_security_policy.xml'
   jolokia['jar_path'] = '/usr/local/jolokia/lib/jolokia-jvm.jar'
   jolokia['host'] = '0.0.0.0'

--- a/cookbooks/bcpc-hadoop/recipes/ssl_configuration.rb
+++ b/cookbooks/bcpc-hadoop/recipes/ssl_configuration.rb
@@ -1,0 +1,166 @@
+#
+# Cookbook Name:: bcpc-hadoop
+# Recipe:: ssl_configuration
+#
+# Copyright 2017, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# On the bootstrap, this recipe searches
+# /usr/local/share/ssl/ca-certificates for locally provided
+# certificates, and uploads them to a data bag for later use by
+# clients.
+#
+# On clients, this recipe pulls down data bag items and configures
+# them in the necessary SSL repositories.
+#
+
+# This glob is used both on the bootstrap AND on the clients.
+custom_certs_glob = '/usr/local/share/ca-certificates/**/*'
+
+if node[:fqdn] == get_bootstrap
+  #
+  # If we're on the bootstrap, we need to load all custom certs and
+  # save them as data bag items.
+  #
+  ruby_block 'Upload Certificates' do
+    block do
+      require 'base64'
+      require 'openssl'
+
+      custom_certs = Dir.glob(custom_certs_glob).select do |ff|
+        ::File.file?(ff)
+      end
+
+      if(!Chef::DataBag.list.key?('ca_certificates'))
+        Chef::DataBag.new.tap do |bb|
+          bb.name('ca_certificates')
+          bb.create
+        end
+      end
+
+      custom_certs.each do |pp|
+        raw_data = File.read(pp)
+        certificate = OpenSSL::X509::Certificate.new(raw_data)
+
+        Chef::DataBagItem.new.tap do |dbi|
+          dbi.data_bag('ca_certificates')
+          dbi.raw_data = {
+                          'id' => certificate.subject.hash.to_s(16),
+                          'encoded_data' => Base64.encode64(raw_data)
+                         }
+          begin
+            dbi.create
+          rescue
+            dbi.save
+          end
+        end
+      end
+
+      node.run_state[:bcpc_ca_certificate_list] = custom_certs
+    end
+  end
+else
+  #
+  # If we're NOT on the bootstrap, we need to retrieve the custom
+  # certs and save them to local directories.
+  #
+  custom_ca_path = '/usr/local/share/ca-certificates/bloomberg'
+
+  directory custom_ca_path  do
+    action :create
+    mode 0755
+    user 'root'
+    group 'root'
+  end
+
+  node.run_state[:bcpc_ca_certificate_list] = []
+
+  ruby_block 'Download Certificates' do
+    block do
+      require 'base64'
+
+      dbi_names =
+        Chef::DataBag.list('ca_certificates')['ca_certificates'].keys rescue []
+
+      dbi_names.each do |dbi_name|
+        raw_data = Chef::DataBagItem.load('ca_certificates', dbi_name).raw_data
+
+        cert_path = File.join(custom_ca_path, raw_data['id'])
+
+        Chef::Resource::File.new(cert_path,
+                                 node.run_context).tap do |ff|
+          ff.user 'root'
+          ff.group 'root'
+          ff.mode 0444
+          ff.content Base64.decode64(raw_data['encoded_data'])
+          ff.run_action(:create)
+        end
+
+        node.run_state[:bcpc_ca_certificate_list] << cert_path
+      end
+    end
+  end
+end
+
+directory ::File.dirname(node['bcpc']['hadoop']['java_ssl']['keystore']) do
+  user 'root'
+  group 'root'
+  mode 0755
+  action :create
+  recursive true
+end
+
+#
+# We create a new Java keystore in /etc/bach/tls/ rather than edit the
+# default one that comes with the JDK.
+#
+ruby_block 'Install certs into Java keystore' do
+  block do
+    require 'mixlib/shellout'
+    node.run_state[:bcpc_ca_certificate_list].each do |cert|
+      cert_alias = ::File.basename(cert)
+      keystore_path = node['bcpc']['hadoop']['java_ssl']['keystore']
+      keystore_password = node['bcpc']['hadoop']['java_ssl']['password']
+
+      not_if_command =
+        Mixlib::ShellOut.new("keytool -noprompt -v " \
+                             "-keystore #{keystore_path} " \
+                             "-storepass #{keystore_password} " \
+                             "-list " \
+                             "-alias #{cert_alias}")
+      not_if_command.run_command
+
+      Chef::Resource::Execute.new("install-#{::File.basename(cert)}",
+                                  node.run_context).tap do |ee|
+        ee.command "yes | keytool -v -alias #{cert_alias} -import " \
+          "-file #{cert} " \
+          "-keystore #{keystore_path} " \
+          "-storepass #{keystore_password} " \
+          "-trustcacerts"
+        if not_if_command.error?
+          ee.run_action(:run)
+        end
+      end
+    end
+  end
+end
+
+package 'ca-certificates' do
+  action :upgrade
+end
+
+# This will install CA certs into the normal root store in /etc/ssl.
+execute 'update-ca-certificates'

--- a/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
+++ b/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
@@ -25,6 +25,11 @@ link "/usr/bin/zookeeper-server-initialize" do
   to "/usr/hdp/current/zookeeper-client/bin/zookeeper-server-initialize"
 end
 
+#Install jolokia's jvm agent to node['bcpc']['jolokia']['path']
+if node[:bcpc][:jolokia][:enable] == true
+  include_recipe 'bcpc-hadoop::jolokia'
+end
+
 template "#{node[:bcpc][:hadoop][:zookeeper][:conf_dir]}/zookeeper-env.sh" do
   source "zk_zookeeper-env.sh.erb"
   mode 0644

--- a/cookbooks/bcpc-hadoop/recipes/zookeeper_server.rb
+++ b/cookbooks/bcpc-hadoop/recipes/zookeeper_server.rb
@@ -1,5 +1,4 @@
 include_recipe 'bcpc-hadoop::zookeeper_config'
-node.override['bcpc']['jolokia']['jvm_args'] = ''
 include_recipe 'bcpc-hadoop::zookeeper_impl'
 
 # Set Zookeeper related zabbix triggers

--- a/cookbooks/bcpc-hadoop/templates/default/zk_zookeeper-env.sh.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/zk_zookeeper-env.sh.erb
@@ -12,7 +12,12 @@ export ZOO_PID_DIR=/var/run/zookeeper
 export ZOOPIDFILE=$ZOO_PID_DIR/zookeeper-server
 export ZOOCFGDIR=<%= node['bcpc']['hadoop']['zookeeper']['conf_dir'] %>
 export ZOO_DATADIR_AUTOCREATE_DISABLE=1
-SERVER_JVMFLAGS="$SERVER_JVMFLAGS -Djute.maxbuffer=<%= node['bcpc']['hadoop']['jute']['maxbuffer']  %> <%= node['bcpc']['jolokia']['jvm_args'] %>"
+SERVER_JVMFLAGS="$SERVER_JVMFLAGS -Djute.maxbuffer=<%= node['bcpc']['hadoop']['jute']['maxbuffer']  %>"
+
+<% if node[:bcpc][:jolokia][:enable] %>
+SERVER_JVMFLAGS="$SERVER_JVMFLAGS <%= node['bcpc']['jolokia']['jvm_args'] %>"
+<% end %>
+
 CLIENT_JVMFLAGS="$CLIENT_JVMFLAGS -Djute.maxbuffer=<%= node['bcpc']['hadoop']['jute']['maxbuffer'] %>"
 <% if node['bcpc']['hadoop'].attribute?(:jmx_enabled) and node['bcpc']['hadoop']['jmx_enabled'] %>
 export JMXPORT=<%= @zk_jmx_port %>

--- a/cookbooks/bcpc_kafka/recipes/kafka.rb
+++ b/cookbooks/bcpc_kafka/recipes/kafka.rb
@@ -71,10 +71,12 @@ node.default[:kafka][:broker][:log][:dirs] = data_volumes.map do |dd|
 end
 
 # Install jolokia's jvm agent to node['bcpc']['jolokia']['path']
-include_recipe 'bcpc-hadoop::jolokia'
+if node[:bcpc][:jolokia][:enable] == true
+  include_recipe 'bcpc-hadoop::jolokia'
 
-# Add the jolokia agent to the Kafka broker's launch options
-node.default[:kafka][:generic_opts] = node[:bcpc][:jolokia][:jvm_args]
+  # Add the jolokia agent to the Kafka broker's launch options
+  node.default[:kafka][:generic_opts] = node[:bcpc][:jolokia][:jvm_args]
+end
 
 #
 # Increase the default ZK client message maximum via jute.maxbuffer

--- a/cookbooks/bcpc_kafka/recipes/kafka.rb
+++ b/cookbooks/bcpc_kafka/recipes/kafka.rb
@@ -76,6 +76,14 @@ include_recipe 'bcpc-hadoop::jolokia'
 # Add the jolokia agent to the Kafka broker's launch options
 node.default[:kafka][:generic_opts] = node[:bcpc][:jolokia][:jvm_args]
 
+#
+# Increase the default ZK client message maximum via jute.maxbuffer
+# system property.  Large topic/partition counts require >1MB
+# messages.
+#
+node.default[:kafka][:generic_opts] +=
+  " -Djute.maxbuffer=#{node[:bcpc][:hadoop][:jute][:maxbuffer] rescue 0xfffff}"
+
 # Increase the default FD limit -- kafka opens a lot of sockets.
 node.default[:kafka][:ulimit_file] = 32_768
 

--- a/cookbooks/bcpc_kafka/recipes/kafka.rb
+++ b/cookbooks/bcpc_kafka/recipes/kafka.rb
@@ -134,3 +134,12 @@ ruby_block 'kafkaup' do
     end
   end
 end
+
+#
+# By default, the upstream cookbook sets server.properties to 600.
+# For internal reasons, we prefer it to be world-readable.
+#
+edit_resource!(:template,
+               ::File.join(node['kafka']['config_dir'], 'server.properties')) do
+  mode 0644
+end

--- a/cookbooks/bcpc_kafka/recipes/kafka.rb
+++ b/cookbooks/bcpc_kafka/recipes/kafka.rb
@@ -19,6 +19,7 @@
 
 include_recipe 'bcpc_kafka::default'
 
+node.force_override[:bcpc][:jolokia][:enable] = true
 #
 # We need node search to set a reasonable value for num.partitions, so
 # the value from the attributes file must be overriden.

--- a/cookbooks/bcpc_kafka/recipes/zookeeper_server.rb
+++ b/cookbooks/bcpc_kafka/recipes/zookeeper_server.rb
@@ -13,9 +13,8 @@ include_recipe 'bcpc_kafka::default'
 
 # For the time being, this will have to be force_override.
 node.force_override[:bcpc][:hadoop][:kerberos][:enable] = false
-
-# Install jolokia's jvm agent to node['bcpc']['jolokia']['path']
-include_recipe 'bcpc-hadoop::jolokia'
+node.force_override[:bcpc][:hadoop][:jmx_agent_enabled] = false
+node.force_override[:bcpc][:jolokia][:enable] = true
 
 include_recipe 'bcpc-hadoop::zookeeper_config'                                  
 include_recipe 'bcpc-hadoop::zookeeper_impl'


### PR DESCRIPTION
This PR contains three minor changes from our discoveries in our dev Kafka environment, and one larger change to simplify VM builds using maven

The minor changes:
- Make Kafka's broker configuration world-readable, as our tenants have repeatedly asked us
- Update the jute.maxbuffer value for the ZK client in Kafka brokers
- Correct Jolokia configuration for Zookeeper nodes

The larger change:

This PR uploads all local CA certificates from the Bootstrap to the Chef server, then has clients download them.  This makes it possible for maven and other tools to pass through a MitM proxy successfully.

This PR includes the changes from Biju's PR #1131, but now with the SSL support needed to avoid adding new things to `bins`.