### PR TITLE
Remove hypervisor's dependency on the Gemfile

### DIFF
--- a/vm-to-cluster.sh
+++ b/vm-to-cluster.sh
@@ -11,16 +11,4 @@ REPO_DIR="`dirname ${BASH_SOURCE[0]}`"
 cd $REPO_DIR
 . ./proxy_setup.sh
 
-# Iterate over a list of "<dpkg name> <gem name>" necessary for the Gemfile
-for p in "libaugeas-dev ruby-augeas" "libmysqlclient-dev mysql2" "libmysqld-dev mysql2" "libkrb5-dev rkerberos"; do 
-  if [ $(dpkg-query -W -f='${Status}' ${p% *} 2>/dev/null | grep -c 'ok installed') -ne 1 ] && [ "$(uname)" != "Darwin" ]; then
-    echo "#### Need ${p% *} for the ${p#* } Gem" > /dev/stderr
-    sudo apt-get install -y ${p% *}
-  fi
-done
-
-export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig
-bundle config --local PATH vendor/bundle
-bundle config --local DISABLE_SHARED_GEMS true
-bundle package --path vendor/bundle
-bundle exec --keep-file-descriptors ./vm_to_cluster.rb $*
+./vm_to_cluster.rb $*


### PR DESCRIPTION
Tested and confirmed that the cluster.txt generation still works.

Scripts on the hypervisor are supposed to be designed to be minimal
anyway.