### PR TITLE
Setting HBase GC log file size and number of files for retention

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
@@ -12,6 +12,9 @@ common_opts =
   ' -XX:+PrintGCDateStamps' \
   ' -XX:+UseParNewGC' \
   ' -Xloggc:${HBASE_LOG_DIR}/gc/gc-pid-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log' \
+  ' -XX:+UseGCLogFileRotation' \
+  ' -XX:NumberOfGCLogFiles=20' \
+  ' -XX:GCLogFileSize=20M' \
   ' -XX:+ExplicitGCInvokesConcurrent' \
   ' -XX:+PrintTenuringDistribution' \
   ' -XX:+UseNUMA' \


### PR DESCRIPTION
Changes to use GC log rotation, set log file size and number of ``HBase`` GC files for retention.