### PR TITLE
Enable users to use non chef-bach ZooKeeper for Kafka

### DIFF
--- a/cookbooks/bcpc_kafka/attributes/default.rb
+++ b/cookbooks/bcpc_kafka/attributes/default.rb
@@ -16,6 +16,7 @@ default[:use_hadoop_zookeeper_quorum] = false
 default[:kafka][:automatic_start] = true
 default[:kafka][:automatic_restart] = true
 default[:kafka][:jmx_port] = node[:bcpc][:hadoop][:kafka][:jmx][:port]
+default[:kafka][:zookeeper_connect] = nil
 
 #
 # ZooKeeper znode in the format /chroot to be used for the Kafka broker

--- a/cookbooks/bcpc_kafka/recipes/kafka.rb
+++ b/cookbooks/bcpc_kafka/recipes/kafka.rb
@@ -39,21 +39,30 @@ package 'netcat-openbsd' do
 end
 
 #
-# In a standalone Kafka cluster, get_head_nodes will return the
-# Zookeeper servers.
+# If using non chef-back ZooKeeper quorum set the connection string in
+# attribute default[:kafka][:zookeeper_connect]
 #
-# In a mixed Hadoop/Kafka cluster, the regular Hadoop head nodes will
-# be running Zookeeper.
-#
-# See cookbooks/bcpc/libraries/utils.rb for details.
-#
-node.default[:kafka][:broker][:zookeeper][:connect] = get_head_nodes.map do |nn|
-  if node[:bcpc][:hadoop][:zookeeper].attribute?(:port) && node[:bcpc][:hadoop][:zookeeper][:port] != nil
-    float_host(nn[:fqdn])+":"+node[:bcpc][:hadoop][:zookeeper][:port].to_s
-  else
-    float_host(nn[:fqdn])
-  end
-end.sort
+if node[:kafka].attribute?(:zookeeper_connect) && node[:kafka][:zookeeper_connect] != nil
+  node.default[:kafka][:broker][:zookeeper][:connect] = node[:kafka][:zookeeper_connect]
+else
+  #
+  # In a standalone Kafka cluster, get_head_nodes will return the
+  # Zookeeper servers.
+  #
+  # In a mixed Hadoop/Kafka cluster, the regular Hadoop head nodes will
+  # be running Zookeeper.
+  #
+  # See cookbooks/bcpc/libraries/utils.rb for details.
+  #
+  node.default[:kafka][:broker][:zookeeper][:connect] = get_head_nodes.map do |nn|
+    if node[:bcpc][:hadoop][:zookeeper].attribute?(:port) && node[:bcpc][:hadoop][:zookeeper][:port] != nil
+      float_host(nn[:fqdn])+":"+node[:bcpc][:hadoop][:zookeeper][:port].to_s
+    else
+      float_host(nn[:fqdn])
+    end
+  end.sort
+
+end
 
 #
 # Add znode to the zookeeper.connect property if it is set in attribute 
@@ -65,8 +74,8 @@ end
 #
 # Add broker.property property if it is defined for the node in attibute node[:kafka][:node_rack_map]
 #
-if node[:kafka].attribute?(:node_rack_map) && node[:kafka][:node_rack_map]["#{node[:hostname]}"] != nil
-  node[:kafka][:broker][:broker][:rack] += node[:kafka][:node_rack_map]["#{node[:hostname]}"]
+if node[:kafka].attribute?(:node_rack_map) && node[:kafka][:node_rack_map][node[:hostname]] != nil
+  node.default[:kafka][:broker][:broker][:rack] = node[:kafka][:node_rack_map][node[:hostname]]
 end
 
 #
@@ -133,8 +142,12 @@ ruby_block 'kafkaup' do
     zk_hosts =
       node[:kafka][:broker][:zookeeper][:connect]
 
-    zk_connection_string =
-      zk_hosts.map { |zkh| "#{zkh}" }.join(',')
+    if node[:kafka].attribute?(:zookeeper_connect) && node[:kafka][:zookeeper_connect] != nil
+      zk_connection_string = node[:kafka][:zookeeper_connect]
+    else
+      zk_connection_string =
+        zk_hosts.map { |zkh| "#{zkh}" }.join(',')
+    end
 
     Chef::Log.info("Zookeeper hosts are #{zk_connection_string}")
 


### PR DESCRIPTION
Users can set ``default[:kafka][:zookeeper_connect] `` with the ``ZK`` connection string in the format ``zkhost:port,zkhost:port,zkhost:port/zknode`` where ``zknode`` is optional if a non ``chef-bach`` ZooKeeper quorum need to be used with ``Kafka``. 