### PR TITLE
Correctly handle node numbers over 255 in ZK templates

### DIFF
--- a/cookbooks/bcpc-hadoop/templates/default/zk_zoo.cfg.erb
+++ b/cookbooks/bcpc-hadoop/templates/default/zk_zoo.cfg.erb
@@ -36,8 +36,8 @@ dataLogDir=<%= node[:bcpc][:hadoop][:zookeeper][:data_log_dir] %>
 clientPort=<%= node[:bcpc][:hadoop][:zookeeper][:port] %>
 clientPortAddress=<%= float_host(node[:hostname]) %>
 
-<% @zk_hosts.sort{ |a,b| a[:fqdn] <=> b[:fqdn] }.each do |s| %> 
-<%="server.#{s[:node_id]}=#{float_host(s[:fqdn])}:#{node[:bcpc][:hadoop][:zookeeper][:leader_connect][:port]}:#{node[:bcpc][:hadoop][:zookeeper][:leader_elect][:port]}" %>
+<% @zk_hosts.sort{ |aa,bb| aa[:fqdn] <=> bb[:fqdn] }.each do |ss| %>
+<%="server.#{bcpc_8bit_node_number(ss)}=#{float_host(ss[:fqdn])}:#{node[:bcpc][:hadoop][:zookeeper][:leader_connect][:port]}:#{node[:bcpc][:hadoop][:zookeeper][:leader_elect][:port]}" %>
 <% end %>
 
 <% if node[:bcpc][:hadoop][:kerberos][:enable] == true then %>


### PR DESCRIPTION
Applying v3.4.1 to an existing hardware cluster will fail catastrophically due to disagreements between Zookeeper `myid` and greater-than-255 node numbers.

This change prevents the catastrophe.   It is a partial fix for issue #1144 