### PR TITLE
Tune jute max buffer

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -38,7 +38,7 @@ default['bcpc']['hadoop']['hdfs']['dfs_blocksize'] = '128m'
 default['bcpc']['hadoop']['hdfs_url'] = "hdfs://#{node.chef_environment}"
 default['bcpc']['hadoop']['jmx_enabled'] = false
 default['bcpc']['hadoop']['jmx_agent_enabled'] = true
-
+default['bcpc']['hadoop']['jute']['maxbuffer'] = 20_291_456
 
 
 

--- a/cookbooks/bcpc-hadoop/attributes/yarn.rb
+++ b/cookbooks/bcpc-hadoop/attributes/yarn.rb
@@ -13,7 +13,6 @@ default['bcpc']['hadoop']['yarn']['resourcemanager']['jmx']['port'] = 3131
 default['bcpc']['hadoop']['yarn']['scheduler']['fair']['min-vcores'] = 2
 default['bcpc']['hadoop']['yarn']['min-free-space-per-disk-mb'] = 100
 default['bcpc']['hadoop']['yarn']['min_user_id'] = 1000
-default['bcpc']['hadoop']['jute']['maxbuffer'] = 20_291_456
 default['bcpc']['hadoop']['yarn']['timeline_server']['webapp']['port'] = 8188
 default['bcpc']['hadoop']['yarn']['resourcemanager']['webapp']['port'] = 8088
 

--- a/cookbooks/bcpc-hadoop/attributes/yarn.rb
+++ b/cookbooks/bcpc-hadoop/attributes/yarn.rb
@@ -13,7 +13,7 @@ default['bcpc']['hadoop']['yarn']['resourcemanager']['jmx']['port'] = 3131
 default['bcpc']['hadoop']['yarn']['scheduler']['fair']['min-vcores'] = 2
 default['bcpc']['hadoop']['yarn']['min-free-space-per-disk-mb'] = 100
 default['bcpc']['hadoop']['yarn']['min_user_id'] = 1000
-default['bcpc']['hadoop']['jute']['maxbuffer'] = 6_291_456
+default['bcpc']['hadoop']['jute']['maxbuffer'] = 20_291_456
 default['bcpc']['hadoop']['yarn']['timeline_server']['webapp']['port'] = 8188
 default['bcpc']['hadoop']['yarn']['resourcemanager']['webapp']['port'] = 8088
 

--- a/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
@@ -35,10 +35,12 @@ node.default['bcpc']['hadoop']['hbase']['env'].tap do |hbase_env|
     ' -Dcom.sun.management.jmxremote.authenticate=false'
 
   hbase_env['HBASE_OPTS'] = '$HBASE_OPTS -Djava.net.preferIPv4Stack=true' \
+    " -Djute.maxbuffer=#{node['bcpc']['hadoop']['jute']['maxbuffer']}" \
     ' -XX:+UseConcMarkSweepGC'
 
   hbase_env['HBASE_MASTER_OPTS'] =
     '$HBASE_MASTER_OPTS' + common_opts +
+    " -Djute.maxbuffer=#{node['bcpc']['hadoop']['jute']['maxbuffer']}" \
     ' -Xmn' + node['bcpc']['hadoop']['hbase_master']['xmn']['size'].to_s + 'm' \
     ' -Xms' + node['bcpc']['hadoop']['hbase_master']['xms']['size'].to_s + 'm' \
     ' -Xmx' + node['bcpc']['hadoop']['hbase_master']['xmx']['size'].to_s + 'm' \
@@ -48,6 +50,7 @@ node.default['bcpc']['hadoop']['hbase']['env'].tap do |hbase_env|
 
   hbase_env['HBASE_REGIONSERVER_OPTS'] =
     '$HBASE_REGION_SERVER_OPTS' + common_opts +
+    " -Djute.maxbuffer=#{node['bcpc']['hadoop']['jute']['maxbuffer']}" \
     ' -Xmn' + node['bcpc']['hadoop']['hbase_rs']['xmn']['size'].to_s + 'm' \
     ' -Xms' + node['bcpc']['hadoop']['hbase_rs']['xms']['size'].to_s + 'm' \
     ' -Xmx' + node['bcpc']['hadoop']['hbase_rs']['xmx']['size'].to_s + 'm' \


### PR DESCRIPTION
With `cluster replication` and `region replication` enabled we are observing a large number of child `zondes` under `/hbase/replication zonde`. The value of `5million` seems to be small and causes `hbase` to fail to connect with `Zookeeper` while trying to read replicaiton related inforamtion. Increating the value to `20 million` seems to have worked well in couple of tested environments.