### PR TITLE
Add in some useful packages for LDAP debugging

### DIFF
--- a/cookbooks/bcpc/recipes/packages.rb
+++ b/cookbooks/bcpc/recipes/packages.rb
@@ -24,6 +24,8 @@
   git
   htop
   iotop
+  ldap-utils
+  libsasl2-modules-gssapi-mit
   lzop
   p7zip-full
   pcp


### PR DESCRIPTION
It's not uncommon to need to do an `ldapsearch` on a head or worker node, and when we encounter this need, we manually install these two packages. Let's stop doing that.