### PR TITLE
Bug fixes against 3.4.0

### DIFF
--- a/cookbooks/bcpc_kafka/recipes/kafka.rb
+++ b/cookbooks/bcpc_kafka/recipes/kafka.rb
@@ -133,7 +133,8 @@ ruby_block 'kafkaup' do
       "/brokers/ids/#{node[:kafka][:broker][:broker_id]}"
 
     # We are using the same connection string that Kafka itself does.
-    zk_connection_string = node[:kafka][:broker][:zookeeper][:connect]
+    zk_connection_string =
+      node[:kafka][:broker][:zookeeper][:connect].join(',')
 
     Chef::Log.info("Zookeeper hosts are #{zk_connection_string}")
 

--- a/lib/cluster-def-gem/lib/cluster_def.rb
+++ b/lib/cluster-def-gem/lib/cluster_def.rb
@@ -67,7 +67,7 @@ module BACH
     def validate_node_number?(nn)
       # node number must either be '-' or a positive integer
       # 1..255
-      if nn != '-' && nn.to_i < 1 || nn.to_i > 255 then
+      if nn != '-' && nn.to_i < 1 || nn.to_i > 2_147_483_646 then
         false
       else
         true
@@ -84,7 +84,7 @@ module BACH
         end
         # validate node ids 
         if (cluster_def.select{ |row| validate_node_number?(row[:node_id]) == false }).length.positive?  then
-          fail "Retreived cluster data appears to be invalid -- node IDs must be positive integers between 0 and 256 (1..255)"
+          fail "Retreived cluster data appears to be invalid -- node IDs must be positive integers"
         end 
     end
 


### PR DESCRIPTION
These changes were necessary to successfully chef an existing cluster with v3.4.0.
- Kafka connection strings are stored in the attribute tree as an array, only joined to a string in a template.  We had incorrectly formatted it as a string.
- Node numbers are already well over 8 bits unsigned in production clusters, and there's no known way to change the node number once assigned.  So it was necessary to loosen the restrictions in the cluster_def gem.

The connection string fix is already present in the release-3.4 branch.

A new 3.4.1 will be required to merge the node number issue.