### PR TITLE
Remove unused "admin users" feature

### DIFF
--- a/cookbooks/bcpc/recipes/bootstrap.rb
+++ b/cookbooks/bcpc/recipes/bootstrap.rb
@@ -115,23 +115,17 @@ if node[:bcpc][:management][:ip] != node[:bcpc][:management][:vip]
   end
   end
 end
+
+#
+# Admin users have not been (intentionally) active on BACH bootstraps
+# in several years.  Delete them if found.
+#
 node[:bcpc][:bootstrap][:admin_users].each do |user_name|
   user user_name do
-    action :create
-    home "/home/#{user_name}"
-    group "#{user}"
-    supports :manage_home => true
+    action :remove
+    only_if "id #{user_name}"
+    ignore_failure true
   end
-  bash 'set group permission on homedir' do
-    code "chmod 775 /home/#{user_name}"
-  end
-end
-
-sudo 'cluster-interaction' do
-  user      node[:bcpc][:bootstrap][:admin_users] * ','
-  runas     "#{user}"
-  commands  ["/home/#{user}/chef-bcpc/cluster-assign-roles.sh','/home/#{user}/chef-bcpc/nodessh.sh",'/usr/bin/knife']
-  only_if { node[:bcpc][:bootstrap][:admin_users].length >= 1 }
 end
 
 package 'acl'


### PR DESCRIPTION
We don't use multiple users on any of our bootstraps, anywhere.

This is a security hole rather than a feature, and it broke one
of my hardware clusters.  That's a good reminder to delete it.

If we make a conscious decision to pursue multi-user bootstraps,
that needs to be thought out more fully than just tossing some user
resources into `bcpc::bootstrap`