### PR TITLE
Fixes for deployment issues in production

### DIFF
--- a/archive_bins.sh
+++ b/archive_bins.sh
@@ -16,7 +16,7 @@ set -x
 
 vagrant ssh -c "tar cvpzf ~/${tarball_name} -C ~/chef-bcpc \
     --exclude=bins/apt_key.*  \
-    bins vendor/bootstrap vendor/cache gemfiles/*.gemfile.lock" | log_pretty
+    bins vendor/bootstrap vendor/cache gemfiles" | log_pretty
 vagrant ssh -c "cp -fv  ~/${tarball_name} \
     /chef-bcpc-host/${tarball_name}" | log_pretty
 mv -v ${tarball_name} ../${tarball_name} | log_pretty

--- a/cookbooks/bach_repository/recipes/oracle_java.rb
+++ b/cookbooks/bach_repository/recipes/oracle_java.rb
@@ -33,10 +33,19 @@ end
 java_tgz_name = Pathname.new(node['bach']['repository']['java']['jdk_url'])\
                         .basename.to_s
 
-remote_file "#{bins_dir}/#{java_tgz_name}" do
+jdk_local_path = "#{bins_dir}/#{java_tgz_name}"
+
+remote_file jdk_local_path do
   source node['bach']['repository']['java']['jdk_url']
   user 'root'
   group 'root'
   mode 0444
   checksum node['bach']['repository']['java']['jdk_checksum']
+end
+
+ruby_block 'Copy JDK to file cache' do
+  block do
+    require 'fileutils'
+    ::FileUtils.cp(jdk_local_path, Chef::Config[:file_cache_path])
+  end
 end

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -121,6 +121,7 @@ default['bcpc']['bootstrap']['server'] = '10.0.100.3'
 default['bcpc']['bootstrap']['vip'] = node['bcpc']['bootstrap']['server']
 default['bcpc']['bootstrap']['dhcp_range'] = '10.0.100.14 10.0.100.250'
 default['bcpc']['bootstrap']['dhcp_subnet'] = '10.0.100.0'
+default['bcpc']['bootstrap']['cluster_def_path'] = '/cluster-def/'
 
 ###########################################
 #


### PR DESCRIPTION
I had to make these two fixes to deploy 3.5.0 to internet-disconnected hosts.

The first is a problem in the java cookbook.   It still attempts a download despite a local copy existing.  We copy it to the cache ahead of the cookbook to avoid the internet dependency.

The second is an issue in archive_bins.sh.  The escaping rules on `vagrant ssh -c` are complicated, and the wildcard is not expanded by the remote shell.  By removing the wildcard entirely, we can sweep up the split gemfiles.