### PR TITLE
Move from default of 'central' to '*' in mirrorOf

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/maven_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/maven_config.rb
@@ -66,7 +66,7 @@ if node['bach']['maven']['central_mirror']
     value 'mirror' => {
                        'id' => 'primary-mirror',
                        'name' => 'Chef-configured primary mirror',
-                       'mirrorOf' => 'central',
+                       'mirrorOf' => '*',
                        'url' => node['bach']['maven']['central_mirror']
                       }
   end


### PR DESCRIPTION
- This is for completely disconnected environments with full mirrors of
  upstream repositories.
- Without this, the primary mirror is always checked second, resulting
  in unnecessary timeouts waiting for internet connections that will
  never succeed (on each request).
- We can override specific sections later on if additional mirrors are
  added for specialty needs.