### PR TITLE
Disable `pcp` and chef-client for Kafka clusters

### DIFF
--- a/cookbooks/bcpc/recipes/packages.rb
+++ b/cookbooks/bcpc/recipes/packages.rb
@@ -28,7 +28,6 @@
   libsasl2-modules-gssapi-mit
   lzop
   p7zip-full
-  pcp
   powertop
   silversearcher-ag
   sysstat

--- a/cookbooks/bcpc/recipes/packages.rb
+++ b/cookbooks/bcpc/recipes/packages.rb
@@ -40,3 +40,11 @@
     action :upgrade
   end
 end
+
+#
+# One particularly unhelpful system package -- frequently consumes
+# 100% of CPU, but we don't send the metrics anywhere.
+#
+package 'pcp' do
+  action :purge
+end

--- a/cookbooks/bcpc_kafka/recipes/default.rb
+++ b/cookbooks/bcpc_kafka/recipes/default.rb
@@ -46,9 +46,20 @@ if not node.has_key?('pam_d') or not node['pam_d'].has_key?('services') or not n
   }
 end
 
-# set vm.swapiness to 0 (to lessen swapping)
+#
+# set vm.swappiness to 0 (to lessen swapping)
 # NOTE: This include_recipe is necessary for resource collection
+#
 include_recipe 'sysctl::default'
+
 sysctl_param 'vm.swappiness' do
   value 0
+end
+
+#
+# Disable the chef client-as-a-service.  This was previously managed
+# by roles, but now it has to be handled here.
+#
+service 'chef-client' do
+  action [:disable, :stop]
 end


### PR DESCRIPTION
These two changes are lessons learned rolling out the v3.6.3 release.

* Performance Co-pilot (`pcp`) is a set of daemons that come with Ubuntu 14.04 by default.  100% CPU consumption is common.  

  As far as I know, we don't use the data collected by these daemons, so there's no reason to put up with the CPU usage.

* Chef-client configuration was recently migrated from roles to recipes.  Correspondingly, Kafka clusters must now disable the chef-client service explicitly, instead of omitting it from a role.