### PR TITLE
Revert to #corrected_mac(vm)

### DIFF
--- a/repxe_host.rb
+++ b/repxe_host.rb
@@ -118,7 +118,7 @@ def cobbler_enroll(entry)
                            '--profile', entry[:cobbler_profile],
                            '--ip-address', entry[:ip_address],
                            '--interface=eth0',
-                           '--mac', empirical_mac(entry))
+                           '--mac', corrected_mac(entry))
 
   c.run_command
   c.invalid! "Failed to enroll #{entry[:hostname]}!" unless c.status.success?


### PR DESCRIPTION
Tested in a VM cluster

`empirical_mac` is code only for Virtualbox VMs