### PR TITLE
Properly backport #1155 to 3.3.x

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -229,7 +229,7 @@ end
 #       2. the ip list is sorted
 def get_static_head_node_local_ip_list
   get_head_nodes.map do |nn|
-    nn[:ip_address]
+    nn['bcpc']['management']['ip']
   end.compact.sort
 end
 


### PR DESCRIPTION
This fixes the new function backported from #1155, which returns no IPs on pre-#1009 clusters