### PR TITLE
Change to enable user to set custom Kafka znode

### DIFF
--- a/cookbooks/bcpc_kafka/attributes/default.rb
+++ b/cookbooks/bcpc_kafka/attributes/default.rb
@@ -16,6 +16,7 @@ default[:use_hadoop_zookeeper_quorum] = false
 default[:kafka][:automatic_start] = true
 default[:kafka][:automatic_restart] = true
 default[:kafka][:jmx_port] = node[:bcpc][:hadoop][:kafka][:jmx][:port]
+default[:kafka][:root_znode] = nil
 
 #
 # Kafka broker settings

--- a/cookbooks/bcpc_kafka/recipes/kafka.rb
+++ b/cookbooks/bcpc_kafka/recipes/kafka.rb
@@ -51,6 +51,10 @@ node.default[:kafka][:broker][:zookeeper][:connect] = get_head_nodes.map do |nn|
   float_host(nn[:fqdn])
 end.sort
 
+if node[:kafka].attribute?(:root_znode) && node[:kafka][:root_znode] != nil
+  node[:kafka][:broker][:zookeeper][:connect] += node[:kafka][:root_znode]
+end
+
 #
 # This is a list of paths for the kafka logs (actual topic data)
 #


### PR DESCRIPTION
Users can set a ``znode`` path in ``default[:kafka][:root_znode]`` attribute when creating a ``Kafka`` cluster. This will enable uses to use a single ``ZooKeeper`` quorum for multiple ``Kafka`` clusters by using different ``znode`` for each one of them.

**Note:** Tested with out setting any value to  ``default[:kafka][:root_znode]`` to make sure existing clusters doesn't break.