### PR TITLE
BF: fix reference to dir_creation group attribute

### DIFF
--- a/cookbooks/bcpc-hadoop/files/default/create_dirs.rb
+++ b/cookbooks/bcpc-hadoop/files/default/create_dirs.rb
@@ -41,7 +41,7 @@ dirinfo.each_pair do |dir, info|
 
   # enforce ownership and permissions
   owner = info[:owner]
-  group = info[:groups]
+  group = info[:group]
   perms = FsPermission.new(info[:perms].to_i(8))
 
   # create the directory


### PR DESCRIPTION
Turns out, this was the wrong dirinfo attribute to reference.
This will fix the error. Testing this on a cluster right now.