### PR TITLE
Allow overriding the environment name again

### DIFF
--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -19,7 +19,7 @@ if [[ "$(pwd)" != "$(git rev-parse --show-toplevel)" ]]; then
   printf '#### WARNING: This should be run in the git top level directory! ####\n' > /dev/stderr
 fi
 
-export BACH_ENVIRONMENT='Test-Laptop'
+export BACH_ENVIRONMENT=${BACH_ENVIRONMENT:-'Test-Laptop'}
 export BACH_CLUSTER_PREFIX=${BACH_CLUSTER_PREFIX:-''}
 export BOOTSTRAP_VM_MEM=${BOOTSTRAP_VM_MEM:-5096}
 export BOOTSTRAP_VM_CPUs=${BOOTSTRAP_VM_CPUS:-2}


### PR DESCRIPTION
One used to be able to override the environment (all our shell scripts allow this and automated_install was intended to as well). This allows one to set `$BACH_ENVIRONMENT` to override `Test-Laptop` if need be.