### PR TITLE
serve conf pages on the cluster's virtual ip address

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -235,8 +235,8 @@ default['bcpc']['zabbix_dbport'] = '3306'
 default['bcpc']['admin_email'] = 'admin@example.com'
 
 default['bcpc']['ha_oozie']['port'] = '11010'
-default['bcpc']['ha_hdfs_conf_page']['port'] = '50070'
-default['bcpc']['ha_hbase_conf_page']['port'] = '16010'
+default['bcpc']['ha_hdfs_master']['port'] = '50070'
+default['bcpc']['ha_hbase_master']['port'] = '16010'
 default['bcpc']['haproxy']['tune_chksize'] = '1000000'
 
 #################################################

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -235,8 +235,8 @@ default['bcpc']['zabbix_dbport'] = '3306'
 default['bcpc']['admin_email'] = 'admin@example.com'
 
 default['bcpc']['ha_oozie']['port'] = '11010'
-default['bcpc']['ha_hdfs_conf_page']['port'] = '50071'
-default['bcpc']['ha_hbase_conf_page']['port'] = '16011'
+default['bcpc']['ha_hdfs_conf_page']['port'] = '50070'
+default['bcpc']['ha_hbase_conf_page']['port'] = '16010'
 default['bcpc']['haproxy']['tune_chksize'] = '1000000'
 
 #################################################

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -235,6 +235,9 @@ default['bcpc']['zabbix_dbport'] = '3306'
 default['bcpc']['admin_email'] = 'admin@example.com'
 
 default['bcpc']['ha_oozie']['port'] = '11010'
+default['bcpc']['ha_hdfs_conf_page']['port'] = '50071'
+default['bcpc']['ha_hbase_conf_page']['port'] = '16011'
+default['bcpc']['haproxy']['tune_chksize'] = '1000000'
 
 #################################################
 #  attributes for chef vault download and install

--- a/cookbooks/bcpc/recipes/haproxy.rb
+++ b/cookbooks/bcpc/recipes/haproxy.rb
@@ -54,7 +54,14 @@ template "/etc/haproxy/haproxy.cfg" do
   source "haproxy.cfg.erb"
   mode 00644
   variables(:mysql_servers => get_nodes_for("mysql","bcpc"),
-    :oozie_servers => get_nodes_for("oozie", "bcpc-hadoop"))
+            :oozie_servers => get_nodes_for("oozie", "bcpc-hadoop"),
+            :cluster_vip => node['bcpc']['management']['vip'],
+            :ha_hdfs_conf_page_port => node['bcpc']['ha_hdfs_conf_page']['port'],
+            :ha_hbase_conf_page_port => node['bcpc']['ha_hbase_conf_page']['port'],
+            :hdfs_servers => get_nodes_for("namenode_master","bcpc-hadoop").concat(get_nodes_for("namenode_standby", "bcpc-hadoop")),
+            :hbase_servers => get_nodes_for("hbase_master", "bcpc-hadoop"),
+            :haproxy_tune_chksize => node['bcpc']['haproxy']['tune_chksize']
+           )
   notifies :restart, "service[haproxy]", :immediately
 end
 

--- a/cookbooks/bcpc/recipes/haproxy.rb
+++ b/cookbooks/bcpc/recipes/haproxy.rb
@@ -56,8 +56,8 @@ template "/etc/haproxy/haproxy.cfg" do
   variables(:mysql_servers => get_nodes_for("mysql","bcpc"),
             :oozie_servers => get_nodes_for("oozie", "bcpc-hadoop"),
             :cluster_vip => node['bcpc']['management']['vip'],
-            :ha_hdfs_conf_page_port => node['bcpc']['ha_hdfs_conf_page']['port'],
-            :ha_hbase_conf_page_port => node['bcpc']['ha_hbase_conf_page']['port'],
+            :ha_hdfs_master_port => node['bcpc']['ha_hdfs_master']['port'],
+            :ha_hbase_master_port => node['bcpc']['ha_hbase_master']['port'],
             :hdfs_servers => get_nodes_for("namenode_master","bcpc-hadoop").concat(get_nodes_for("namenode_standby", "bcpc-hadoop")),
             :hbase_servers => get_nodes_for("hbase_master", "bcpc-hadoop"),
             :haproxy_tune_chksize => node['bcpc']['haproxy']['tune_chksize']

--- a/cookbooks/bcpc/templates/default/haproxy.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy.cfg.erb
@@ -82,8 +82,9 @@ listen hdfs-conf-page <%= @cluster_vip %>:<%= @ha_hdfs_conf_page_port %>
   balance roundrobin
   option httpchk GET /jmx
   http-check expect string tag.HAState"\ :\ "active
+  source <%= node[:bcpc][:floating][:ip] %>
   <% @hdfs_servers.each do |server| -%>
-  <%= "server #{server['hostname']} #{server['bcpc']['floating']['ip']}:50070 check" %>
+  <%= "server #{server['hostname']} #{server['bcpc']['floating']['ip']}:#{@ha_hdfs_conf_page_port} check" %>
   <% end -%>
 
 # hbase conf page
@@ -91,6 +92,7 @@ listen hbase-conf-page <%= @cluster_vip %>:<%= @ha_hbase_conf_page_port %>
   balance roundrobin
   option httpchk GET /jmx
   http-check expect string tag.isActiveMaster"\ :\ "true
+  source <%= node[:bcpc][:floating][:ip] %>
   <% @hbase_servers.each do |server| -%>
-  <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:16010 check" %>
+  <%= "server #{server['hostname']} #{server['bcpc']['floating']['ip']}:#{@ha_hbase_conf_page_port} check" %>
   <% end -%>

--- a/cookbooks/bcpc/templates/default/haproxy.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy.cfg.erb
@@ -10,6 +10,8 @@ global
   group  haproxy
   pidfile  /var/run/haproxy.pid
   log /dev/log local0 info
+  # hadoop conf page is more than the default size 16384 bytes
+  tune.chksize <%= @haproxy_tune_chksize %>
 
 defaults
   log  global
@@ -53,7 +55,7 @@ listen mysql-galera <%="#{node[:bcpc][:management][:vip]}"%>:3306
   mode tcp
   balance leastconn
   option  tcplog
-option tcpka
+  option tcpka
   option httpchk
 <% @mysql_servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:3306 check port 3307 inter 1s rise 1 fall 1 observe layer4 backup" %>
@@ -74,3 +76,21 @@ backend backend_oozie
   <%= "server #{float_host(server[:fqdn])} #{server['bcpc']['floating']['ip']}:11000 check" %>
 <% end -%>
 <% end -%>
+
+# hdfs conf page
+listen hdfs-conf-page <%= @cluster_vip %>:<%= @ha_hdfs_conf_page_port %>
+  balance roundrobin
+  option httpchk GET /jmx
+  http-check expect string tag.HAState"\ :\ "active
+  <% @hdfs_servers.each do |server| -%>
+  <%= "server #{server['hostname']} #{server['bcpc']['floating']['ip']}:50070 check" %>
+  <% end -%>
+
+# hbase conf page
+listen hbase-conf-page <%= @cluster_vip %>:<%= @ha_hbase_conf_page_port %>
+  balance roundrobin
+  option httpchk GET /jmx
+  http-check expect string tag.isActiveMaster"\ :\ "true
+  <% @hbase_servers.each do |server| -%>
+  <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:16010 check" %>
+  <% end -%>

--- a/cookbooks/bcpc/templates/default/haproxy.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy.cfg.erb
@@ -10,7 +10,7 @@ global
   group  haproxy
   pidfile  /var/run/haproxy.pid
   log /dev/log local0 info
-  # hadoop conf page is more than the default size 16384 bytes
+  # jmx page that is used for httpchk is more than the default size 16384 bytes
   tune.chksize <%= @haproxy_tune_chksize %>
 
 defaults
@@ -77,22 +77,22 @@ backend backend_oozie
 <% end -%>
 <% end -%>
 
-# hdfs conf page
-listen hdfs-conf-page <%= @cluster_vip %>:<%= @ha_hdfs_conf_page_port %>
+# hdfs master
+listen hdfs-master <%= @cluster_vip %>:<%= @ha_hdfs_master_port %>
   balance roundrobin
   option httpchk GET /jmx
   http-check expect string tag.HAState"\ :\ "active
   source <%= node[:bcpc][:floating][:ip] %>
   <% @hdfs_servers.each do |server| -%>
-  <%= "server #{server['hostname']} #{server['bcpc']['floating']['ip']}:#{@ha_hdfs_conf_page_port} check" %>
+  <%= "server #{server['hostname']} #{server['bcpc']['floating']['ip']}:#{@ha_hdfs_master_port} check" %>
   <% end -%>
 
-# hbase conf page
-listen hbase-conf-page <%= @cluster_vip %>:<%= @ha_hbase_conf_page_port %>
+# hbase master
+listen hbase-master <%= @cluster_vip %>:<%= @ha_hbase_master_port %>
   balance roundrobin
   option httpchk GET /jmx
   http-check expect string tag.isActiveMaster"\ :\ "true
   source <%= node[:bcpc][:floating][:ip] %>
   <% @hbase_servers.each do |server| -%>
-  <%= "server #{server['hostname']} #{server['bcpc']['floating']['ip']}:#{@ha_hbase_conf_page_port} check" %>
+  <%= "server #{server['hostname']} #{server['bcpc']['floating']['ip']}:#{@ha_hbase_master_port} check" %>
   <% end -%>


### PR DESCRIPTION
This is to make conf pages HA available on the cluster's virtual ip.
Each each conf page is identified by the port number.
e.g.  
HDFS: http://10.0.100.5:50071/conf
HBase: http://10.0.100.5:16011/conf

More pages will be added in the future (e.g. Yarn)

Ready for review.