### PR TITLE
Split gemfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ rvm:
   - 2
 bundler_args: --without cookbooks
 cache: bundler
-gemfile: Gemfile
+gemfile: gemfiles/bootstrap.gemfile
 before_install:
   - chef --version &> /dev/null || curl -L https://www.getchef.com/chef/install.sh | sudo bash -s -- -P chefdk -v 1.2.22
   - eval "$(/opt/chefdk/bin/chef shell-init bash)"
-  - bundle config --local PATH vendor/bundle
+  - bundle config --local PATH vendor/bootstrap
   - bundle config --local DISABLE_SHARED_GEMS true
 before_script:
   - chef --version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,9 +69,9 @@ This process is to run tests using ChefDK. It is also possible to run using pure
 * `export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig`
 * `cd ~vagrant/chef-bcpc`
 * `source proxy_setup.sh`
-* `bundler install --path vendor/bundle`
+* `bundler install --path vendor/bootstrap`
 * `bundler exec rspec`
-* `for c in cookbooks/*; do pushd $c; bundler install --path vendor/bundle && bundler exec rspec || echo "Failed in $c" 1>&2 ; popd; done`
+* `for c in cookbooks/*; do pushd $c; bundler install --path vendor/bootstrap && bundler exec rspec || echo "Failed in $c" 1>&2 ; popd; done`
 
 ## Test-Kitchen
 * `export PATH=/opt/chefdk/embedded/bin:$PATH`

--- a/archive_bins.sh
+++ b/archive_bins.sh
@@ -16,7 +16,7 @@ set -x
 
 vagrant ssh -c "tar cvpzf ~/${tarball_name} -C ~/chef-bcpc \
     --exclude=bins/apt_key.*  \
-    bins vendor/bundle vendor/cache Gemfile.lock" | log_pretty
+    bins vendor/bootstrap vendor/cache gemfiles/*.gemfile.lock" | log_pretty
 vagrant ssh -c "cp -fv  ~/${tarball_name} \
     /chef-bcpc-host/${tarball_name}" | log_pretty
 mv -v ${tarball_name} ../${tarball_name} | log_pretty

--- a/cluster-assign-roles.sh
+++ b/cluster-assign-roles.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This shell stub invokes the cluster_assign_roles.rb script using the
-# binary gems pre-installed in vendor/bundle.
+# binary gems pre-installed in vendor/bootstrap.
 #
 # See cluster_assign_roles.rb for a detailed description.
 #
@@ -9,6 +9,4 @@ export PATH=/opt/chefdk/embedded/bin:/usr/bin:/bin
 
 REPO_DIR="`dirname ${BASH_SOURCE[0]}`"
 cd $REPO_DIR
-bundle config --local PATH vendor/bundle
-bundle config --local DISABLE_SHARED_GEMS true
 bundle exec --keep-file-descriptors ./cluster_assign_roles.rb $*

--- a/gemfiles/bootstrap.gemfile
+++ b/gemfiles/bootstrap.gemfile
@@ -1,4 +1,9 @@
 # -*- mode: enh-ruby -*-
+# This Gemfile represents dependencies needed by the Bootstrap to run various
+# bootstrap-related scripts:
+#   * cluster-assign-roles.sh
+#   * repxe-host.sh
+#   * wait-for-hosts.sh
 ruby RUBY_VERSION
 # These versions are pinned to match Chef --
 # to avoid having different Ruby versions try Chef before ChefDK

--- a/gemfiles/bootstrap.gemfile
+++ b/gemfiles/bootstrap.gemfile
@@ -31,8 +31,10 @@ else
   end
 end
 
+bach_root = File.expand_path(File.join(File.dirname(__FILE__), '../'))
+
 gem 'fpm'
-gem 'cluster_def', :path => 'lib/cluster-def-gem'
+gem 'cluster_def', :path => File.join(bach_root, 'lib/cluster-def-gem')
 
 source 'https://rubygems.org' do
   gem 'faker'
@@ -47,7 +49,7 @@ end
 
 # Pull in the other Gemfiles from our cookbooks
 group :cookbooks do
-  Dir.glob(File.join(File.dirname(__FILE__), 'cookbooks',
+  Dir.glob(File.join(bach_root, 'cookbooks',
       '**', "Gemfile")) do |gemfile|
     eval(IO.read(gemfile), binding)
   end

--- a/gemfiles/hypervisor.gemfile
+++ b/gemfiles/hypervisor.gemfile
@@ -1,0 +1,6 @@
+# -*- mode: enh-ruby -*-
+# This Gemfile is supposed represent dependencies needed by scripts run inside
+# the Hypervisor.  This should be as small as possible
+#
+# A few scripts include:
+#   * vm-to-cluster.sh

--- a/gemfiles/nodes.gemfile
+++ b/gemfiles/nodes.gemfile
@@ -1,0 +1,3 @@
+# -*- mode: enh-ruby -*-
+# This Gemfile is supposed to mirror gems in the bootstrap so that it can be
+# downloaded by Chef Nodes

--- a/repxe-host.sh
+++ b/repxe-host.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This shell stub invokes the repxe_host.rb script using the
-# binary gems pre-installed in vendor/bundle.
+# binary gems pre-installed in vendor/bootstrap.
 #
 # See repxe_host.rb for a detailed description.
 #
@@ -9,7 +9,5 @@ export PATH=/opt/chefdk/embedded/bin:/usr/bin:/bin
 
 REPO_DIR="`dirname ${BASH_SOURCE[0]}`"
 cd $REPO_DIR
-bundle config --local PATH vendor/bundle
-bundle config --local DISABLE_SHARED_GEMS true
 bundle exec --keep-file-descriptors $PWD/repxe_host.rb $*
 

--- a/wait-for-hosts.sh
+++ b/wait-for-hosts.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This shell stub invokes the wait_for_hosts.rb script using the
-# binary gems pre-installed in vendor/bundle.
+# binary gems pre-installed in vendor/bootstrap.
 #
 # See wait_for_hosts.rb for a detailed description.
 #
@@ -9,6 +9,4 @@ export PATH=/opt/chefdk/embedded/bin:/usr/bin:/bin
 
 REPO_DIR="`dirname ${BASH_SOURCE[0]}`"
 cd $REPO_DIR
-bundle config --local PATH vendor/bundle
-bundle config --local DISABLE_SHARED_GEMS true
 bundle exec --keep-file-descriptors ./wait_for_hosts.rb $*


### PR DESCRIPTION
First phase of having bootstrap, chef nodes and hypervisor having different gem dependencies. will pave way to allow faster cluster builds (not installing `berkshelf` dependencies which take forever to build), prepare for chef 13 (no more `/opt/chef/Gemfile`), and having easier `Gemfile.lock` to debug and reason about.

* bootstrap.gemfile
* nodes.gemfile
* hypervisor.gemfile

Tested `cluster-assign-roles.sh`, `repxe-host.sh`, and `wait-for-host.sh`  (needed by `tests/automated_install.sh`) and verified that they still work 