### PR TITLE
Remove CLUSTER_PREFIX prepending to cluster.txt

### DIFF
--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -63,13 +63,6 @@ VBOX_DIR="`dirname ${BASH_SOURCE[0]}`/vbox"
 [[ -d $VBOX_DIR ]] || mkdir $VBOX_DIR
 VBOX_DIR_PATH=`python -c "import os.path; print os.path.abspath(\"${VBOX_DIR}/\")"`
 
-# ensure cluster.txt has CLUSTER_PREFIX prepended before VM names
-# NOTE: somewhat crude we see if any line does not start with the
-# cluster name and if so all lines have it prepended
-if [[ -n "$(grep -v "^${CLUSTER_PREFIX}" ./cluster.txt)" ]]; then
-  sed -i "s/^/${CLUSTER_PREFIX}-/" cluster.txt
-fi
-
 # Populate the VM list array from cluster.txt
 code_to_produce_vm_list="
 require './lib/cluster_data.rb';


### PR DESCRIPTION
In vbox_create.sh, this block of code tries to ensure each cluster.txt hostname starts with the cluster prefix. However, the format of cluster.txt has changed, so this will now prepend to the node-id rather than the hostname (CLUSTER_PREFIX-1 vs. CLUSTER_PREFIX-bcpc-vm1). Also, CLUSTER_PREFIX is the wrong environment variable for the cluster prefix. The correct environment variable is BACH_CLUSTER_PREFIX.

I think the block is unnecessary because the ruby script, "code_to_produce_vm_list" already prepends the cluster prefix to each vm hostname. It won't work correctly if the hostname already starts with the prefix. 
```
#Populate the VM list array from cluster.txt
code_to_produce_vm_list="
require './lib/cluster_data.rb';
include BACH::ClusterData;
cp=ENV.fetch('BACH_CLUSTER_PREFIX', '');
cp += '-' unless cp.empty?;
vms = parse_cluster_txt(File.readlines('cluster.txt'))
puts vms.map{|e| cp + e[:hostname]}.join(' ')
"
```
If we want to modify cluster.txt in the future, it may be better to use a perl regex to take advantage of the negative lookahead features not supported by sed.
```
# prepend the cluster prefix to the second token
# if [[ -n ${BACH_CLUSTER_PREFIX} ]]; then
#   echo "BACH_CLUSTER_PREFIX: ${BACH_CLUSTER_PREFIX}"
#   echo "Prepending Cluster Prefix to cluster.txt vms"
#   perl -pi -e 's/(\d+|-)\s+(?!'${BACH_CLUSTER_PREFIX}-')(\w+)/\1 '${BACH_CLUSTER_PREFIX}-'\2/' cluster.txt
# fi
```