### PR TITLE
Pin 'line' cookbook to less than 2.0.0

### DIFF
--- a/cookbooks/bcpc/metadata.rb
+++ b/cookbooks/bcpc/metadata.rb
@@ -16,7 +16,7 @@ depends 'cobblerd'
 depends 'cron'
 depends 'database'
 depends 'graphite_handler'
-depends 'line'
+depends 'line', '< 2.0.0' # 2.0.0 drops Chef 12.0 support
 depends 'maven', '~> 5.0.1'
 depends 'nscd'
 depends 'ntp'


### PR DESCRIPTION
Per J. Justice,  `line` v2.0.0 drops support for Chef 12.x and earlier.  We need to pin on whatever the last pre-2.0.0 version is.