### PR TITLE
add a function to get ip list of head nodes

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -239,6 +239,15 @@ def get_head_node_names
   end.compact.sort
 end
 
+# returns a list of head nodes local IPs
+# NOTE: 1. is supposed to obtain from cluster.txt
+#       2. the ip list is sorted
+def get_static_head_node_local_ip_list
+  get_head_nodes.map do |nn|
+    nn[:ip_address]
+  end.compact.sort
+end
+
 def get_nodes_for(recipe, cookbook=cookbook_name)
   results = Chef::Search::Query.new.search(
     :node, "recipes:#{cookbook}\\:\\:#{recipe} AND " \

--- a/cookbooks/bcpc/recipes/certs.rb
+++ b/cookbooks/bcpc/recipes/certs.rb
@@ -71,17 +71,16 @@ end
 # 2. head nodes machine IP and hostnames
 ip_list = [node['bcpc']['management']['vip']]
 dns_list = [node['bcpc']['management']['viphost']]
-headnodes = get_head_nodes
-headnodes.each do |hh|
-  ip = hh['bcpc']['management']['ip']
+
+get_static_head_node_local_ip_list.each do |ip|
   ip_list.push(ip) unless ip.nil?
-  fqdn = hh['fqdn']
+end
+
+get_head_node_names.each do |fqdn|
   dns_list.push(fqdn) unless fqdn.nil?
 end
 
-ip_list.sort!
 Chef::Log.info("ssl-keypair: IP list=#{ip_list}")
-dns_list.sort!
 Chef::Log.info("ssl-keypair: DNS list=#{dns_list}")
 
 # construct the config file for generating the ssl keypair


### PR DESCRIPTION
node['bcpc']['management']['ip'] doesn't exist in the return of get_head_nodes after node search is removed and values are read from cluster.txt
Created a function to return head node ip list