### PR TITLE
Graphite 112 and zabbix 3

### DIFF
--- a/cookbooks/bach_repository/recipes/graphite.rb
+++ b/cookbooks/bach_repository/recipes/graphite.rb
@@ -71,21 +71,22 @@ epoch = Time.now.strftime('%s')
   },
   {
     name: 'carbon',
-    version: '1.1.1',
-    url: 'https://github.com/graphite-project/carbon/archive/1.1.1.tar.gz',
-    checksum: '913d0f1d1e8c69176c85c9b85b89c51333906da1280a1550efa013a55b5c2d72'
+    version: '1.1.2',
+    url: 'https://github.com/graphite-project/carbon/archive/1.1.2.tar.gz',
+
+    checksum: 'f0fa61ff9fb3f3c20a802ecbf2da2f11abcc04c41ec2139bfc3192b79b82bf7e'
   },
   {
     name: 'whisper',
-    version: '1.1.1',
-    url: 'https://github.com/graphite-project/whisper/archive/1.1.1.tar.gz',
-    checksum: '729a38c7794e0b4a34b40b4afb61703364905befcd2bcb5f8f48a4b79ea32667'
+    version: '1.1.2',
+    url: 'https://github.com/graphite-project/whisper/archive/1.1.2.tar.gz',
+    checksum: 'ad03a25f4d71ba5942c55b82267ece3b0b2881bbd7a84b513d78b15b5de9a8ba'
   },
   {
     name: 'graphite-web',
-    version: '1.1.1',
-    url: 'https://github.com/graphite-project/graphite-web/archive/1.1.1.tar.gz',
-    checksum: '6dfae92e0d0ef94e22934d7a0ddecc38b118015cbb20041a72cbe4ed98908a2a'
+    version: '1.1.2',
+    url: 'https://github.com/graphite-project/graphite-web/archive/1.1.2.tar.gz',
+    checksum: '8a36221db5a17d9cbee11e85be5c346024a6229d28e9d8c2417d1660bf9cfe8e'
   }
 ].each do |package|
 

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -176,7 +176,7 @@ default['bcpc']['repos_for']['trusty'].tap do |trusty_repos|
     repo[:components] = ['main']
     repo[:distribution] = 'trusty'
     repo[:key] = 'zabbix-official-repo.key'
-    repo[:uri] = 'http://repo.zabbix.com/zabbix/2.4/ubuntu/'
+    repo[:uri] = 'http://repo.zabbix.com/zabbix/3.0/ubuntu/'
   end
 end
 

--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -248,6 +248,10 @@ def get_static_head_node_local_ip_list
   end.compact.sort
 end
 
+def get_static_head_nodes_count
+  get_head_nodes.length
+end
+
 def get_nodes_for(recipe, cookbook=cookbook_name)
   results = Chef::Search::Query.new.search(
     :node, "recipes:#{cookbook}\\:\\:#{recipe} AND " \

--- a/cookbooks/bcpc/recipes/graphite.rb
+++ b/cookbooks/bcpc/recipes/graphite.rb
@@ -91,9 +91,6 @@ end
   end
 end
 
-# we need real node objects in order to extract the mgmt ip
-head_nodes = get_head_nodes
-
 # Directory resource sets owner and group only to the leaf directory.
 # All other directories will be owned by root
 directory node['bcpc']['graphite']['local_storage_dir'].to_s do
@@ -132,8 +129,8 @@ template '/opt/graphite/conf/carbon.conf' do
   group 'root'
   mode 0o0644
   variables(
-    'servers' => head_nodes,
-    'min_quorum' => head_nodes.length/2 + 1 )
+    'servers' => get_static_head_node_local_ip_list,
+    'min_quorum' => get_static_head_nodes_count/2 + 1 )
   notifies :restart, 'service[carbon-cache]', :delayed
   notifies :restart, 'service[carbon-aggregator]', :delayed
   notifies :restart, 'service[carbon-relay]', :delayed
@@ -160,7 +157,7 @@ template '/opt/graphite/conf/relay-rules.conf' do
   owner 'root'
   group 'root'
   mode 0o0644
-  variables( 'servers' => head_nodes )
+  variables( 'servers' => get_static_head_node_local_ip_list)
   notifies :restart, 'service[carbon-relay]', :delayed
 end
 
@@ -219,8 +216,8 @@ template '/opt/graphite/webapp/graphite/local_settings.py' do
   mode 0o0440
   variables(
     'web_port' => node['bcpc']['graphite']['web_port'],
-    'servers' => head_nodes,
-    'min_quorum' => head_nodes.length/2 + 1 )
+    'servers' => get_static_head_node_local_ip_list,
+    'min_quorum' => get_static_head_nodes_count/2 + 1 )
   notifies :restart, 'service[apache2]', :delayed
 end
 

--- a/cookbooks/bcpc/templates/default/carbon/carbon.conf.erb
+++ b/cookbooks/bcpc/templates/default/carbon/carbon.conf.erb
@@ -334,6 +334,9 @@ ENABLE_TAGS = False
 # There are separate queues for new series and for updates to existing series
 # TAG_QUEUE_SIZE = 10000
 
+# Set to enable Sentry.io exception monitoring.
+# RAVEN_DSN='YOUR_DSN_HERE'.
+
 # To configure special settings for the carbon-cache instance 'b', uncomment this:
 #[cache:b]
 #LINE_RECEIVER_PORT = 2103
@@ -518,6 +521,10 @@ MIN_RESET_RATIO=0.9
 # below (2*CARBON_METRIC_INTERVAL) + 1 second will result in a lot of
 # reset connections for no good reason.
 MIN_RESET_INTERVAL=121
+
+# Enable TCP Keep Alive (http://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html).
+# Default settings will send a probe every 30s. Default is False.
+# TCP_KEEPALIVE=True
 
 [aggregator]
 # LINE_RECEIVER_INTERFACE = 0.0.0.0

--- a/cookbooks/bcpc/templates/default/graphite/local_settings.py.erb
+++ b/cookbooks/bcpc/templates/default/graphite/local_settings.py.erb
@@ -169,7 +169,7 @@ DATABASES = {
 # remote server in the cluster. These servers must each have local access to
 # metric data. Note that the first server to return a match for a query will be
 # used.
-CLUSTER_SERVERS = [ <%="#{@servers.map{|hst| "\"#{hst[:ip_address]}:#{@web_port}\""}.sort.join(', ')}"%> ]
+CLUSTER_SERVERS = [ <%="#{@servers.map{|hst| "\"#{hst}:#{@web_port}\""}.sort.join(', ')}"%> ]
 INTRACLUSTER_HTTPS = <%="#{node['bcpc']['graphite']['web_https'] == true ? 'True' : 'False'}" %>
 ## These are timeout values (in seconds) for requests to remote webapps
 REMOTE_FIND_TIMEOUT = 6.0             # Timeout for metric find requests


### PR DESCRIPTION
graphite 1.1.1 has missing metrics issue due to a bug in the hashing function.
zabbix 2.4.8 is no longer supported and has bug in nodata( ) function.