### PR TITLE
Never return nil from bcpc fetch_all_nodes

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -190,7 +190,7 @@ def fetch_all_nodes
     node.run_state['cluster_def'] = BACH::ClusterDef.new(node_obj: node)
   end
   cd = node.run_state['cluster_def']
-  cd.fetch_cluster_def
+  cd.fetch_cluster_def || []
 end
 
 # Get all nodes for this Chef environment


### PR DESCRIPTION
If nil is returned, it is not possible to chef a new bootstrap.

