### PR TITLE
Pin seven_zip cookbook for Chef-Client 12

### DIFF
--- a/cookbooks/bcpc/metadata.rb
+++ b/cookbooks/bcpc/metadata.rb
@@ -21,5 +21,6 @@ depends 'maven', '~> 5.0.1'
 depends 'nscd'
 depends 'ntp'
 depends 'ubuntu'
+depends 'seven_zip', '~> 3.0.0' # 3.1.0 requires Chef-13 client
 depends 'sudo'
 depends 'pdns'


### PR DESCRIPTION
The [seven_zip](https://supermarket.chef.io/cookbooks/seven_zip/versions/3.1.0) cookbook has moved on to requiring Chef-Client 13 so pin to version ~3.0.0 which is the last to support Chef-Client 12.