### PR TITLE
Automated serial console connections, Cluster prefix idempotence, General shell script linting and documentation

### DIFF
--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -25,13 +25,12 @@ export BACH_REPO_DIR=$(git rev-parse --show-toplevel)
 export BACH_CLUSTER_DIR=${BACH_REPO_DIR}/../cluster
 
 if [[ $(pwd) != $BACH_REPO_DIR ]]; then
-  printf '#### WARNING: This should be run in the git top level directory! ####\n' >/dev/stderr
+  printf "#### WARNING: This should be run in the git top level directory! ####\n" >/dev/stderr
 fi
 
-if [ -n $BACH_CLUSTER_PREFIX ]; then
+export BOOTSTRAP_NAME="bcpc-bootstrap"
+if [[ -n $BACH_CLUSTER_PREFIX ]]; then
   export BOOTSTRAP_NAME="${BACH_CLUSTER_PREFIX}-${BOOTSTRAP_NAME}"
-else
-  export BOOTSTRAP_NAME="bcpc-bootstrap"
 fi
 
 # OS-Specific Dependencies
@@ -138,7 +137,7 @@ else
   bash -c "$WAIT_FOR_HOSTS"
 fi
 
-printf "Finished waiting for hosts to boot."
+printf "Finished waiting for hosts to boot.\n"
 snapshotVMs "${SNAP_POST_PXE}"
 
 printf "#### Chef the nodes with Basic role\n"
@@ -150,7 +149,7 @@ printf "Cluster type: $CLUSTER_TYPE\n"
 
 # Kafka does not run Bootstrap step
 if [ "${CLUSTER_TYPE}" == "hadoop" ]; then
-  printf "Running C-A-R 'bootstrap' before final C-A-R"
+  printf "Running C-A-R 'bootstrap' before final C-A-R\n"
   # https://github.com/bloomberg/chef-bach/issues/847
   # We know the first run might fail set +e
   set +e
@@ -159,7 +158,7 @@ if [ "${CLUSTER_TYPE}" == "hadoop" ]; then
   # if we still fail here we have some other issue
   vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $BACH_ENVIRONMENT Bootstrap"
   snapshotVMs "${SNAP_POST_BOOTSTRAP}"
-  printf "Running final C-A-R(s)"
+  printf "Running final C-A-R(s)\n"
 fi
 
 printf "#### Chef machine bcpc-vms with $CLUSTER_TYPE\n"
@@ -172,4 +171,4 @@ if [[ "${CLUSTER_TYPE}" == "hadoop" ]]; then
 fi
 snapshotVMs "${SNAP_POST_INSTALL}"
 
-printf '#### Install Completed!\n'
+printf "#### Install Completed!\n"

--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -1,77 +1,85 @@
 #!/bin/bash
 
+# set -x # builtin command printing
+set -e # builtin immediate exit
+
 ################################################################################
 # This script designed to provide a complete one-touch install of Chef-BCPC in
 # an environment with a proxy and custom DNS servers; VMs booted headlessly
 # simple few environment variables to tune booting for fast testing of Chef-BCPC
 # Run this script in the root of the git repository
-#
+################################################################################
 
-set -e
-
-if [ "$(uname)" == "Darwin" ]; then
-  SEDINPLACE='sed -i ""'
-else
-  SEDINPLACE='sed -i'
-fi
-
-if [[ "$(pwd)" != "$(git rev-parse --show-toplevel)" ]]; then
-  printf '#### WARNING: This should be run in the git top level directory! ####\n' > /dev/stderr
-fi
-
-export BACH_ENVIRONMENT='Test-Laptop'
-export BACH_CLUSTER_PREFIX=${BACH_CLUSTER_PREFIX:-''}
+# Export Resource Allocation
 export BOOTSTRAP_VM_MEM=${BOOTSTRAP_VM_MEM:-5096}
 export BOOTSTRAP_VM_CPUs=${BOOTSTRAP_VM_CPUS:-2}
 export CLUSTER_VM_MEM=${CLUSTER_VM_MEM:-7120}
 export CLUSTER_VM_CPUs=${CLUSTER_VM_CPUs:-4}
 export CLUSTER_TYPE=${CLUSTER_TYPE:-Hadoop}
-export PATH=/opt/chefdk/embedded/bin:$PATH
 
-BOOTSTRAP_NAME="bcpc-bootstrap"
-if [ "$BACH_CLUSTER_PREFIX" != "" ]; then
-  BOOTSTRAP_NAME="${BACH_CLUSTER_PREFIX}-bcpc-bootstrap"
+# Export BACH Repo and VM Cluster Environment
+export PATH=/opt/chefdk/embedded/bin:$PATH
+export BACH_ENVIRONMENT='Test-Laptop'
+export BACH_CLUSTER_PREFIX=${BACH_CLUSTER_PREFIX:-''}
+export BACH_REPO_DIR=$(git rev-parse --show-toplevel)
+export BACH_CLUSTER_DIR=${BACH_REPO_DIR}/../cluster
+
+if [[ $(pwd) != $BACH_REPO_DIR ]]; then
+  printf '#### WARNING: This should be run in the git top level directory! ####\n' >/dev/stderr
 fi
 
-export BOOTSTRAP_NAME
+if [ -n $BACH_CLUSTER_PREFIX ]; then
+  export BOOTSTRAP_NAME="${BACH_CLUSTER_PREFIX}-${BOOTSTRAP_NAME}"
+else
+  export BOOTSTRAP_NAME="bcpc-bootstrap"
+fi
 
-# normalize capitaliztion of CLUSTER_TYPE to lower case
-typeset -l CLUSTER_TYPE="${CLUSTER_TYPE}"
+# OS-Specific Dependencies
+if [ "$(uname)" == "Darwin" ]; then
+  brew install coreutils
+  READLINK=greadlink
+  SEDINPLACE='sed -i ""'
+else
+  READLINK=readlink
+  SEDINPLACE='sed -i'
+fi
 
+#### Setup Configuration files
 printf "#### Setup configuration files\n"
-# setup vagrant
 $SEDINPLACE 's/vb.gui = true/vb.gui = false/' Vagrantfile
 
 # Prepare the test environment file and inject local settings.
 if hash ruby; then
   ruby ./tests/edit_environment.rb
 else
-  printf "#### WARNING: no ruby found -- proceeding without editing environment!\n" > /dev/stderr
-  mkdir -p ../cluster
-  cp -rv stub-environment/* ../cluster
+  printf "#### WARNING: no ruby found -- proceeding without editing environment!\n" >/dev/stderr
+  mkdir -p $BACH_CLUSTER_DIR && cp -rv stub-environment/* $BACH_CLUSTER_DIR
 fi
 
-if [ "${CLUSTER_TYPE,,}" == "kafka" ]; then
-  printf "Using kafka_cluster.txt\n"
-  cp stub-environment/kafka_cluster.txt ../cluster/cluster.txt
+# Set cluster environment
+# normalize capitaliztion of CLUSTER_TYPE to lower case
+typeset -l CLUSTER_TYPE="${CLUSTER_TYPE}"
+if [ "${CLUSTER_TYPE}" == "kafka" ]; then
+  printf "Cluster type(${CLUSTER_TYPE}): (kafka_cluster.txt)\n"
+  cp stub-environment/kafka_cluster.txt $BACH_CLUSTER_DIR/cluster.txt
+elif [ "${CLUSTER_TYPE}" == "hadoop" ]; then
+  printf "Cluster type(${CLUSTER_TYPE}): (hadoop_cluster.txt)\n"
+  cp stub-environment/hadoop_cluster.txt $BACH_CLUSTER_DIR/cluster.txt
 else
-  printf "Using hadoop_cluster.txt\n"
-  cp stub-environment/hadoop_cluster.txt ../cluster/cluster.txt
+  printf "#### WARNING: unsupported cluster type: ${CLUSTER_TYPE}\n" >/dev/stderr
 fi
 
 # Remove unused files.
-rm -f ../cluster/kafka_cluster.txt
-rm -f ../cluster/hadoop_cluster.txt
+rm -f $BACH_CLUSTER_DIR/kafka_cluster.txt
+rm -f $BACH_CLUSTER_DIR/hadoop_cluster.txt
 
+#### Setup Virtualbox VMs and Bootstrap
 printf "#### Setup VB's and Bootstrap\n"
 source ./vbox_create.sh
 
 # Ensure we got VM_LIST from vbox_create.sh
-echo "Using CLUSTER_PREFIX=${BACH_CLUSTER_PREFIX}"
-echo "VM LIST"
-for vm in ${VM_LIST[*]}; do
-  echo $vm
-done
+echo "CLUSTER_PREFIX: ${BACH_CLUSTER_PREFIX}"
+echo "VM LIST: "; for vm in ${VM_LIST[*]}; do echo $vm; done
 
 # VM Snapshot Statemachine:
 # Before PXE boot:
@@ -85,50 +93,52 @@ SNAP_POST_BOOTSTRAP='Post-Bootstrap'
 # After cluster-assign-roles <cluster> Step:
 SNAP_POST_INSTALL='Post-Install'
 
-
 download_VM_files || ( echo "############## VBOX CREATE DOWNLOAD VM FILES RETURNED $? ##############" && exit 1 )
 create_bootstrap_VM || ( echo "############## VBOX CREATE BOOTSTRAP VM RETURNED $? ##############" && exit 1 )
 
-python_to_find_bootstrap_ip="import json; j = json.load(file('${environments[0]}')); print j['override_attributes']['bcpc']['bootstrap']['server']"
+python_to_find_bootstrap_ip="
+import json;
+j = json.load(file('${environments[0]}'));
+print j['override_attributes']['bcpc']['bootstrap']['server']
+"
 BOOTSTRAP_IP=$(python -c "$python_to_find_bootstrap_ip")
 
 create_cluster_VMs || ( echo "############## VBOX CREATE CLUSTER VMs RETURNED $? ##############" && exit 1 )
 install_cluster $BACH_ENVIRONMENT $BOOTSTRAP_IP || ( echo "############## VBOX CREATE INSTALL CLUSTER RETURNED $? ##############" && exit 1 )
 
 printf "#### Cobbler Boot\n"
-printf "  Snapshotting pre-Cobbler and booting (unless already running)\n"
+printf "Snapshotting pre-Cobbler and booting (unless already running)\n"
 snapshotVMs "${SNAP_PRE_PXE}"
 for vm in ${VM_LIST[*]} ${BOOTSTRAP_NAME}; do
-  vboxmanage showvminfo $vm --machinereadable | grep -q '^VMState="running"$' || \
-    VBoxManage startvm $vm --type headless
+  vboxmanage showvminfo $vm --machinereadable | grep -q '^VMState="running"$' ||
+  vboxmanage startvm $vm --type headless
 done
 
+WAIT_FOR_HOSTS=\
+"vagrant ssh -c 'cd chef-bcpc; source proxy_setup.sh; ./wait-for-hosts.sh ${VM_LIST[*]};'"
 if hash screen; then
-  if [ "$(uname)" == "Darwin" ]; then
-    brew install coreutils
-    pushd $(greadlink -f $(dirname $0)) > /dev/null
-  else
-    pushd $(readlink -f $(dirname $0)) > /dev/null
-  fi
-
   # Create a new screenrc with our VM list in it
-  cp ./screenrc ../../cluster/screenrc
+  SCREENRC=$BACH_CLUSTER_DIR/screenrc
+  cp tests/screenrc $SCREENRC
+  echo "cd $BACH_REPO_DIR" >> $SCREENRC
 
-  echo "cd `pwd`; cd .." >> ../../cluster/screenrc
-
-  ii=1
+  echo "Starting vm serial consoles (${VM_LIST[*]})"
+  SERIAL_CONSOLE="$BACH_REPO_DIR/tests/virtualbox_serial_console.sh"
+  KILL_CONSOLES="pgrep -f $SERIAL_CONSOLE | xargs kill -9"
   for vm in ${VM_LIST[*]}; do
-    echo "screen -t \"$vm serial console\" $ii" \
-         "./tests/virtualbox_serial_console.sh $vm" >> ../../cluster/screenrc
-    ((ii++))
+    echo "screen -t \"$vm serial console\" -- $SERIAL_CONSOLE $vm" >> $SCREENRC
   done
-  popd > /dev/null
-  echo "  Enter this command to view VM serial consoles:"
-  echo "    screen -S 'BACH serial consoles' `readlink -f ../cluster/screenrc`"
-  echo
+
+  echo "screen -t \"Wait For Hosts\" -- bash -c \"$WAIT_FOR_HOSTS && $KILL_CONSOLES\"" >> $SCREENRC;
+  screen -S 'BACH VM Install Progress' -c $SCREENRC
+else
+  echo "#### WARNING: Did not find screen -- please use " \
+    "tests/virtualbox_serial_console.sh " \
+    "<vm name> if you need a serial console." > /dev/stderr
+  bash -c "$WAIT_FOR_HOSTS"
 fi
 
-vagrant ssh -c "cd chef-bcpc; source proxy_setup.sh; ./wait-for-hosts.sh ${VM_LIST[*]}"
+printf "Finished waiting for hosts to boot."
 snapshotVMs "${SNAP_POST_PXE}"
 
 printf "#### Chef the nodes with Basic role\n"
@@ -139,7 +149,7 @@ printf "#### Chef the nodes with complete roles\n"
 printf "Cluster type: $CLUSTER_TYPE\n"
 
 # Kafka does not run Bootstrap step
-if [ "${CLUSTER_TYPE,,}" == "hadoop" ]; then
+if [ "${CLUSTER_TYPE}" == "hadoop" ]; then
   printf "Running C-A-R 'bootstrap' before final C-A-R"
   # https://github.com/bloomberg/chef-bach/issues/847
   # We know the first run might fail set +e
@@ -157,7 +167,7 @@ vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $BACH_ENVIRONMENT $CLUST
 
 # for Hadoop installs we need to re-run the headnodes once HDFS is up to ensure
 # we deploy various JARs. Run a second time once a datanode is up.
-if [[ "${CLUSTER_TYPE,,}" == "hadoop" ]]; then
+if [[ "${CLUSTER_TYPE}" == "hadoop" ]]; then
   vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $BACH_ENVIRONMENT $CLUSTER_TYPE BCPC-Hadoop-Head"
 fi
 snapshotVMs "${SNAP_POST_INSTALL}"

--- a/tests/screenrc
+++ b/tests/screenrc
@@ -5,9 +5,8 @@ echo ''
 echo '=================== Chef-BACH Ubuntu Install Progress ==================='
 echo 'Chef-BACH is PXE booting your VMs and using the netinstaller'
 echo 'to setup your machines. This is a GNU screen session with the'
-echo 'serial console open to monitor progress of each VM (windows 1'
-echo 'through 3 connect to bcpc-vm1 - bcpc-vm3)
-echo
+echo 'serial console open to monitor progress of each VM '
+echo '(windows 1 through 4 connect to bcpc-vm1 - bcpc-vm4)'
 echo 'Hitting: ^A h will get you the screen help'
 echo '========================================================================='
 echo ''

--- a/tests/virtualbox_serial_console.sh
+++ b/tests/virtualbox_serial_console.sh
@@ -8,20 +8,21 @@ if [[ "$#" != 1 ]]; then
 fi
 vm_name="$1"
 
-source $(readlink -f $(dirname $0)/..)/virtualbox_env.sh
-
-# If we are running on Ubuntu check socat(1) is installed
-socat_install_cmd='sudo apt-get install -y socat'
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-  if [ "$(lsb_release -si)" == "Ubuntu" -a \
-     -z "$(dpkg -s socat 2>/dev/null | grep '^Status.*installed')" ]; then
-    echo "Did not find socat(1) installed; running: $socat_install_cmd" >> /dev/stderr
-    $socat_install_cmd
-  fi
+# If we are running on Ubuntu check netcat(1) is installed
+if [[
+  "$OSTYPE" == "linux-gnu"
+  && "$(lsb_release -si)" == "Ubuntu"
+  && -z "$(dpkg -s netcat-openbsd 2>/dev/null | grep '^Status.*installed')"
+]]; then
+  netcat_install_cmd='sudo apt-get install -y netcat-openbsd'
+  echo "Did not find netcat(1) installed; running: $netcat_install_cmd" >> /dev/stderr
+  $netcat_install_cmd
 fi
 
+source $(readlink -f $(dirname $0)/..)/virtualbox_env.sh
 $VBM list runningvms | grep -q "\"$vm_name\"" || (echo "VM name: $1 not found"; exit 1)
 serial_socket=$($VBM showvminfo $vm_name | grep '^UART 1:' | sed -e "s/.* '//" -e "s/'$//")
 
-trap "stty sane" 0 1 2 3 15
-socat unix-connect:$serial_socket stdio,raw,echo=0,icanon=0
+# trap "stty sane" 0 1 2 3 15
+# socat unix-connect:$serial_socket stdio,raw,echo=0,icanon=0
+nc -U $serial_socket

--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -69,8 +69,10 @@ require './lib/cluster_data.rb';
 include BACH::ClusterData;
 cp=ENV.fetch('BACH_CLUSTER_PREFIX', '');
 cp += '-' unless cp.empty?;
-vms = parse_cluster_txt(File.readlines('cluster.txt'))
-puts vms.map{|e| cp + e[:hostname]}.join(' ')
+vms = parse_cluster_txt(File.readlines('cluster.txt')).map do |e|
+  (e[:hostname] !~ /^#{cp}/) ? (cp + e[:hostname]) : e[:hostname]
+end.join(' ')
+puts vms
 "
 export VM_LIST=( $(/usr/bin/env ruby -e "$code_to_produce_vm_list") )
 

--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -113,29 +113,6 @@ function snapshotVMs {
   wait && printf "Done Snapshotting\n"
 }
 
-# ################################################################################
-# # Function to enumerate VirtualBox hostonly interfaces
-# # in use from VM's.
-# # Argument: name of an associative array defined in calling context
-# # Post-Condition: Updates associative array provided by name with keys being
-# #                 all interfaces in use and values being the number of VMs on
-# #                 each network
-# function discover_VBOX_hostonly_ifs {
-#   # make used_ifs a typeref to the passed-in associative array
-#   local -n used_ifs=$1
-#   for net in $($VBM list hostonlyifs | grep '^Name:' | sed 's/^Name:[ ]*//'); do
-#     used_ifs[$net]=0
-#   done
-#   for vm in $($VBM list vms | sed -e 's/^[^{]*{//' -e 's/}$//'); do
-#     ifs=$($VBM showvminfo --machinereadable $vm | \
-#       egrep '^hostonlyadapter[0-9]*' | \
-#       sed -e 's/^hostonlyadapter[0-9]*="//' -e 's/"$//')
-#     for interface in $ifs; do
-#       used_ifs[$interface]=$((${used_ifs[$interface]} + 1))
-#     done
-#   done
-# }
-
 ################################################################################
 # Function to remove VirtualBox DHCP servers
 # By default, checks for any DHCP server on networks without VM's & removes them

--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -63,13 +63,6 @@ VBOX_DIR="`dirname ${BASH_SOURCE[0]}`/vbox"
 [[ -d $VBOX_DIR ]] || mkdir $VBOX_DIR
 VBOX_DIR_PATH=`python -c "import os.path; print os.path.abspath(\"${VBOX_DIR}/\")"`
 
-# ensure cluster.txt has CLUSTER_PREFIX prepended before VM names
-# NOTE: somewhat crude we see if any line does not start with the
-# cluster name and if so all lines have it prepended
-if [[ -n "$(grep -v "^${CLUSTER_PREFIX}" ./cluster.txt)" ]]; then
-  sed -i "s/^/${CLUSTER_PREFIX}-/" cluster.txt
-fi
-
 # Populate the VM list array from cluster.txt
 code_to_produce_vm_list="
 require './lib/cluster_data.rb';
@@ -149,7 +142,7 @@ function remove_DHCPservers {
   if [[ -z "$network_name" ]]; then
     local vms=$($VBM list vms|sed 's/^.*{\([0-9a-f-]*\)}/\1/')
     # will produce a list of networks like ^vboxnet0$|^vboxnet1$ which are in use by VMs
-    local existing_nets_reg_ex=$(sed -e 's/^/^/' -e '/$/$/' -e 's/ /$|^/g' <<< $(for vm in $vms; do $VBM showvminfo --details --machinereadable $vm | grep -i 'adapter[2-9]=' | sed -e 's/^.*=//' -e 's/"//g'; done | sort -u))
+    local existing_nets_reg_ex=$(sed -e 's/^/^/' -e 's/$/$/' -e 's/ /$|^/g' <<< $(for vm in $vms; do $VBM showvminfo --details --machinereadable $vm | grep -i 'adapter[2-9]=' | sed -e 's/^.*=//' -e 's/"//g'; done | sort -u))
 
     $VBM list dhcpservers | grep -E "^NetworkName:\s+HostInterfaceNetworking" | sed 's/^.*-//' |
     while read -r network_name; do

--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -3,16 +3,17 @@
 # bash imports
 source ./virtualbox_env.sh
 
-set -x
-
 if !hash ruby 2> /dev/null ; then
   echo 'No ruby in path!'
   exit 1
 fi
 
 if [[ -f ./proxy_setup.sh ]]; then
-  . ./proxy_setup.sh
+  source ./proxy_setup.sh
+  echo "The http proxy is: $http_proxy"
+  echo "The https proxy is: $https_proxy"
 fi
+
 # CURL is exported by proxy_setup.sh
 if [[ -z "$CURL" ]]; then
   echo 'CURL is not defined'
@@ -28,6 +29,7 @@ fi
 # Bootstrap VM Defaults (these need to be exported for Vagrant's Vagrantfile)
 export BOOTSTRAP_VM_MEM=${BOOTSTRAP_VM_MEM-2048}
 export BOOTSTRAP_VM_CPUs=${BOOTSTRAP_VM_CPUs-1}
+
 # Use this if you intend to make an apt-mirror in this VM (see the
 # instructions on using an apt-mirror towards the end of bootstrap.md)
 # -- Vagrant VMs do not use this size --
@@ -43,8 +45,9 @@ export CLUSTER_VM_CPUs=${CLUSTER_VM_CPUs-1}
 export CLUSTER_VM_EFI=${CLUSTER_VM_EFI:-true}
 export CLUSTER_VM_DRIVE_SIZE=${CLUSTER_VM_DRIVE_SIZE-20480}
 
-if !hash vagrant 2> /dev/null ; then
-  echo 'Vagrant not detected - we need Vagrant!' >&2
+if !hash vagrant 2>/dev/null ; then
+  echo 'Vagrant not detected!' >/dev/stderr
+  echo 'Install the latest version from vagrantup.com' >/dev/stderr
   exit 1
 fi
 
@@ -52,16 +55,15 @@ fi
 environments=( ./environments/*.json )
 if (( ${#environments[*]} > 1 )); then
   echo 'Need one and only one environment in environments/*.json; got: ' \
-       "${environments[*]}" >&2
+       "${environments[*]}" >/dev/stderr
   exit 1
 fi
 
 # The root drive on cluster nodes must allow for a RAM-sized swap volume.
 CLUSTER_VM_ROOT_DRIVE_SIZE=$((CLUSTER_VM_DRIVE_SIZE + CLUSTER_VM_MEM - 2048))
 
-VBOX_DIR="`dirname ${BASH_SOURCE[0]}`/vbox"
-[[ -d $VBOX_DIR ]] || mkdir $VBOX_DIR
-VBOX_DIR_PATH=`python -c "import os.path; print os.path.abspath(\"${VBOX_DIR}/\")"`
+VBOX_DIR="$(git rev-parse --show-toplevel)/vbox"
+mkdir -p $VBOX_DIR
 
 # Populate the VM list array from cluster.txt
 code_to_produce_vm_list="
@@ -80,18 +82,20 @@ export VM_LIST=( $(/usr/bin/env ruby -e "$code_to_produce_vm_list") )
 # Function to download files necessary for VM stand-up
 #
 function download_VM_files {
-  pushd $VBOX_DIR_PATH
+  UBUNTU_URL=http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/installer-amd64/current/images/trusty-netboot/mini.iso
+  VAGRANT_URL=http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box
 
+  pushd $VBOX_DIR >/dev/null
   # Grab the Ubuntu 14.04 installer image
   if [[ ! -f ubuntu-14.04-mini.iso ]]; then
-     $CURL -o ubuntu-14.04-mini.iso http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/installer-amd64/current/images/trusty-netboot/mini.iso
+    $CURL -o ubuntu-14.04-mini.iso $UBUNTU_URL
   fi
 
   # Can we create the bootstrap VM via Vagrant
   if [[ ! -f trusty-server-cloudimg-amd64-vagrant-disk1.box ]]; then
-    $CURL -o trusty-server-cloudimg-amd64-vagrant-disk1.box http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box
+    $CURL -o trusty-server-cloudimg-amd64-vagrant-disk1.box $VAGRANT_URL
   fi
-  popd
+  popd >/dev/null
 }
 
 ################################################################################
@@ -109,28 +113,28 @@ function snapshotVMs {
   wait && printf "Done Snapshotting\n"
 }
 
-################################################################################
-# Function to enumerate VirtualBox hostonly interfaces
-# in use from VM's.
-# Argument: name of an associative array defined in calling context
-# Post-Condition: Updates associative array provided by name with keys being
-#                 all interfaces in use and values being the number of VMs on
-#                 each network
-function discover_VBOX_hostonly_ifs {
-  # make used_ifs a typeref to the passed-in associative array
-  local -n used_ifs=$1
-  for net in $($VBM list hostonlyifs | grep '^Name:' | sed 's/^Name:[ ]*//'); do
-    used_ifs[$net]=0
-  done
-  for vm in $($VBM list vms | sed -e 's/^[^{]*{//' -e 's/}$//'); do
-    ifs=$($VBM showvminfo --machinereadable $vm | \
-      egrep '^hostonlyadapter[0-9]*' | \
-      sed -e 's/^hostonlyadapter[0-9]*="//' -e 's/"$//')
-    for interface in $ifs; do
-      used_ifs[$interface]=$((${used_ifs[$interface]} + 1))
-    done
-  done
-}
+# ################################################################################
+# # Function to enumerate VirtualBox hostonly interfaces
+# # in use from VM's.
+# # Argument: name of an associative array defined in calling context
+# # Post-Condition: Updates associative array provided by name with keys being
+# #                 all interfaces in use and values being the number of VMs on
+# #                 each network
+# function discover_VBOX_hostonly_ifs {
+#   # make used_ifs a typeref to the passed-in associative array
+#   local -n used_ifs=$1
+#   for net in $($VBM list hostonlyifs | grep '^Name:' | sed 's/^Name:[ ]*//'); do
+#     used_ifs[$net]=0
+#   done
+#   for vm in $($VBM list vms | sed -e 's/^[^{]*{//' -e 's/}$//'); do
+#     ifs=$($VBM showvminfo --machinereadable $vm | \
+#       egrep '^hostonlyadapter[0-9]*' | \
+#       sed -e 's/^hostonlyadapter[0-9]*="//' -e 's/"$//')
+#     for interface in $ifs; do
+#       used_ifs[$interface]=$((${used_ifs[$interface]} + 1))
+#     done
+#   done
+# }
 
 ################################################################################
 # Function to remove VirtualBox DHCP servers
@@ -142,7 +146,7 @@ function discover_VBOX_hostonly_ifs {
 function remove_DHCPservers {
   local network_name=${1-}
   if [[ -z "$network_name" ]]; then
-    local vms=$($VBM list vms|sed 's/^.*{\([0-9a-f-]*\)}/\1/')
+    local vms=$($VBM list vms | sed 's/^.*{\([0-9a-f-]*\)}/\1/')
     # will produce a list of networks like ^vboxnet0$|^vboxnet1$ which are in use by VMs
     local existing_nets_reg_ex=$(sed -e 's/^/^/' -e 's/$/$/' -e 's/ /$|^/g' <<< $(for vm in $vms; do $VBM showvminfo --details --machinereadable $vm | grep -i 'adapter[2-9]=' | sed -e 's/^.*=//' -e 's/"//g'; done | sort -u))
 
@@ -157,16 +161,17 @@ function remove_DHCPservers {
   fi
 }
 
-###################################################################
+#########################################
 # Function to create the bootstrap VM
 #
 function create_bootstrap_VM {
-  pushd $VBOX_DIR_PATH
+  pushd $VBOX_DIR >/dev/null
 
   remove_DHCPservers
 
-  echo "Vagrant detected - using Vagrant to initialize bcpc-bootstrap VM"
-  cp ../Vagrantfile .
+  if [[ -f ../Vagrantfile ]]; then
+    cp ../Vagrantfile .
+  fi
 
   if [[ -f ../Vagrantfile.local.rb ]]; then
       cp ../Vagrantfile.local.rb .
@@ -174,11 +179,14 @@ function create_bootstrap_VM {
 
   if [[ ! -f insecure_private_key ]]; then
     # Ensure that the private key has been created by running vagrant at least once
-    vagrant status
     cp $HOME/.vagrant.d/insecure_private_key .
   fi
-  vagrant up --provision
-  popd
+
+  if ! vagrant status | grep "running (virtualbox)"; then 
+    echo "Using Vagrant to initialize bcpc-bootstrap VM"
+    vagrant up --provision
+  fi
+  popd >/dev/null
 }
 
 
@@ -197,24 +205,24 @@ function create_vbox_ipxe_disk {
 #
 function create_cluster_VMs {
   # Gather VirtualBox networks in use by bootstrap VM
-  oifs="$IFS"
-  IFS=$'\n'
-  bootstrap_interfaces=($($VBM showvminfo ${BOOTSTRAP_NAME} \
-    --machinereadable | \
-    egrep '^hostonlyadapter[0-9]=' | \
-    sort | \
-    sed -e 's/.*=//' -e 's/"//g'))
+  oifs="$IFS"; IFS=$'\n'
+  bootstrap_interfaces=($(
+    $VBM showvminfo ${BOOTSTRAP_NAME} --machinereadable |
+    egrep '^hostonlyadapter[0-9]=' |
+    sort |
+    sed -e 's/.*=//' -e 's/"//g'
+  ))
   IFS="$oifs"
+
   VBN0="${bootstrap_interfaces[0]?Need a Virtualbox network 1 for the bootstrap}"
   VBN1="${bootstrap_interfaces[1]?Need a Virtualbox network 2 for the bootstrap}"
   VBN2="${bootstrap_interfaces[2]?Need a Virtualbox network 3 for the bootstrap}"
 
   if [[ $CLUSTER_VM_EFI == true ]]; then
-    #
-    # Add the ipxe USB key to the vbox storage registry as an immutable
-    # disk, so we can share it between several VMs.
-    #
+    # Add the ipxe USB key to the vbox storage registry as an immutable disk.
+    # we can share it between several VMs.
     current_ipxe=$(vboxmanage list hdds | egrep '^Location:.*ipxe.vdi$')
+
     # we have an ipxe disk added
     if [[ -n "$current_ipxe" ]]; then
       ipxe_location=$(echo "$current_ipxe" | sed 's/^Location:[ ]*//')
@@ -222,94 +230,87 @@ function create_cluster_VMs {
       if $VBM showmediuminfo "$ipxe_location" | egrep -q '^State:.*inaccessible'; then
         $VBM closemedium disk "$ipxe_location"
         # update if we changed ipxe_location to the local workspace
-        ipxe_location="$VBOX_DIR_PATH/ipxe.vdi"
+        ipxe_location="$VBOX_DIR/ipxe.vdi"
         create_vbox_ipxe_disk "$ipxe_location"
       fi
     else
-      ipxe_location="$VBOX_DIR_PATH/ipxe.vdi"
+      ipxe_location="$VBOX_DIR/ipxe.vdi"
       create_vbox_ipxe_disk "$ipxe_location"
     fi
 
-    # provide the IPXE disk location so we know if it is from
-    # another cluster
+    # provide the IPXE disk location so we know if it is from another cluster
     echo "NOTE: Using IPXE volume at: $ipxe_location"
   fi
 
   # Create each VM
   for vm in ${VM_LIST[*]}; do
-      # Only if VM doesn't exist
-      if ! $VBM list vms | grep "^\"${vm}\"" ; then
-          $VBM createvm --name $vm --ostype Ubuntu_64 \
-	       --basefolder $VBOX_DIR_PATH --register
+    # Only if VM doesn't exist
+    if ! $VBM list vms | grep "^\"${vm}\"" ; then
+      $VBM createvm --name $vm --ostype Ubuntu_64 \
+        --basefolder $VBOX_DIR --register
 
-          $VBM modifyvm $vm --memory $CLUSTER_VM_MEM
-          $VBM modifyvm $vm --cpus $CLUSTER_VM_CPUs
+      $VBM modifyvm $vm --memory $CLUSTER_VM_MEM
+      $VBM modifyvm $vm --cpus $CLUSTER_VM_CPUs
 
-	  if [[ $CLUSTER_VM_EFI == true ]]; then
-	      # Force UEFI firmware.
-	      $VBM modifyvm $vm --firmware efi
-	  fi
-
-          # Add the network interfaces
-          $VBM modifyvm $vm --nic1 hostonly --hostonlyadapter1 "$VBN0"
-          $VBM modifyvm $vm --nic2 hostonly --hostonlyadapter2 "$VBN1"
-          $VBM modifyvm $vm --nic3 hostonly --hostonlyadapter3 "$VBN2"
-
-	  # Create a disk controller to hang disks off of.
-	  DISK_CONTROLLER="SATA_Controller"
-	  $VBM storagectl $vm --name $DISK_CONTROLLER --add sata
-
-	  #
-	  # Create the root disk, /dev/sda.
-	  #
-	  # (/dev/sda is hardcoded into the preseed file.)
-	  #
-	  port=0
-	  DISK_PATH=$VBOX_DIR_PATH/$vm/$vm-a.vdi
-	  $VBM createhd --filename $DISK_PATH \
-	       --size $CLUSTER_VM_ROOT_DRIVE_SIZE
-          $VBM storageattach $vm --storagectl $DISK_CONTROLLER \
-	       --device 0 --port $port --type hdd --medium $DISK_PATH
-	  port=$((port+1))
-
-	  if [[ $CLUSTER_VM_EFI == true ]]; then
-	      # Attach the iPXE boot medium as /dev/sdb.
-              $VBM storageattach $vm --storagectl $DISK_CONTROLLER \
-		   --device 0 --port $port --type hdd --medium $ipxe_location
-	      port=$((port+1))
-	  else
-	      # If we're not using EFI, force the BIOS to boot net.
-	      $VBM modifyvm $vm --boot1 net
-	  fi
-
-	  #
-	  # Create our data disks
-	  #
-	  # For these to be used properly, we will need to override
-	  # the attribute default[:bcpc][:hadoop][:disks] in a role or
-	  # environment.
-	  #
-          for disk in c d e f; do
-	      DISK_PATH=$VBOX_DIR_PATH/$vm/$vm-$disk.vdi
-              $VBM createhd --filename $DISK_PATH \
-		   --size $CLUSTER_VM_DRIVE_SIZE
-              $VBM storageattach $vm --storagectl $DISK_CONTROLLER \
-		   --device 0 --port $port --type hdd --medium $DISK_PATH
-              port=$((port+1))
-          done
-
-          # Set hardware acceleration options
-          $VBM modifyvm $vm \
-	       --largepages on \
-	       --vtxvpid on \
-	       --hwvirtex on \
-	       --nestedpaging on \
-	       --ioapic on
-
-          # Add serial ports
-          $VBM modifyvm $vm --uart1 0x3F8 4
-          $VBM modifyvm $vm --uartmode1 server /tmp/serial-${vm}-ttyS0
+      if [[ $CLUSTER_VM_EFI == true ]]; then
+          # Force UEFI firmware.
+          $VBM modifyvm $vm --firmware efi
       fi
+
+      # Add the network interfaces
+      $VBM modifyvm $vm --nic1 hostonly --hostonlyadapter1 "$VBN0"
+      $VBM modifyvm $vm --nic2 hostonly --hostonlyadapter2 "$VBN1"
+      $VBM modifyvm $vm --nic3 hostonly --hostonlyadapter3 "$VBN2"
+
+      # Create a disk controller to hang disks off of.
+      DISK_CONTROLLER="SATA_Controller"
+      $VBM storagectl $vm --name $DISK_CONTROLLER --add sata
+      port=0
+
+      # Create the root disk, /dev/sda.
+      # (/dev/sda is hardcoded into the preseed file.)
+      DISK_PATH=$VBOX_DIR/$vm/$vm-a.vdi
+      $VBM createhd --filename $DISK_PATH \
+        --size $CLUSTER_VM_ROOT_DRIVE_SIZE
+      $VBM storageattach $vm --storagectl $DISK_CONTROLLER \
+        --device 0 --port $port --type hdd --medium $DISK_PATH
+      port=$((port+1))
+
+      if [[ $CLUSTER_VM_EFI == true ]]; then
+        # Attach the iPXE boot medium as /dev/sdb.
+        $VBM storageattach $vm --storagectl $DISK_CONTROLLER \
+          --device 0 --port $port --type hdd --medium $ipxe_location
+        port=$((port+1))
+      else
+        # If we're not using EFI, force the BIOS to boot net.
+        echo "Using BIOS for $vm"
+        $VBM modifyvm $vm --boot1 net
+      fi
+
+      # Create our data disks
+      # For these to be used properly, we will need to override
+      # the attribute default[:bcpc][:hadoop][:disks] in a role or environment.
+      for disk in {c..f}; do
+        DISK_PATH=$VBOX_DIR/$vm/$vm-$disk.vdi
+        $VBM createhd --filename $DISK_PATH \
+          --size $CLUSTER_VM_DRIVE_SIZE
+        $VBM storageattach $vm --storagectl $DISK_CONTROLLER \
+          --device 0 --port $port --type hdd --medium $DISK_PATH
+        port=$((port+1))
+      done
+
+      # Set hardware acceleration options
+      $VBM modifyvm $vm \
+        --largepages on \
+        --vtxvpid on \
+        --hwvirtex on \
+        --nestedpaging on \
+        --ioapic on
+
+      # Add serial ports
+      $VBM modifyvm $vm --uart1 0x3F8 4
+      $VBM modifyvm $vm --uartmode1 server /tmp/serial-${vm}-ttyS0
+    fi
   done
   # update cluster.txt to match VirtualBox MAC's
   ./vm-to-cluster.sh
@@ -322,11 +323,12 @@ function create_cluster_VMs {
 function install_cluster {
   environment=${1-Test-Laptop}
   ip=${2-10.0.100.3}
-  # N.B. As of Aug 2013, grub-pc gets confused and wants to prompt re: 3-way
-  # merge.  Sigh.
+
+  # N.B. As of Aug 2013, grub-pc gets confused and wants to prompt re: 3-way merge (sigh).
   #vagrant ssh -c "sudo ucf -p /etc/default/grub"
   #vagrant ssh -c "sudo ucfr -p grub-pc /etc/default/grub"
   vagrant ssh -c "test -f /etc/default/grub.ucf-dist && sudo mv /etc/default/grub.ucf-dist /etc/default/grub" || true
+
   # Duplicate what d-i's apt-setup generators/50mirror does when set in preseed
   if [ -n "$http_proxy" ]; then
     proxy_found=true
@@ -335,6 +337,7 @@ function install_cluster {
       vagrant ssh -c "echo 'Acquire::http::Proxy \"$http_proxy\";' | sudo tee -a /etc/apt/apt.conf"
     fi
   fi
+
   echo "Bootstrap complete - setting up Chef server"
   echo "N.B. This may take approximately 30-45 minutes to complete."
   vagrant ssh -c 'sudo rm -f /var/chef/cache/chef-stacktrace.out'

--- a/vm_to_cluster.rb
+++ b/vm_to_cluster.rb
@@ -70,7 +70,7 @@ if File.basename(__FILE__) == File.basename($PROGRAM_NAME)
     # HACK: We have not edited cluster.txt yet, but may have 
     # forced the VMs to have a ${BACH_CLUSTER_PREFIX}-
     # when we generated VM_LIST in vbox_create.sh
-    if ENV['BACH_CLUSTER_PREFIX'] != '' then
+    if /^#{ENV['BACH_CLUSTER_PREFIX']}/ !~ e[:hostname] then
       e[:hostname] = "#{ENV['BACH_CLUSTER_PREFIX']}-#{e[:hostname]}"
     end
     # use a bogus MAC for not yet created VMs in case it gets handed to Cobbler


### PR DESCRIPTION
Most of this pull request is general linting and documentation that I've made to my fork to better understand the vm cluster build process. The pull request also includes some key functionality changes to automate the serial console connections and retain idempotence in prefixed-cluster builds.

The linting changes are not crucial to be merged, but I think they help to make the shell scripts a little more understandable. 

**After these changes, I was able to automatically build a vm cluster with a prefix in 3hrs 15mins.** 
Waiting for the hosts to install took 9 checks before proceeding.

1) Automates the serial console connections to the bcpc-vms in tests/automated_install.sh. 
These changes are mainly in lines 120-140 of tests/automated_install.sh. The previous screen session either approach failed to connect to the serial consoles or failed to kill them properly.
The main difference here is the use of the screen command argument, bash -c "$WAIT_FOR_HOSTS && $KILL_SCREENS".  This feature builds on the proposed changes of https://github.com/bloomberg/chef-bach/pull/868

2) Retains idempotence in prefixed-cluster builds
After changing the format of cluster.txt to include a node index as the first field, some of the previous installation scripts break idempotence. Lines 74-77 in vbox_create.sh and line 74 in vm_to_cluster.rb now check that the hostname starts with the prefix. Previous versions would always prepend a non empty prefix to the cluster.txt file.

3) General shell scirpt linting and documentation
I tried to refactor some of the shell script segments in a simpler way while retaining the original functionality. The pull request makes it look more complicated than it is. It may be a good idea to pull down the pull request branch and actually look at the scripts, mainly tests/automated_install.sh and vbox_create.sh. I realize that changes that make the scripts clearer and simpler to me may not necessarily do the same for others.