### PR TITLE
repair BCPC-Hadoop roles

### DIFF
--- a/stub-environment/roles/BACH-Backup.json
+++ b/stub-environment/roles/BACH-Backup.json
@@ -4,6 +4,7 @@
     "chef_type": "role",
     "json_class": "Chef::Role",
     "run_list": [
+      "recipe[bcpc-hadoop::bach_backup_wrapper]",
       "recipe[bach_backup::default]",
       "recipe[backup::default]",
       "recipe[backup::bootstrap]",

--- a/stub-environment/roles/BCPC-Hadoop-Head-ResourceManager.json
+++ b/stub-environment/roles/BCPC-Hadoop-Head-ResourceManager.json
@@ -4,8 +4,7 @@
   "run_list": [
     "role[Basic]",
     "recipe[bcpc-hadoop::resource_manager]",
-    "recipe[bcpc-hadoop::smoke_test_user]",
-    "recipe[bcpc-hadoop::bach_backup_user]"
+    "recipe[bcpc-hadoop::smoke_test_user]"
   ],
   "description": "A highly-available head node in a BCPC Hadoop cluster",
   "chef_type": "role",

--- a/stub-environment/roles/BCPC-Hadoop-Head.json
+++ b/stub-environment/roles/BCPC-Hadoop-Head.json
@@ -23,7 +23,6 @@
     "recipe[hdfsdu::create_user]",
     "recipe[bcpc-hadoop::configs]",
     "recipe[pam::default]",
-    "recipe[bcpc-hadoop::bach_backup_wrapper]",
     "recipe[bcpc-hadoop::zookeeper_server]",
     "recipe[bcpc-hadoop::journalnode]",
     "recipe[bcpc-hadoop::graphite_to_zabbix]"

--- a/stub-environment/roles/BCPC-Hadoop-Worker.json
+++ b/stub-environment/roles/BCPC-Hadoop-Worker.json
@@ -12,7 +12,6 @@
     "recipe[bcpc-hadoop::hdp_repo]",
     "recipe[bach_krb5::krb5_client]",
     "recipe[hdfsdu::create_user]",
-    "recipe[bcpc-hadoop::bach_backup_wrapper]",
     "recipe[bcpc-hadoop::configs]",
     "recipe[pam::default]",
     "recipe[bach_spark::default]",


### PR DESCRIPTION
Previously, we merged the PR for bach backups, #1226.
It turns out that the modifications to the BCPC roles cause the builds to crash and burn on clusters that utilize LDAP for user and group information. 

We should revert these role modifications immediately.
I need to devise a way to completely contain the needed backup functionality in the BACH-Backup role that works on both VM and Physical clusters.