### PR TITLE
Revert "Enable users to use non chef-bach ZooKeeper for Kafka"

### DIFF
--- a/cookbooks/bcpc_kafka/attributes/default.rb
+++ b/cookbooks/bcpc_kafka/attributes/default.rb
@@ -16,7 +16,6 @@ default[:use_hadoop_zookeeper_quorum] = false
 default[:kafka][:automatic_start] = true
 default[:kafka][:automatic_restart] = true
 default[:kafka][:jmx_port] = node[:bcpc][:hadoop][:kafka][:jmx][:port]
-default[:kafka][:zookeeper_connect] = nil
 
 #
 # ZooKeeper znode in the format /chroot to be used for the Kafka broker


### PR DESCRIPTION
Reverts bloomberg/chef-bach#1174

These changes turned out to be totally unnecessary.

`node[:kafka][:broker][:zookeeper][:connect]` can be overriden directly in the environment, without a new attribute or any copying inside the chef code.