### PR TITLE
Remove float_host from bcpc_kafka

### DIFF
--- a/cookbooks/bcpc_kafka/attributes/default.rb
+++ b/cookbooks/bcpc_kafka/attributes/default.rb
@@ -91,8 +91,8 @@ default[:kafka][:broker].tap do |broker|
   # 6668 is authenticated, but lacks SSL.
   #
   broker[:listeners] =
-    "PLAINTEXT://#{float_host(node[:fqdn])}:6667," \
-    "SASL_PLAINTEXT://#{float_host(node[:fqdn])}:6668"
+    "PLAINTEXT://#{node[:fqdn]}:6667," \
+    "SASL_PLAINTEXT://#{node[:fqdn]}:6668"
 end
 
 #

--- a/cookbooks/bcpc_kafka/libraries/utils.rb
+++ b/cookbooks/bcpc_kafka/libraries/utils.rb
@@ -18,8 +18,8 @@
 #
 
 # The method GET_ZK_NODES searches for Zookeeper nodes at two levels (Run List and Roles).
-# During a chef-client run a run list is updated before the chef-client run and is available for 
-# searching nodes. Roles and recipes are updated after the chef-client run completes and commits 
+# During a chef-client run a run list is updated before the chef-client run and is available for
+# searching nodes. Roles and recipes are updated after the chef-client run completes and commits
 # data back to the chef-server
 
 def get_zk_nodes
@@ -28,5 +28,5 @@ def get_zk_nodes
   ro_results = search(:node, "roles:BCPC-Kafka-Head-Zookeeper AND chef_environment:#{node.chef_environment}")
   ro_results.map!{|x| x[:hostname] == node[:hostname] ? node : x}
   results = rl_results.concat ro_results
-  return results.uniq{|x| float_host(x[:hostname])}.sort
+  return results.uniq{|x| x[:hostname]}.sort
 end

--- a/cookbooks/bcpc_kafka/recipes/kafka.rb
+++ b/cookbooks/bcpc_kafka/recipes/kafka.rb
@@ -50,9 +50,9 @@ end
 unless (node[:kafka][:broker][:zookeeper][:connect] rescue nil)
   node.default[:kafka][:broker][:zookeeper][:connect] = get_head_nodes.map do |nn|
     if node[:bcpc][:hadoop][:zookeeper].attribute?(:port) && node[:bcpc][:hadoop][:zookeeper][:port] != nil
-      float_host(nn[:fqdn])+":"+node[:bcpc][:hadoop][:zookeeper][:port].to_s
+      nn[:fqdn] + ":"+node[:bcpc][:hadoop][:zookeeper][:port].to_s
     else
-      float_host(nn[:fqdn])
+      nn[:fqdn]
     end
   end.sort
 end
@@ -161,7 +161,7 @@ template kafka_jaas_path do
   source 'kafka/jaas.conf.erb'
   mode 0444
   variables ({
-              principal: "kafka/#{float_host(node[:fqdn])}",
+              principal: "kafka/#{node[:fqdn]}",
               keytab_path: '/etc/security/keytabs/kafka.service.keytab'
              })
 end


### PR DESCRIPTION
`float_host` and friends broke my hardware clusters today.   This fix un-breaks them.

I have not yet examined how badly this damages the VM build process.  This may be the final straw that drives me to root out _all_ of the multi-host stuff, across all the cookbooks.