### PR TITLE
Update Grub configuration to allow toggling of legacy NIC names

### DIFF
--- a/cookbooks/bcpc/recipes/grub.rb
+++ b/cookbooks/bcpc/recipes/grub.rb
@@ -17,11 +17,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+# Legacy NIC names for most machines
+subnet = node['bcpc']['management']['subnet']
+ifnames = ''
+unless node['bcpc']['networks'][subnet]['management']['legacy_names'] == false
+  ifnames = 'net.ifnames=0 biosdevname=0 ' # Leave the trailing space
+end
+
 template '/etc/default/grub' do
   source 'grub/etc_default_grub.erb'
   owner 'root'
   group 'root'
   mode 0o0644
+  variables(ifnames: ifnames)
   notifies :run, 'execute[update-grub]'
 end
 

--- a/cookbooks/bcpc/templates/default/grub/etc_default_grub.erb
+++ b/cookbooks/bcpc/templates/default/grub/etc_default_grub.erb
@@ -14,7 +14,7 @@ GRUB_HIDDEN_TIMEOUT_QUIET=true
 GRUB_TIMEOUT=10
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
 GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0 <%= node['bcpc']['bootstrap']['preseed']['add_kernel_opts'] %>"
+GRUB_CMDLINE_LINUX="<%= @ifnames %><%= node['bcpc']['bootstrap']['preseed']['add_kernel_opts'] %>"
 
 # Uncomment to enable BadRAM filtering, modify to suit your needs
 # This works with Linux (no patch required) and with any kernel that obtains


### PR DESCRIPTION
As the title says. On some hardware, we may want to allow udevd to choose the interface name for better predictability.