### PR TITLE
Modify BCPC-Hadoop and the stub-environment to support the BACH-Backup role on BACH clusters.

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/backup.rb
+++ b/cookbooks/bcpc-hadoop/attributes/backup.rb
@@ -1,0 +1,18 @@
+# Cookbook Name:: bcpc-hadoop
+# BCPC Hadoop Attributes for backup jobs
+#
+# Copyright 2018, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+default[:bcpc][:hadoop][:backup][:user] = "bach_backup"

--- a/cookbooks/bcpc-hadoop/attributes/kerberos.rb
+++ b/cookbooks/bcpc-hadoop/attributes/kerberos.rb
@@ -128,6 +128,15 @@ default['bcpc']['hadoop']['kerberos']['data'] = {
     perms: '0440',
     spnego_keytab: 'spnego.service.keytab'
   },
+  backup: {
+    principal: node[:bcpc][:hadoop][:backup][:user],
+    keytab: 'backup.service.keytab',
+    owner: node[:bcpc][:hadoop][:backup][:user],
+    group: node[:bcpc][:hadoop][:backup][:user],
+    princhost: '_HOST',
+    perms: '0440',
+    spnego_keytab: 'spnego.service.keytab'
+  },
   ambari: {
       principal: "#{node['bcpc']['hadoop']['proxyuser']['ambari']}",
       keytab: 'ambari.service.keytab',

--- a/cookbooks/bcpc-hadoop/recipes/bach_backup_user.rb
+++ b/cookbooks/bcpc-hadoop/recipes/bach_backup_user.rb
@@ -1,0 +1,34 @@
+# Cookbook Name:: bcpc-hadoop
+# Recipe:: bach_backup_user
+# Creates the user needed for hadoop cluster backup jobs
+#
+# Copyright 2016, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+backup_user = node[:bcpc][:hadoop][:backup][:user]
+
+user backup_user do
+  action :create
+  comment 'backup service user'
+end
+
+# make backup user an hdfs superuser
+group 'hdfs' do
+  members backup_user
+  append true
+end
+
+configure_kerberos 'backup_kerberos' do
+  service_name 'backup'
+end

--- a/cookbooks/bcpc-hadoop/recipes/bach_backup_wrapper.rb
+++ b/cookbooks/bcpc-hadoop/recipes/bach_backup_wrapper.rb
@@ -1,0 +1,19 @@
+# Cookbook Name:: bcpc-hadoop
+# Recipe:: bach_backup_wrapper
+# Wrapper recipe for bach_backup hadoop cluster support
+#
+# Copyright 2016, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_recipe 'bcpc-hadoop::bach_backup_user'

--- a/stub-environment/roles/BCPC-Hadoop-Head-ResourceManager.json
+++ b/stub-environment/roles/BCPC-Hadoop-Head-ResourceManager.json
@@ -4,7 +4,8 @@
   "run_list": [
     "role[Basic]",
     "recipe[bcpc-hadoop::resource_manager]",
-    "recipe[bcpc-hadoop::smoke_test_user]"
+    "recipe[bcpc-hadoop::smoke_test_user]",
+    "recipe[bcpc-hadoop::bach_backup_user]"
   ],
   "description": "A highly-available head node in a BCPC Hadoop cluster",
   "chef_type": "role",

--- a/stub-environment/roles/BCPC-Hadoop-Head.json
+++ b/stub-environment/roles/BCPC-Hadoop-Head.json
@@ -23,6 +23,7 @@
     "recipe[hdfsdu::create_user]",
     "recipe[bcpc-hadoop::configs]",
     "recipe[pam::default]",
+    "recipe[bcpc-hadoop::bach_backup_wrapper]",
     "recipe[bcpc-hadoop::zookeeper_server]",
     "recipe[bcpc-hadoop::journalnode]",
     "recipe[bcpc-hadoop::graphite_to_zabbix]"

--- a/stub-environment/roles/BCPC-Hadoop-Worker.json
+++ b/stub-environment/roles/BCPC-Hadoop-Worker.json
@@ -12,6 +12,7 @@
     "recipe[bcpc-hadoop::hdp_repo]",
     "recipe[bach_krb5::krb5_client]",
     "recipe[hdfsdu::create_user]",
+    "recipe[bcpc-hadoop::bach_backup_wrapper]",
     "recipe[bcpc-hadoop::configs]",
     "recipe[pam::default]",
     "recipe[bach_spark::default]",


### PR DESCRIPTION
These changes modify the `bcpc-hadoop`  cookbook to support the `backup` cookbooks. 
They work fine on a VM cluster, but the creation of a new kerberos keytab will cause breaking changes in certain production cluster environments. 