### PR TITLE
Fix for #1288 - Master fails to populate node[:bcpc][:hadoop][:hs_hosts]

### DIFF
--- a/cookbooks/bcpc-hadoop/attributes/default.rb
+++ b/cookbooks/bcpc-hadoop/attributes/default.rb
@@ -129,8 +129,8 @@ default['bcpc']['hadoop']['services'] = {
     key: :rm_hosts,
     role: 'role[BCPC-Hadoop-Head-ResourceManager]',
   },
-  job_history_server: {
-    key: :jh_hosts,
+  history_server: {
+    key: :hs_hosts,
     role: 'role[BCPC-Hadoop-Head-MapReduce]',
   },
 


### PR DESCRIPTION
This removes the unused `jn_hosts` entry and corrects it to `hs_hosts`; I have verified that it runs through on a VM cluster happily and Oozie smoke-tests and HDFSDU now work again after this change.