### PR TITLE
Update Ubuntu mini-iso checksum for the September 12th update

### DIFF
--- a/cookbooks/bach_repository/recipes/ubuntu.rb
+++ b/cookbooks/bach_repository/recipes/ubuntu.rb
@@ -9,6 +9,6 @@ remote_file "#{bins_dir}/ubuntu-14.04-hwe44-mini.iso" do
   source 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/' +
          'installer-amd64/current/images/xenial-netboot/mini.iso'
   mode 0444
-  checksum '28b11928cd8bd63ee522f2e9b0a2f3bfd0dd1d826471e8f7726d65d583b32154'
+  checksum 'eefab8ae8f25584c901e6e094482baa2974e9f321fe7ea7822659edeac279609'
 end
 


### PR DESCRIPTION
This corrects one hitting the following as the Ubuntu mini.iso has a new release:
```
  * remote_file[/home/vagrant/chef-bcpc/bins/ubuntu-14.04-hwe44-mini.iso] action create

    ================================================================================
    Error executing action `create` on resource 'remote_file[/home/vagrant/chef-bcpc/bins/ubuntu-14.04-hwe44-mini.iso]'
    ================================================================================

    Chef::Exceptions::ChecksumMismatch
    ----------------------------------
    Checksum on resource (28b119) does not match checksum on content (eefab8)

    Resource Declaration:
    ---------------------
    # In /var/chef/cache/cookbooks/bach_repository/recipes/ubuntu.rb 

      8: remote_file "#{bins_dir}/ubuntu-14.04-hwe44-mini.iso" do
      9:   source 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/' +
     10:          'installer-amd64/current/images/xenial-netboot/mini.iso'
     11:   mode 0444
     12:   checksum '28b11928cd8bd63ee522f2e9b0a2f3bfd0dd1d826471e8f7726d65d583b32154'
     13: end
     14:
```