### PR TITLE
Copy jce policy to the chef filecache

### DIFF
--- a/cookbooks/bach_repository/recipes/oracle_java.rb
+++ b/cookbooks/bach_repository/recipes/oracle_java.rb
@@ -47,5 +47,6 @@ ruby_block 'Copy JDK to file cache' do
   block do
     require 'fileutils'
     ::FileUtils.cp(jdk_local_path, Chef::Config[:file_cache_path])
+    ::FileUtils.cp("#{bins_dir}/jce_policy-8.zip", "#{Chef::Config[:file_cache_path]}/jce.zip")
   end
 end


### PR DESCRIPTION
This is only working in existing clusters because the filecache already
downloaded it years ago.

It works in VM cluster builds because they are connected to the
internet.

Gets us a step forward into building a bootstrap machine without source