### PR TITLE
Change to enable users to set Kafka broker.rack property

### DIFF
--- a/cookbooks/bcpc_kafka/attributes/default.rb
+++ b/cookbooks/bcpc_kafka/attributes/default.rb
@@ -16,7 +16,17 @@ default[:use_hadoop_zookeeper_quorum] = false
 default[:kafka][:automatic_start] = true
 default[:kafka][:automatic_restart] = true
 default[:kafka][:jmx_port] = node[:bcpc][:hadoop][:kafka][:jmx][:port]
+
+#
+# ZooKeeper znode in the format /chroot to be used for the Kafka broker
+#
 default[:kafka][:root_znode] = nil
+
+#
+# Mapping of Kafka broker servers in a cluster to a rack id
+# e.g. {'bcpc-vm1' => 'rack1', 'bcpc-vm2' => 'rack2' ...}
+#
+default[:kafka][:node_rack_map] = {}
 
 #
 # Kafka broker settings

--- a/cookbooks/bcpc_kafka/recipes/kafka.rb
+++ b/cookbooks/bcpc_kafka/recipes/kafka.rb
@@ -51,8 +51,18 @@ node.default[:kafka][:broker][:zookeeper][:connect] = get_head_nodes.map do |nn|
   float_host(nn[:fqdn])
 end.sort
 
+#
+# Add znode to the zookeeper.connect property if it is set in attribute 
+#
 if node[:kafka].attribute?(:root_znode) && node[:kafka][:root_znode] != nil
   node[:kafka][:broker][:zookeeper][:connect] += node[:kafka][:root_znode]
+end
+
+#
+# Add broker.property property if it is defined for the node in attibute node[:kafka][:node_rack_map]
+#
+if node[:kafka].attribute?(:node_rack_map) && node[:kafka][:node_rack_map]["#{node[:hostname]}"] != nil
+  node[:kafka][:broker][:broker][:rack] += node[:kafka][:node_rack_map]["#{node[:hostname]}"]
 end
 
 #


### PR DESCRIPTION
Users can make ``Kafka`` rack aware by setting ``broker.rack`` property in ``server.properties`` file. This change will help users to do the same through ``chef-bach``.

**Note:** Tested to make sure that this change with default values will not break an existing cluster.