### PR TITLE
Fix Oozie high-availability hosts.

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -108,9 +108,63 @@ default['bcpc']['hadoop']['hb_hosts'] = []
 default['bcpc']['hadoop']['hive_hosts'] = []
 default['bcpc']['hadoop']['oozie_hosts'] = []
 default['bcpc']['hadoop']['httpfs_hosts'] = []
-default['bcpc']['hadoop']['httpfs_hosts'] = []
 default['bcpc']['hadoop']['rs_hosts'] = []
 default['bcpc']['hadoop']['mysql_hosts'] = []
+
+# logical mapping of services to runlist details.
+default['bcpc']['hadoop']['services'] = {
+  zookeeper: {
+    key: [:zookeeper, :servers],
+    role: 'role[BCPC-Hadoop-Head]',
+  },
+  journal_node: {
+    key: :jn_hosts,
+    role: 'role[BCPC-Hadoop-Head]',
+  },
+
+  resource_manager: {
+    key: :rm_hosts,
+    role: 'role[BCPC-Hadoop-Head-ResourceManager]',
+  },
+  job_history_server: {
+    key: :jh_hosts,
+    role: 'role[BCPC-Hadoop-Head-MapReduce]',
+  },
+
+  oozie_server: {
+    key: :oozie_hosts,
+    role: 'role[BCPC-Hadoop-Head-MapReduce]',
+    recipe: 'recipe[bcpc-hadoop::oozie]',
+  },
+  mysql: {
+    key: :mysql_hosts,
+    role: 'role[BCPC-Hadoop-Head]',
+  },
+
+  hadoop_datanode: {
+    key: :dn_hosts,
+    role: 'role[BCPC-Hadoop-Worker]', 
+  },
+
+  hbase_master: {
+    key: :hb_hosts,
+    role: 'role[BCPC-Hadoop-Head-HBase]',
+  },
+  hbase_regionserver: {
+    key: :rs_hosts,
+    role: 'role[BCPC-Hadoop-Worker]',
+  },
+
+  hive_server: {
+    key: :hive_hosts,
+    role: 'role[BCPC-Hadoop-Head-Hive]',
+  },
+
+  httpfs_server: {
+    key: :httpfs_hosts,
+    role: 'role[BCPC-Hadoop-Worker]',
+  },
+}
 
 default['bcpc']['keepalived']['config_template'] = 'keepalived.conf_hadoop'
 

--- a/cookbooks/bcpc-hadoop/libraries/utils.rb
+++ b/cookbooks/bcpc-hadoop/libraries/utils.rb
@@ -203,59 +203,94 @@ def set_hosts
     'hbase_head' => 'role[BCPC-Hadoop-Head-HBase]'
   }
 
+  srvc2recipe = {
+    'oozie_server' => 'recipe[bcpc-hadoop::oozie]'
+  }
+
   if node.run_state['cluster_def'].nil? then
     node.run_state['cluster_def'] = BACH::ClusterDef.new(node_obj: node)
   end
-  cd = node.run_state['cluster_def']
+  nodes = node.run_state['cluster_def'].fetch_cluster_def
+
+  # host search helper lambdas
+  runs_role = Proc.new { |host, role| host[:runlist].include? srvc2role[role] }
+  runs_recipe = Proc.new { |host, recipe| host[:runlist].include? srvc2recipe[recipe] }
+
+  # mapped host objects
+  to_host = Proc.new do |host| {
+    'hostname' => host[:fqdn]
+  } end
+  to_labeled_host = Proc.new do |host| {
+    'hostname' => host[:fqdn],
+    'node_number' => host[:node_id],
+    'zookeeper_myid' => nil
+  } end
   
   node.default[:bcpc][:hadoop][:zookeeper][:servers] = 
-    cd.fetch_cluster_def.select { |hst| hst[:runlist].include? srvc2role['zookeeper'] }.map {
-      |hst| { 'hostname' => hst[:fqdn], 'node_number' => hst[:node_id], 'zookeeper_myid' => nil } }
+    nodes.select { |n| runs_role.call(n, 'zookeeper') }.map { |n| to_labeled_host.call(n) }
 
   node.default[:bcpc][:hadoop][:jn_hosts] = 
-    cd.fetch_cluster_def.select { |hst| hst[:runlist].include? srvc2role['journal_node'] }.map {
-      |hst| { 'hostname' => hst[:fqdn]} }
+    nodes.select { |n| runs_role.call(n, 'journal_node') }.map { |n| to_host.call(n) }
 
   node.default[:bcpc][:hadoop][:rm_hosts] = 
-    cd.fetch_cluster_def.select { |hst| hst[:runlist].include? srvc2role['resource_manager'] }.map {
-      |hst| { 'hostname' => hst[:fqdn], 'node_number' => hst[:node_id], 'zookeeper_myid' => nil } }
+    nodes.select { |n| runs_role.call(n, 'resource_manager') }.map { |n| to_labeled_host.call(n) }
 
   node.default[:bcpc][:hadoop][:hs_hosts] = 
-    cd.fetch_cluster_def.select { |hst| hst[:runlist].include? srvc2role['job_history_server'] }.map {
-      |hst| { 'hostname' => hst[:fqdn]} }
+    nodes.select { |n| runs_role.call(n, 'job_history_server') }.map { |n| to_host.call(n) }
 
   node.default[:bcpc][:hadoop][:dn_hosts] = 
-    cd.fetch_cluster_def.select { |hst| hst[:runlist].include? srvc2role['hadoop_worker'] }.map {
-      |hst| { 'hostname' => hst[:fqdn]} }
+    nodes.select { |n| runs_role.call(n, 'hadoop_worker') }.map { |n| to_host.call(n) }
 
   node.default[:bcpc][:hadoop][:hb_hosts] = 
-    cd.fetch_cluster_def.select { |hst| hst[:runlist].include? srvc2role['hbase_head'] }.map {
-      |hst| { 'hostname' => hst[:fqdn]} }
+    nodes.select { |n| runs_role.call(n, 'hbase_head') }.map { |n| to_host.call(n) }
 
   # different flavors of hive
   node.default[:bcpc][:hadoop][:hive_hosts] = 
-      cd.fetch_cluster_def.select { |hst| hst[:runlist].include? srvc2role['hive_server'] }.map {
-      |hst| { 'hostname' => hst[:fqdn]} }
+    nodes.select { |n| runs_role.call(n, 'hive_server') }.map { |n| to_host.call(n) }
 
-  # BCPC-Hadoop-Head-MapReduce
+  # (the BCPC-Hadoop-Head-MapReduce role nests the oozie recipe)
   node.default[:bcpc][:hadoop][:oozie_hosts]  = 
-    cd.fetch_cluster_def.select { |hst| hst[:runlist].include? srvc2role['oozie_server'] }.map {
-      |hst| { 'hostname' => hst[:fqdn]} }
-  
+    nodes.select do |n|
+      runs_role.call(n, 'oozie_server') || runs_recipe.call(n, 'oozie_server')
+    end.map { |n| to_host.call(n) }
+
   # every datanode
   node.default[:bcpc][:hadoop][:httpfs_hosts] = 
-    cd.fetch_cluster_def.select { |hst| hst[:runlist].include? srvc2role['hadoop_worker']  }.map {
-      |hst| { 'hostname' => hst[:fqdn]} }
+    nodes.select { |n| runs_role.call(n, 'hadoop_worker') }.map { |n| to_host.call(n) }
 
-  # Worker
+  # every worker
   node.default[:bcpc][:hadoop][:rs_hosts] = 
-    cd.fetch_cluster_def.select { |hst| hst[:runlist].include? srvc2role['hadoop_worker']  }.map {
-      |hst| { 'hostname' => hst[:fqdn]} }
+    nodes.select { |n| runs_role.call(n, 'hadoop_worker') }.map { |n| to_host.call(n) }
 
   # BCPC-Hadoop-Head
   node.default[:bcpc][:hadoop][:mysql_hosts] = 
-    cd.fetch_cluster_def.select { |hst| hst[:runlist].include? srvc2role['hadoop_head'] }.map {
-      |hst| { 'hostname' => hst[:fqdn]} }
+    nodes.select { |n| runs_role.call(n, 'hadoop_head') }.map { |n| to_host.call(n) }
+
+  # set the oozie_url
+  oozie_hosts = node[:bcpc][:hadoop][:oozie_hosts]
+  if oozie_hosts.length > 1
+    # high-availability
+    node.default[:bcpc][:hadoop][:oozie_url] =
+      "http://#{float_host(node[:bcpc][:management][:viphost])}:" +
+        "#{node[:bcpc][:ha_oozie][:port]}/oozie"
+  elsif oozie_hosts.length == 1
+    # single oozie host
+    node.default[:bcpc][:hadoop][:oozie_url] =
+      "http://#{float_host(oozie_hosts.first[:hostname])}:" +
+        "#{node[:bcpc][:hadoop][:oozie_port]}/oozie"
+  end
+
+  # set the resourcemanager_url (rm_address)
+  rm_hosts = node[:bcpc][:hadoop][:rm_hosts]
+  if rm_hosts.length > 1
+    # high-availability
+    node.default[:bcpc][:hadoop][:rm_address] = node.chef_environment
+  else
+    node.default[:bcpc][:hadoop][:rm_address] =
+      "http://#{float_host(rm_hosts.first[:hostname])}:" +
+        "#{node[:bcpc][:hadoop][:yarn][:resourcemanager][:port]}"
+  end
+
 end
 
 #

--- a/cookbooks/bcpc-hadoop/libraries/utils.rb
+++ b/cookbooks/bcpc-hadoop/libraries/utils.rb
@@ -207,24 +207,24 @@ def set_hosts
   } end
 
   node['bcpc']['hadoop']['services'].each do |name, service|
-    *keys, last = [:bcpc, :hadoop, *service[:key]]
+    *keys, last = ['bcpc', 'hadoop', *service['key']]
     keys.inject(node.default, :fetch)[last] =
       hosts.select do |h|
-        runs_role.call(h, service[:role]) ||
-        runs_recipe.call(h, service[:recipe])
+        runs_role.call(h, service['role']) ||
+        runs_recipe.call(h, service['recipe'])
       end.map do |h|
         to_host.call(h)
       end
   end
 
   # set the oozie_url
-  oozie_hosts = node[:bcpc][:hadoop][:oozie_hosts]
-  vip_host = float_host(node[:bcpc][:management][:viphost])
-  first_host = float_host(oozie_hosts.first[:hostname])
-  oozie_ha_port = node[:bcpc][:ha_oozie][:port]
-  oozie_port = node[:bcpc][:hadoop][:oozie_port]
+  oozie_hosts = node['bcpc']['hadoop']['oozie_hosts']
+  vip_host = float_host(node['bcpc']['management']['viphost'])
+  first_host = float_host(oozie_hosts.first['hostname'])
+  oozie_ha_port = node['bcpc']['ha_oozie']['port']
+  oozie_port = node['bcpc']['hadoop']['oozie_port']
 
-  node.default[:bcpc][:hadoop][:oozie_url] =
+  node.default['bcpc']['hadoop']['oozie_url'] =
     if oozie_hosts.length > 1
       # high-availability
       "http://#{vip_host}:#{oozie_ha_port}/oozie"
@@ -234,11 +234,11 @@ def set_hosts
     end
 
   # set the resourcemanager_url (rm_address)
-  rm_hosts = node[:bcpc][:hadoop][:rm_hosts]
-  first_host = float_host(rm_hosts.first[:hostname])
-  rm_port = node[:bcpc][:hadoop][:yarn][:resourcemanager][:port]
+  rm_hosts = node['bcpc']['hadoop']['rm_hosts']
+  first_host = float_host(rm_hosts.first['hostname'])
+  rm_port = node['bcpc']['hadoop']['yarn']['resourcemanager']['port']
 
-  node.default[:bcpc][:hadoop][:rm_address] =
+  node.default['bcpc']['hadoop']['rm_address'] =
     if rm_hosts.length > 1
       # high-availability
       node.chef_environment

--- a/cookbooks/bcpc-hadoop/libraries/utils.rb
+++ b/cookbooks/bcpc-hadoop/libraries/utils.rb
@@ -269,17 +269,24 @@ def set_hosts
     # high-availability
     node.default[:bcpc][:hadoop][:oozie_url] =
       "http://#{float_host(node[:bcpc][:management][:viphost])}:" +
-        "#{node[:bcpc][:ha_oozie][:port]}/oozie"
+      "#{node[:bcpc][:ha_oozie][:port]}/oozie"
   elsif oozie_hosts.length == 1
     # single oozie host
     node.default[:bcpc][:hadoop][:oozie_url] =
       "http://#{float_host(oozie_hosts.first[:hostname])}:" +
-        "#{node[:bcpc][:hadoop][:oozie_port]}/oozie"
+      "#{node[:bcpc][:hadoop][:oozie_port]}/oozie"
   end
 
-  # set the HA resourcemanager_url (rm_address)
+  # set the resourcemanager_url (rm_address)
   rm_hosts = node[:bcpc][:hadoop][:rm_hosts]
-  node.default[:bcpc][:hadoop][:rm_address] = node.chef_environment
+  if rm_hosts.length > 1
+    # high-availability
+    node.default[:bcpc][:hadoop][:rm_address] = node.chef_environment
+  else
+    node.default[:bcpc][:hadoop][:rm_address] =
+      "http://#{float_host(rm_hosts.first[:hostname])}:" +
+      "#{node[:bcpc][:hadoop][:yarn][:resourcemanager][:port]}"
+  end
 
 end
 


### PR DESCRIPTION
The current method for detecting hosts that run Oozie servers is decentralized, nonstandard, and inaccurate. Many of the auxiliary cookbooks that depend on Oozie (running oozie jobs) have their own method for setting the Oozie and ResourceManager URLs. These cookbooks (hdfsdu, ambari, backup, etc.) must call the `set_hosts` bcpc-hadoop helper before attempting to set the URLs. They also rely on the `set_hosts` function to properly set the `node.default[:bcpc][:hadoop][:oozie_hosts]` attribute. 

Currently, an oozie_host is detected as any node running the role[BCPC-Hadoop-Head-MapReduce]. Any node that runs the recipe[bcpc-hadoop::oozie] recipe w.o. running the MapReduce role goes undetected as an Oozie host. 

These changes centralize the initialization of two new attributes, `default[:bcpc][:hadoop][:oozie_url]` and `default[:bcpc][:hadoop][:rm_address]`. They also check for nodes running recipe[bcpc-hadoop::oozie] or role[BCPC-Hadoop-Head-MapReduce] to determine the correct oozie_hosts attribute. 

The auxiliary cookbooks will continue to work as before with these changes, but they can be refactored in the future to source these centralized attributes.