### PR TITLE
--no-use-wheel is deprecated

### DIFF
--- a/cookbooks/bach_repository/recipes/python.rb
+++ b/cookbooks/bach_repository/recipes/python.rb
@@ -85,7 +85,7 @@ end
 ].each do |package_name, min_version|
   execute "new-pip-upgrade-#{package_name}" do
     command '/usr/local/bin/pip ' \
-      "install #{package_name} --upgrade " \
+      "install #{package_name} --no-binary=:all: --upgrade " \
       "#{pip_cert_option} #{pip_cheese_shop_option}"
     environment pip_environment
     not_if do


### PR DESCRIPTION
got an error when building a vm cluster
```
    ================================================================================
    Error executing action `run` on resource 'execute[new-pip-upgrade-packaging]'
    ================================================================================
    
    Mixlib::ShellOut::ShellCommandFailed
    ------------------------------------
    Expected process to exit with [0], but received '2'
    ---- Begin output of /usr/local/bin/pip install packaging --no-use-wheel --upgrade   ----
    STDOUT: 
    STDERR: Usage:   
      pip install [options] <requirement specifier> [package-index-options] ...
      pip install [options] -r <requirements file> [package-index-options] ...
      pip install [options] [-e] <vcs project url> ...
      pip install [options] [-e] <local project path> ...
      pip install [options] <archive url/path> ...
    
    no such option: --no-use-wheel
    ---- End output of /usr/local/bin/pip install packaging --no-use-wheel --upgrade   ----
    Ran /usr/local/bin/pip install packaging --no-use-wheel --upgrade   returned 2
```
from pip install help
```
  --no-use-wheel              Do not Find and prefer wheel archives when searching indexes and find-links locations. DEPRECATED in favour of --no-binary.```