### PR TITLE
enable client connection log

### DIFF
--- a/cookbooks/bcpc/templates/default/carbon/carbon.conf.erb
+++ b/cookbooks/bcpc/templates/default/carbon/carbon.conf.erb
@@ -346,7 +346,6 @@ ENABLE_TAGS = False
 # In order to turn off logging of successful connections for the line
 # receiver, set this to False
 # LOG_LISTENER_CONN_SUCCESS = True
-LOG_LISTENER_CONN_SUCCESS = False
 
 [relay]
 # LINE_RECEIVER_INTERFACE = 0.0.0.0
@@ -489,7 +488,6 @@ METRIC_CLIENT_IDLE_TIMEOUT = <%="#{node[:bcpc][:graphite][:carbon][:relay][:idle
 # In order to turn off logging of successful connections for the line
 # receiver, set this to False
 # LOG_LISTENER_CONN_SUCCESS = True
-LOG_LISTENER_CONN_SUCCESS = False
 
 # If you're connecting from the relay to a destination that's over the
 # internet or similarly iffy connection, a backlog can develop because
@@ -615,7 +613,6 @@ MAX_AGGREGATION_INTERVALS = 5
 # In order to turn off logging of successful connections for the line
 # receiver, set this to False
 # LOG_LISTENER_CONN_SUCCESS = True
-LOG_LISTENER_CONN_SUCCESS = False
 
 # In order to turn off logging of metrics with no corresponding
 # aggregation rules receiver, set this to False


### PR DESCRIPTION
the message of sending queue is full is reported in this log, should be enabled.