### PR TITLE
Use maven central and a default trust store

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/maven.rb
+++ b/cookbooks/bcpc-hadoop/attributes/maven.rb
@@ -19,3 +19,6 @@
 # configured as the default value, so we are obliged to override it.
 #
 default['maven']['repositories'] = ['http://repo1.maven.apache.org/maven2']
+
+# This is used in a maven_settings resource to configure plugin repos.
+default[:bach][:maven][:central_mirror] = nil

--- a/cookbooks/bcpc-hadoop/recipes/maven_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/maven_config.rb
@@ -61,6 +61,17 @@ unless node['bcpc']['bootstrap']['proxy'].nil?
   end
 end
 
+if node['bach']['maven']['central_mirror']
+  maven_settings 'settings.mirrors' do
+    value 'mirror' => {
+                       'id' => 'primary-mirror',
+                       'name' => 'Chef-configured primary mirror',
+                       'mirrorOf' => 'central',
+                       'url' => node['bach']['maven']['central_mirror']
+                      }
+  end
+end
+
 # it looks like the Maven cookbook uses the default
 # restrictive umask from Chef-Client
 execute 'chmod maven' do


### PR DESCRIPTION
This should remedy the problems encountered in issue #1175.

This PR contains two fixes:
- On nodes with no custom certificates, the trust store in `/etc/bach/tls` becomes a link to the Java default keystore.  This fixes the missing keystore on some clusters.
- A `maven_settings` resource is used to insert our local mirrors as a global maven configuration.  This is necessary not for jar deployment, but for maven plugin installation. 