### PR TITLE
[jRuby] - Allow floating points in quotas

### DIFF
--- a/cookbooks/bcpc-hadoop/files/default/create_dirs.rb
+++ b/cookbooks/bcpc-hadoop/files/default/create_dirs.rb
@@ -67,10 +67,10 @@ dirinfo.each_pair do |dir, info|
       'p' => 1024**5
     }
 
-    base = s[/[0-9.]*/].to_i
+    base = s[/[0-9.]*/].to_f
     prefix = prefixes[s[/[kmgtp]/] || '']
 
-    base * prefix
+    (base * prefix).ceil.to_i
   end
 
   # set space and namespace quotas


### PR DESCRIPTION
This is both a minor bug _and_ a minor enhancement. If you pass a float to the script before this change, it does the equivalent of a `.floor` when doing `.to_i`. This ensures we can use simpler notation like `9.9T` instead of `9900G`. @ronny-macmaster is currently testing this on a hardware dev cluster. I'll mark it tested when he finishes.