### PR TITLE
Allow disabling of DHCP for whole subnets

### DIFF
--- a/cookbooks/bcpc/recipes/cobbler.rb
+++ b/cookbooks/bcpc/recipes/cobbler.rb
@@ -159,10 +159,16 @@ template '/etc/cobbler/settings' do
   notifies :restart, "service[#{node['cobbler']['service']['name']}]", :immediately
 end
 
+# Filter bcpc::networks to remove any racks that explicitly disable DHCP
+allsubnets = node['bcpc']['networks']
+subnets = allsubnets.dup.delete_if do |rack, _|
+  node['bcpc']['networks'][rack]['management']['ignore_dhcp'] == true
+end
+
 template '/etc/cobbler/dhcp.template' do
   source 'cobbler/dhcp.template.erb'
   mode 0644
-  variables(subnets: node[:bcpc][:networks])
+  variables(subnets: subnets)
   notifies :run, 'bash[cobbler-sync]', :delayed
 end
 


### PR DESCRIPTION
This should prevent DHCP responses from ever being sent on subnets where `ignore_dhcp == true`. 

Tested on a hardware dev cluster by adding a fake subnet and ensuring the subnet got removed from dhcpd.conf after this change.