### PR TITLE
Fix the 'ssh failed to start error' on every chef run.

### DIFF
--- a/cookbooks/bcpc/recipes/ssh.rb
+++ b/cookbooks/bcpc/recipes/ssh.rb
@@ -36,21 +36,7 @@ package 'openssh-server' do
 end
 
 service 'ssh' do
-  action :enable
-  ignore_failure true
-end
-
-#
-# The Init::Debian provider fails to start an already-started
-# service on Ubuntu 14.04, due to bugs in their sysvinit
-# compatibility scripts.
-#
-execute '/etc/init.d/ssh start' do
-  action :run
-
-  if node[:lsb][:codename] == 'trusty'
-    ignore_failure true
-  end
+  action [:enable, :start]
 end
 
 template '/etc/ssh/sshd_config' do


### PR DESCRIPTION
This change pulls out the first commit of #1271 and just applies a simple diff to fix the error.
The default service provider now works fine for ssh on ubuntu 14.04, so we can use it instead of a manual execution resource.

Tested under the following scenarios:
  * ssh is disabled, not yet running.
  * ssh is disabled, already running.
  * ssh is enabled, not yet running.
  * ssh is enabled, already running.

Tested using the following methods:
Disable the service with:
```
$ sudo chef-shell
chef (12.19.36)> recipe_mode
chef:recipe (12.19.36)> service 'ssh' do
chef:recipe > action :disable
chef:recipe ?> end
chef:recipe (12.19.36)> run_chef
```

Modify and check the status of ssh with:
```
$ sudo service ssh stop
$ sudo service ssh status
$ sudo service ssh start
```

Run this recipe with chef:
```
$ sudo chef-client -o 'bcpc::ssh'
```