### PR TITLE
Bootstrap local

### DIFF
--- a/Vagrantfile.local.rb
+++ b/Vagrantfile.local.rb
@@ -14,57 +14,59 @@
 #
 Vagrant.configure('2') do |config|
 
-  # load any local SSL certificates if present
-  local_ca = ENV.fetch 'LOCAL_CERTS', '/usr/local/share/ca-certificates'
-  if Dir.exist?(local_ca)
-    debian_bundle_path = '/etc/ssl/certs/ca-certificates.crt'
+  config.vm.define 'bootstrap' do |bs|
+    
+    # load any local SSL certificates if present
+    local_ca = ENV.fetch 'LOCAL_CERTS', '/usr/local/share/ca-certificates'
+    if Dir.exist?(local_ca)
+      debian_bundle_path = '/etc/ssl/certs/ca-certificates.crt'
 
-    config.vm.synced_folder local_ca,
-      '/usr/local/share/ca-certificates',
-      mount_options: ['ro']
+      bs.vm.synced_folder local_ca, '/usr/local/share/ca-certificates',
+        type: 'rsync'
 
-    config.vm.provision 'deploy-certs', type: 'shell',  inline: <<~eos
-      DEBIAN_TOOL_PATH=/usr/sbin/update-ca-certificates
+      bs.vm.provision 'deploy-certs', type: 'shell',  inline: <<~eos
+        DEBIAN_TOOL_PATH=/usr/sbin/update-ca-certificates
 
-      # Debian/Ubuntu
-      if [[ -x $DEBIAN_TOOL_PATH ]]; then
-        SSL_PATH=#{debian_bundle_path}
-        $DEBIAN_TOOL_PATH
-      else
-        exit -1
+        # Debian/Ubuntu
+        if [[ -x $DEBIAN_TOOL_PATH ]]; then
+          SSL_PATH=#{debian_bundle_path}
+          $DEBIAN_TOOL_PATH
+        else
+          exit -1
+        fi
+
+        echo "SSL_CERT_FILE=$SSL_PATH" >> \
+          /etc/environment
+
+        umask 0277
+        echo 'Defaults env_keep += "SSL_CERT_FILE"' > \
+          /etc/sudoers.d/ssl
+      eos
+
+      # Note: the box_download_ca_cert is used on the host, not the guest.
+      bs.vm.box_download_ca_cert = debian_bundle_path
+    end
+
+    # set proxies if present
+    bs.vm.provision 'propagate-proxies', type:'shell',  inline: <<~eos
+      if [ -n "#{ENV['https_proxy']}" ]; then
+        echo 'https_proxy=#{ENV['https_proxy']}' >> \
+          /etc/environment
       fi
 
-      echo "SSL_CERT_FILE=$SSL_PATH" >> \
-        /etc/environment
+      if [ -n "#{ENV['http_proxy']}" ]; then
+        echo 'http_proxy=#{ENV['http_proxy']}' >> \
+          /etc/environment
+      fi
+
+      if [ -n "#{ENV['no_proxy']}" ]; then
+        echo "no_proxy='#{ENV['no_proxy']}'" >> \
+          /etc/environment
+      fi
 
       umask 0277
-      echo 'Defaults env_keep += "SSL_CERT_FILE"' > \
-        /etc/sudoers.d/ssl
+      echo 'Defaults env_keep += "http_proxy https_proxy no_proxy"' > \
+        /etc/sudoers.d/proxy
     eos
-
-    # Note: the box_download_ca_cert is used on the host, not the guest.
-    config.vm.box_download_ca_cert = debian_bundle_path
   end
-
-  # set proxies if present
-  config.vm.provision 'propagate-proxies', type:'shell',  inline: <<~eos
-    if [ -n "#{ENV['https_proxy']}" ]; then
-      echo 'https_proxy=#{ENV['https_proxy']}' >> \
-        /etc/environment
-    fi
-
-    if [ -n "#{ENV['http_proxy']}" ]; then
-      echo 'http_proxy=#{ENV['http_proxy']}' >> \
-        /etc/environment
-    fi
-
-    if [ -n "#{ENV['no_proxy']}" ]; then
-      echo "no_proxy='#{ENV['no_proxy']}'" >> \
-        /etc/environment
-    fi
-
-    umask 0277
-    echo 'Defaults env_keep += "http_proxy https_proxy no_proxy"' > \
-      /etc/sudoers.d/proxy
-  eos
 end


### PR DESCRIPTION
While debugging with @bijugs , `bcpc::ssl_certs_deploy` needs to write to `/usr/loca/share/ca-certificates`. this fails because that directory is already mounted in cluster VMs as read-only.

Restricting it to the bootstrap should solve this.  We don't need to propagate hypervisor CAs to the actual VMs anyway.