### PR TITLE
Enable grub/serial tty configuration management (redux)

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -26,7 +26,7 @@ default['bcpc']['domain_name'] = 'bcpc.example.com'
 default['bcpc']['encrypt_data_bag'] = false
 
 default['bcpc']['bootstrap']['preseed'].tap do |preseed|
-  preseed['add_kernel_opts'] = ''
+  preseed['add_kernel_opts'] = 'console=ttyS0,115200n8r console=ttyS1,115200n8r console=tty1'
   preseed['additional_packages'] = %w(openssh-server lldpd)
 
   # Disable device renaming -- use the kernel's enumeration order.

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -25,8 +25,18 @@ default['bcpc']['domain_name'] = 'bcpc.example.com'
 
 default['bcpc']['encrypt_data_bag'] = false
 
+# Configure options for Grub serial console management
+default['bcpc']['grub'].tap do |grub|
+  grub['serial']['consoles'] = %w(ttyS0 ttyS1)
+end
+
+# Build the list of strings for console output
+sconsoles = node['bcpc']['grub']['serial']['consoles'].map do |console|
+  "console=#{console},115200n8r"
+end.join(' ')
+
 default['bcpc']['bootstrap']['preseed'].tap do |preseed|
-  preseed['add_kernel_opts'] = 'console=ttyS0,115200n8r console=ttyS1,115200n8r console=tty1'
+  preseed['add_kernel_opts'] = "#{sconsoles} console=tty1"
   preseed['additional_packages'] = %w(openssh-server lldpd)
 
   # Disable device renaming -- use the kernel's enumeration order.

--- a/cookbooks/bcpc/recipes/grub.rb
+++ b/cookbooks/bcpc/recipes/grub.rb
@@ -1,0 +1,51 @@
+# vim: tabstop=2:shiftwidth=2:softtabstop=2
+#
+# Cookbook Name:: bcpc
+# Recipe:: grub.rb
+#
+# Copyright 2017, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+template '/etc/default/grub' do
+  source 'grub/etc_default_grub.erb'
+  owner 'root'
+  group 'root'
+  mode 0o0644
+  notifies :run, 'execute[update-grub]'
+end
+
+execute 'update-grub' do
+  command '/usr/sbin/update-grub'
+  user 'root'
+  action :nothing
+end
+
+template '/etc/init/ttyS0.conf' do
+  source 'grub/ttyS0.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :run, 'execute[initctl_reloadconfig]', :immediate
+  notifies :restart, 'service[ttyS0]', :delayed
+end
+
+execute 'initctl_reloadconfig' do
+  command '/sbin/initctl reload-configuration'
+  action :nothing
+end
+
+service 'ttyS0' do
+  supports status: true, restart: true, reload: false
+  action [:start, :enable]
+end

--- a/cookbooks/bcpc/recipes/grub.rb
+++ b/cookbooks/bcpc/recipes/grub.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: bcpc
 # Recipe:: grub.rb
 #
-# Copyright 2017, Bloomberg Finance L.P.
+# Copyright 2018, Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,7 +40,10 @@ sconsoles.each do |console|
     source 'grub/ttySX.conf.erb'
     owner 'root'
     group 'root'
-    mode '0644'
+    mode 0o0644
+    variables(
+      console: console
+    )
     notifies :run, 'execute[initctl_reloadconfig]', :immediate
     notifies :restart, "service[#{console}]", :delayed
   end

--- a/cookbooks/bcpc/recipes/grub.rb
+++ b/cookbooks/bcpc/recipes/grub.rb
@@ -35,6 +35,7 @@ end
 sconsoles = node['bcpc']['grub']['serial']['consoles']
 
 # Create getty upstart configuration for all
+# FIXME: Rewrite this block when moving to 16.04/18.04
 sconsoles.each do |console|
   template "/etc/init/#{console}.conf" do
     source 'grub/ttySX.conf.erb'

--- a/cookbooks/bcpc/templates/default/grub/etc_default_grub.erb
+++ b/cookbooks/bcpc/templates/default/grub/etc_default_grub.erb
@@ -1,0 +1,36 @@
+# If you change this file, run 'update-grub' afterwards to update
+# /boot/grub/grub.cfg.
+# For full documentation of the options in this file, see:
+#   info -f grub -n 'Simple configuration'
+
+GRUB_DEFAULT=0
+GRUB_HIDDEN_TIMEOUT=0
+GRUB_HIDDEN_TIMEOUT_QUIET=true
+GRUB_TIMEOUT=10
+GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
+GRUB_CMDLINE_LINUX_DEFAULT="quiet"
+GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0 <%= node['bcpc']['bootstrap']['preseed']['add_kernel_opts'] %>"
+
+# Uncomment to enable BadRAM filtering, modify to suit your needs
+# This works with Linux (no patch required) and with any kernel that obtains
+# the memory map information from GRUB (GNU Mach, kernel of FreeBSD ...)
+#GRUB_BADRAM="0x01234567,0xfefefefe,0x89abcdef,0xefefefef"
+
+# Uncomment to disable graphical terminal (grub-pc only)
+#GRUB_TERMINAL=console
+
+# The resolution used on graphical terminal
+# note that you can use only modes which your graphic card supports via VBE
+# you can see them in real GRUB with the command `vbeinfo'
+#GRUB_GFXMODE=640x480
+
+# Uncomment if you don't want GRUB to pass "root=UUID=xxx" parameter to Linux
+#GRUB_DISABLE_LINUX_UUID=true
+
+# Uncomment to disable generation of recovery mode menu entries
+#GRUB_DISABLE_RECOVERY="true"
+
+# Uncomment to get a beep at grub start
+#GRUB_INIT_TUNE="480 440 1"
+GRUB_TERMINAL=serial
+GRUB_SERIAL_COMMAND="serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1"

--- a/cookbooks/bcpc/templates/default/grub/etc_default_grub.erb
+++ b/cookbooks/bcpc/templates/default/grub/etc_default_grub.erb
@@ -1,3 +1,8 @@
+###############################################
+##   WARNING - THIS FILE IS MANAGED BY CHEF  ##
+## DO NOT MODIFY BY HAND, OR YOU'LL BE SORRY ##
+###############################################
+
 # If you change this file, run 'update-grub' afterwards to update
 # /boot/grub/grub.cfg.
 # For full documentation of the options in this file, see:

--- a/cookbooks/bcpc/templates/default/grub/ttyS0.conf.erb
+++ b/cookbooks/bcpc/templates/default/grub/ttyS0.conf.erb
@@ -1,0 +1,14 @@
+# ttyS0 - getty
+#
+# This service maintains a getty on ttyS0 from the point the system is
+# started until it is shut down again.
+
+start on stopped rc RUNLEVEL=[2345] and (
+            not-container or
+            container CONTAINER=lxc or
+            container CONTAINER=lxc-libvirt)
+
+stop on runlevel [!2345]
+
+respawn
+exec /sbin/getty -L -8 ttyS0 115200 vt102

--- a/cookbooks/bcpc/templates/default/grub/ttySX.conf.erb
+++ b/cookbooks/bcpc/templates/default/grub/ttySX.conf.erb
@@ -1,6 +1,6 @@
-# ttyS0 - getty
+# <%= @console %> - getty
 #
-# This service maintains a getty on ttyS0 from the point the system is
+# This service maintains a getty on <%= @console %> from the point the system is
 # started until it is shut down again.
 
 start on stopped rc RUNLEVEL=[2345] and (
@@ -11,4 +11,4 @@ start on stopped rc RUNLEVEL=[2345] and (
 stop on runlevel [!2345]
 
 respawn
-exec /sbin/getty -L -8 ttyS0 115200 vt102
+exec /sbin/getty -L -8 <%= @console %> 115200 vt102

--- a/cookbooks/bcpc/templates/default/grub/ttySX.conf.erb
+++ b/cookbooks/bcpc/templates/default/grub/ttySX.conf.erb
@@ -1,3 +1,8 @@
+###############################################
+##   WARNING - THIS FILE IS MANAGED BY CHEF  ##
+## DO NOT MODIFY BY HAND, OR YOU'LL BE SORRY ##
+###############################################
+
 # <%= @console %> - getty
 #
 # This service maintains a getty on <%= @console %> from the point the system is


### PR DESCRIPTION
- Change default serial port speed to 115200 from 9600
- Update default `add_kernel_opts` to include ttyS0, ttyS1, and tty1, which
  seems to be the magic fix for all of our hardware's serial consoles
- Add execute block for `update-grub` to ensure Grub configs get updated
  after modifying `/etc/default/grub`
- Manage service for `ttyS*` upstart job + force initctl reload config to
  make sure the changes are actually present before restarting the tty
- This is an Ubuntu 14.04 specific change, due to the upstart management stuff, but only that one block should need modifying for future releases.

Recipe to be included in the proper role(s) as needed.

Revives and then supersedes #806 

Still needs to be tested.