### PR TITLE
Use the HAProxy port for oozie HA

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/oozie_client.rb
+++ b/cookbooks/bcpc-hadoop/recipes/oozie_client.rb
@@ -13,7 +13,7 @@ end
 hdp_select('oozie-client', node[:bcpc][:hadoop][:distribution][:active_release])
 
 oozie_url = "http://#{node[:bcpc][:management][:viphost]}:" +
-  node[:bcpc][:hadoop][:oozie_port].to_s + '/oozie'
+  node['bcpc']['ha_oozie']['port'].to_s + '/oozie'
 
 file '/etc/profile.d/oozie-url.sh' do
   mode 0555


### PR DESCRIPTION
Defined in cookbooks/bcpc/attributes/default.rb:229.