### PR TITLE
Allow 30 minutes for kdump to write out crash dumps

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/configs.rb
+++ b/cookbooks/bcpc-hadoop/recipes/configs.rb
@@ -44,7 +44,7 @@ end
 
 # Reboot on kernel panic
 sysctl_param 'kernel.panic' do
-  value 10
+  value 1800
 end
 
 # Populate node attributes for all kind of hosts


### PR DESCRIPTION
This builds on #1294 by changing from `10` to `1800`. Since we already have kdump configured, we should give it enough time to write the dumps/logs out. Hopefully this answers the question @jmh045000 asked on the original PR.