### PR TITLE
Correct broken metadata

### DIFF
--- a/cookbooks/bach_deployment/attributes/default.rb
+++ b/cookbooks/bach_deployment/attributes/default.rb
@@ -1,6 +1,6 @@
 force_default['bach']['deploy']['appfile']['data'] = {
   appfoo: {
-    repo_url: 'http://bcpc.example.com'
+    repo_url: 'http://bcpc.example.com',
     copy_to: '',
     copy_type: 'file',
     runas: 'root',

--- a/cookbooks/hdfsdu/metadata.rb
+++ b/cookbooks/hdfsdu/metadata.rb
@@ -1,5 +1,6 @@
 name             'hdfsdu'
 maintainer       'Bloomberg Finance L.P.'
+maintainer_email 'hadoop@bloomberg.net'
 license          'Apache License 2.0'
 description      'Builds, installs and configures hdfsdu'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))


### PR DESCRIPTION
- Add missing comma to `bach_deployment` cookbook metadata
- Add missing maintainer_email field to `hdfsdu`