### PR TITLE
Disable bucket cache on HBase masters

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
@@ -134,7 +134,8 @@ end
 # If HBASE bucket cache is enabled the properties from this section will be included in hbase-site.xml
 #
 bucketcache_size = (node['bcpc']['hadoop']['hbase_rs']['mx_dir_mem']['size'] - node['bcpc']['hadoop']['hbase_rs']['hdfs_dir_mem']['size']).floor
-if node['bcpc']['hadoop']['hbase']['bucketcache']['enabled'] == true
+if node['bcpc']['hadoop']['hbase']['bucketcache']['enabled'] == true &&
+   node['bcpc']['hadoop']['rs_hosts'].map { |rs| rs.values[0] }.include?(node['fqdn'])
   generated_values['hbase.regionserver.global.memstore.upperLimit'] = node['bcpc']['hadoop']['hbase_rs']['memstore']['upperlimit'].to_s
   generated_values['hfile.block.cache.size'] = node['bcpc']['hadoop']['hbase']['blockcache']['size'].to_s
   generated_values['hbase.bucketcache.size'] = bucketcache_size

--- a/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_config.rb
@@ -134,8 +134,12 @@ end
 # If HBASE bucket cache is enabled the properties from this section will be included in hbase-site.xml
 #
 bucketcache_size = (node['bcpc']['hadoop']['hbase_rs']['mx_dir_mem']['size'] - node['bcpc']['hadoop']['hbase_rs']['hdfs_dir_mem']['size']).floor
-if node['bcpc']['hadoop']['hbase']['bucketcache']['enabled'] == true &&
-   node['bcpc']['hadoop']['rs_hosts'].map { |rs| rs.values[0] }.include?(node['fqdn'])
+bucketcache_enabled = node['bcpc']['hadoop']['hbase']['bucketcache']['enabled']
+is_region_server = node['bcpc']['hadoop']['rs_hosts'].any? do |rs|
+  rs.values[0] == node['fqdn']
+end
+
+if bucketcache_enabled && is_region_server
   generated_values['hbase.regionserver.global.memstore.upperLimit'] = node['bcpc']['hadoop']['hbase_rs']['memstore']['upperlimit'].to_s
   generated_values['hfile.block.cache.size'] = node['bcpc']['hadoop']['hbase']['blockcache']['size'].to_s
   generated_values['hbase.bucketcache.size'] = bucketcache_size

--- a/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
+++ b/cookbooks/bcpc-hadoop/recipes/hbase_env.rb
@@ -63,10 +63,6 @@ if node['bcpc']['hadoop']['hbase']['bucketcache']['enabled'] == true
   node.default['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] =
     node['bcpc']['hadoop']['hbase']['env']['HBASE_REGIONSERVER_OPTS'] +
     ' -XX:MaxDirectMemorySize=' + node['bcpc']['hadoop']['hbase_rs']['mx_dir_mem']['size'].to_s + 'm'
-
-  node.default['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] =
-    node['bcpc']['hadoop']['hbase']['env']['HBASE_MASTER_OPTS'] +
-    ' -XX:MaxDirectMemorySize=' + node['bcpc']['hadoop']['hbase_master']['mx_dir_mem']['size'].to_s + 'm'
 end
 
 if node[:bcpc][:hadoop][:kerberos][:enable] == true


### PR DESCRIPTION
This removes the config parameters from HBase masters that are added when the bucket cache is enabled. These were only intended for region servers anyway.

EDIT: This was tested on a dev hardware cluster.
EDIT2: The second iteration was tested in the same place.