### PR TITLE
Allow fair_share_queue overrides

### DIFF
--- a/cookbooks/bcpc-hadoop/libraries/hadoop_helpers.rb
+++ b/cookbooks/bcpc-hadoop/libraries/hadoop_helpers.rb
@@ -29,7 +29,7 @@ module Bcpc_Hadoop
           q.parent['name'] = queue_name
           # process minResource, weight, etc. tags under the queue
           queue_definition.select do |k, v|
-            !Set.new(non_render_attributes).include?(k) && !v.nil?
+            !Set.new(non_render_attributes).include?(k.to_sym) && !v.nil?
           end.each do |k,v|
             q.send(k) do |attr|
               attr.text v.to_s


### PR DESCRIPTION
These changes will allow an attribute to override / define fair scheduler queue properties. 

Tested on both the VM and dev hardware cluster.

**Purpose:**
Deploying a release on existing hardware clusters quickly can sometimes prove challenging.
We'd like to avoid deploying new releases to push out small and urgent compute budget changes.
These changes will allow us to override the budgets codified in tenant recipes with environment attributes.

**Usage:**
Override the node['bcpc']['hadoop']['yarn']['fair_scheduler_queue'] in the environment json.
The data structure takes the following form:

```
node['bcpc']['hadoop']['yarn']['fair_scheduler_queue'] = {
  queue_name[string]: {
    parent_resource: [chef_resource_string],
    minResources: [string ~= /(\d+)mb (\d+)vcores/],
    maxResources: [string ~= /(\d+)mb (\d+)vcores/],
    maxRunningApps: [integer],
    maxAMShare: [float],
    weight: [float],
    schedulingPolicy: [string ~= /(fair|fifo|drf)/i],
    aclSubmitApps: [string (csv)],
    aclAdministerApps: [string (csv)],
    minSharePreemptionTimeout: [integer],
    fairSharePreemptionTimeout: [integer],
    fairSharePreemptionThreshold: [float]
  },
  ...
}
```

See the second comment below for an example.

**Reference:**
1. [fair_share_queue resource](https://github.com/bloomberg/chef-bach/blob/master/cookbooks/bcpc-hadoop/libraries/fair_share_queue.rb)
1. [fair_share_queue helper methods](https://github.com/bloomberg/chef-bach/blob/master/cookbooks/bcpc-hadoop/libraries/hadoop_helpers.rb)
1. [yarn_schedulers recipe](https://github.com/bloomberg/chef-bach/blob/master/cookbooks/bcpc-hadoop/recipes/yarn_schedulers.rb)
1. [fair_scheduler reference](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/FairScheduler.html)