### PR TITLE
Set unique name for Kafka GC logs and set log size

### DIFF
--- a/cookbooks/bcpc_kafka/attributes/default.rb
+++ b/cookbooks/bcpc_kafka/attributes/default.rb
@@ -84,3 +84,15 @@ default[:kafka][:md5_checksum] = ''
 # (/disk/0 is a mount point created by the bcpc-hadoop::disks recipe)
 #
 default[:kafka][:log_dir] = '/disk/0/kafka/logs'
+
+#
+# Kafka GC log settings
+#
+default['kafka']['gc_log_opts'] = %W[
+  -Xloggc:#{::File.join(node['kafka']['log_dir'], 'kafka-gc-pid-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log')}
+  -XX:+UseGCLogFileRotation
+  -XX:NumberOfGCLogFiles=20
+  -XX:GCLogFileSize=20M
+  -XX:+PrintGCDateStamps
+  -XX:+PrintGCTimeStamps
+].join(' ')


### PR DESCRIPTION
- Sets unique name for ``Kafka`` GC logs
- Rolls out GC logs after 20 files
- Each log file is set to 20 M size which translated to 400 MB of GC logs in case we need history.