### PR TITLE
add the activity metrics from hdfs datanode

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/jmxtrans_agent.rb
+++ b/cookbooks/bcpc-hadoop/attributes/jmxtrans_agent.rb
@@ -698,6 +698,83 @@ default['bcpc']['hadoop']['jmxtrans_agent']['datanode']['queries'] = default['bc
     'objectName' => 'Hadoop:name=DataNodeInfo,service=DataNode',
     'resultAlias' => 'dn_data_node_info.%name%.#attribute#',
     'attributes' => 'RpcPort,XceiverCount'
+  },
+  {
+    'objectName' => 'Hadoop:service=DataNode,name=*',
+    'resultAlias' => 'dn_data_node_activity.DataNodeActivity.#attribute#',
+    'attributes' =>
+      'BlockChecksumOpAvgTime, ' \
+      'BlockChecksumOpNumOps, ' \
+      'BlockReportsAvgTime, ' \
+      'BlockReportsNumOps, ' \
+      'BlockVerificationFailures, ' \
+      'BlocksCached, ' \
+      'BlocksDeletedInPendingIBR, ' \
+      'BlocksGetLocalPathInfo, ' \
+      'BlocksInPendingIBR, ' \
+      'BlocksRead, ' \
+      'BlocksReceivedInPendingIBR, ' \
+      'BlocksReceivingInPendingIBR, ' \
+      'BlocksRemoved, ' \
+      'BlocksReplicated, ' \
+      'BlocksUncached, ' \
+      'BlocksVerified, ' \
+      'BlocksWritten, ' \
+      'BytesRead, ' \
+      'BytesWritten, ' \
+      'CacheReportsAvgTime, ' \
+      'CacheReportsNumOps, ' \
+      'CopyBlockOpAvgTime, ' \
+      'CopyBlockOpNumOps, ' \
+      'DataNodeActiveXceiversCount, ' \
+      'DatanodeNetworkErrors, ' \
+      'FlushNanosAvgTime, ' \
+      'FlushNanosNumOps, ' \
+      'FsyncCount, ' \
+      'FsyncNanosAvgTime, ' \
+      'FsyncNanosNumOps, ' \
+      'HeartbeatsAvgTime, ' \
+      'HeartbeatsNumOps, ' \
+      'HeartbeatsTotalAvgTime, ' \
+      'HeartbeatsTotalNumOps, ' \
+      'IncrementalBlockReportsAvgTime, ' \
+      'IncrementalBlockReportsNumOps, ' \
+      'LifelinesAvgTime, ' \
+      'LifelinesNumOps, ' \
+      'PacketAckRoundTripTimeNanosAvgTime, ' \
+      'PacketAckRoundTripTimeNanosNumOps, ' \
+      'RamDiskBlocksDeletedBeforeLazyPersisted, ' \
+      'RamDiskBlocksEvicted, ' \
+      'RamDiskBlocksEvictedWithoutRead, ' \
+      'RamDiskBlocksEvictionWindowMsAvgTime, ' \
+      'RamDiskBlocksEvictionWindowMsNumOps, ' \
+      'RamDiskBlocksLazyPersistWindowMsAvgTime, ' \
+      'RamDiskBlocksLazyPersistWindowMsNumOps, ' \
+      'RamDiskBlocksLazyPersisted, ' \
+      'RamDiskBlocksReadHits, ' \
+      'RamDiskBlocksWrite, ' \
+      'RamDiskBlocksWriteFallback, ' \
+      'RamDiskBytesLazyPersisted, ' \
+      'RamDiskBytesWrite, ' \
+      'ReadBlockOpAvgTime, ' \
+      'ReadBlockOpNumOps, ' \
+      'ReadsFromLocalClient, ' \
+      'ReadsFromRemoteClient, ' \
+      'RemoteBytesRead, ' \
+      'RemoteBytesWritten, ' \
+      'ReplaceBlockOpAvgTime, ' \
+      'ReplaceBlockOpNumOps, ' \
+      'SendDataPacketBlockedOnNetworkNanosAvgTime, ' \
+      'SendDataPacketBlockedOnNetworkNanosNumOps, ' \
+      'SendDataPacketTransferNanosAvgTime, ' \
+      'SendDataPacketTransferNanosNumOps, ' \
+      'TotalReadTime, ' \
+      'TotalWriteTime, ' \
+      'VolumeFailures, ' \
+      'WriteBlockOpAvgTime, ' \
+      'WriteBlockOpNumOps, ' \
+      'WritesFromLocalClient, ' \
+      'WritesFromRemoteClient'
   }
 ]
 


### PR DESCRIPTION
More datanode metrics should be included.
Metrics like `ReadBlockOpAvgTime` or `BytesRead` is likely to help in case of debugging hotspot or slowness.