### PR TITLE
Refactor the bcpc::ssh recipe. Remove 'failed to start' error.

### DIFF
--- a/cookbooks/bcpc/recipes/ssh.rb
+++ b/cookbooks/bcpc/recipes/ssh.rb
@@ -36,21 +36,7 @@ package 'openssh-server' do
 end
 
 service 'ssh' do
-  action :enable
-  ignore_failure true
-end
-
-#
-# The Init::Debian provider fails to start an already-started
-# service on Ubuntu 14.04, due to bugs in their sysvinit
-# compatibility scripts.
-#
-execute '/etc/init.d/ssh start' do
-  action :run
-
-  if node[:lsb][:codename] == 'trusty'
-    ignore_failure true
-  end
+  action [:enable, :start]
 end
 
 template '/etc/ssh/sshd_config' do


### PR DESCRIPTION
Here's a simplification the SSH recipe.
We can fetch key items from the vault at compile rather than converge time.
If done this way, we can take advantage of the recipe DSL instead of creating resources with Chef::Resource.

Also, on our current version of chef, the init provider seems to work fine with upstart.
If we utilize the service resource :start action, the 'failed to start ssh' error on every chef run goes away.

The PR is broken up into two commits. 
The first commit can be cherry picked to only fix the 'failed to start' error.
The second commit is recommended to simplify the cognitive complexity of the recipe.
It shortens the recipe by 25%, and it removes some unnecessary levels of nesting.
The diff looks a little nasty, but viewing the full recipe looks a lot nicer.
This is the typically the first recipe that cluster_assign_roles.rb runs on a newly provisioned node,
so we should start the chef-run off right.


This has been tested under the following situations:
* ssh is not running
* ssh is already running

* host keys already exist in the vault
  should save the key values in the vault over the existing host keys on the node.
* host keys don't exist in the vault, but they exist on the node.
  create and update the vault with the existing host key values from the node.
* host keys exist in neither the vault nor on the node.
  now, it logs warning messages. previously, this was unhandled in the original recipe.

If the vault item does not yet exist, and the client does not have admin privileges to create the vault item, an exception is immediately raised at compile time rather than proceeding with a improperly configured ssh service.