### PR TITLE
remove default value which gets merged and fails chef-client run

### DIFF
--- a/cookbooks/bach_deployment/attributes/default.rb
+++ b/cookbooks/bach_deployment/attributes/default.rb
@@ -1,12 +1,12 @@
 force_default['bach']['deploy']['appfile']['data'] = {
-  appfoo: {
-    repo_url: 'http://bcpc.example.com',
-    copy_to: '',
-    copy_type: 'file',
-    runas: 'root',
-    filename: 'example.jar',
-    filemode: '0644',
-    fileowner: 'root',
-    checksum: '4bd'
-  }
+#  appfoo: {
+#    repo_url: 'http://bcpc.example.com',
+#    copy_to: '',
+#    copy_type: 'file',
+#    runas: 'root',
+#    filename: 'example.jar',
+#    filemode: '0644',
+#    fileowner: 'root',
+#    checksum: '4bd'
+#  }
 }


### PR DESCRIPTION
the default value ends up merged with the actual value, and fails the chef-client run
```
{
  "appfoo"=> {
    "repo_url"=>"http://bcpc.example.com",
    "copy_to"=>"",
    "copy_type"=>"file",
    "runas"=>"root",
    "filename"=>"example.jar",
    "filemode"=>"0644",
    "fileowner"=>"root",
    "checksum"=>"4bd"
  },
  "myapp"=> {
    "repo_url"=> "<some url>",
    "copy_to"=>"<some local dir>",
    "copy_type"=>"file",
    "runas"=>"root",
    "filename"=>"<my jar file name>",
    "filemode"=>"0644",
    "fileowner"=>"root",
    "checksum"=> "<my check sum>"
  }
}
```