### PR TITLE
Measure the root queue metrics

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/jmxtrans_agent.rb
+++ b/cookbooks/bcpc-hadoop/attributes/jmxtrans_agent.rb
@@ -926,8 +926,8 @@ default['bcpc']['hadoop']['jmxtrans_agent']['resourcemanager']['queries'] = defa
     'attributes' => 'NumActiveNMs'
   },
   {
-    'objectName' => 'Hadoop:service=ResourceManager,name=QueueMetrics,q0=root,user=*',
-    'resultAlias' => 'ResourceManager.%name%.%user%.#attribute#',
+    'objectName' => 'Hadoop:service=ResourceManager,name=QueueMetrics,*',
+    'resultAlias' => 'ResourceManager.%name%.%q0%_%q1%_%q2%.%user%.#attribute#',
     'attributes' =>
       'AppsRunning,' \
       'AppsPending,' \


### PR DESCRIPTION
This is how the YARN dashboard and /ws/v1/cluster/metrics endpoint
reports their cluster-wide resource usage.